### PR TITLE
implement FIPS 204 Alg 6 keygen_internal

### DIFF
--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -11,6 +11,9 @@
 #include "poly.h"
 #include "polyvec.h"
 
+#define crypto_sign_keypair_internal DILITHIUM_NAMESPACE(keypair_internal)
+int crypto_sign_keypair_internal(uint8_t *pk, uint8_t *sk, uint8_t *seed);
+
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 


### PR DESCRIPTION
This PR implements the internal/external split of ML-DSA keygen as described in [FIPS 204](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf).

This will allow us to perform ACVP testing for internal functions, and brings us closer to the FIPS 204 specification.