### PR TITLE
Implementation of external-mu mode for ML-DSA signing and verification

### DIFF
--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -23,12 +23,16 @@ int crypto_sign_signature_internal(uint8_t *sig, size_t *siglen,
                                    const uint8_t *m, size_t mlen,
                                    const uint8_t *pre, size_t prelen,
                                    const uint8_t rnd[RNDBYTES],
-                                   const uint8_t *sk);
+                                   const uint8_t *sk, int externalmu);
 
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
                           size_t mlen, const uint8_t *ctx, size_t ctxlen,
                           const uint8_t *sk);
+
+#define crypto_sign_signature_extmu DILITHIUM_NAMESPACE(signature_extmu)
+int crypto_sign_signature_extmu(uint8_t *sig, size_t *siglen,
+                                const uint8_t mu[CRHBYTES], const uint8_t *sk);
 
 #define crypto_sign DILITHIUM_NAMESPACETOP
 int crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen,
@@ -38,12 +42,16 @@ int crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen,
 int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
                                 const uint8_t *m, size_t mlen,
                                 const uint8_t *pre, size_t prelen,
-                                const uint8_t *pk);
+                                const uint8_t *pk, int externalmu);
 
 #define crypto_sign_verify DILITHIUM_NAMESPACE(verify)
 int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
                        size_t mlen, const uint8_t *ctx, size_t ctxlen,
                        const uint8_t *pk);
+
+#define crypto_sign_verify_extmu DILITHIUM_NAMESPACE(verify_extmu)
+int crypto_sign_verify_extmu(const uint8_t *sig, size_t siglen,
+                             const uint8_t mu[CRHBYTES], const uint8_t *pk);
 
 #define crypto_sign_open DILITHIUM_NAMESPACE(open)
 int crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen,

--- a/test/acvp_mldsa.c
+++ b/test/acvp_mldsa.c
@@ -147,7 +147,7 @@ static void acvp_mldsa_sigGen_AFT(const unsigned char *message, size_t mlen,
   memcpy(pre + 2, context, ctxlen);
 
   CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                       ctxlen + 2, rnd, sk) == 0);
+                                       ctxlen + 2, rnd, sk, 0) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 


### PR DESCRIPTION
#### Description:
This PR implements the external-mu variant of ML-DSA signing and verification as specified in FIPS 204. The changes allow direct input of the mu value rather than computing it from the message during signing and verification.

#### Key changes:
- Added `crypto_sign_signature_extmu()` and `crypto_sign_verify_extmu()` functions that accept pre-computed mu values
- Modified internal signing/verification functions to support an external mu mode flag
- Updated function documentation to reference relevant FIPS 204 algorithms
- Maintained backward compatibility with existing signing/verification APIs

#### Call outs:
- Uses a boolean flag `externalmu` to control mu handling in internal functions
- Skips CRH computation when mu is provided externally
- Copies external mu directly when in external mode

The external-mu mode enables more flexible usage patterns while maintaining the security properties of ML-DSA. This is particularly useful for applications that need to separate mu computation from the core signing/verification operations.

#### Out of Scope:
Testing:
- Unit tests for external-mu mode signing and verification
- Verification of compatibility with existing usage
- Test vectors matching FIPS 204 specification

For reviewers: 

- naming conventions don't have to be final here. I'll propose a switch over from the `crypto_sign_*` convention for all APIs that can include any names we don't like here.
- I'm open to suggestions on how we implement external mu. Currently implemented as a boolean flag to the internal functions, to reduce duplicated code. The `verify_extmu` function is essentially just a wrapper, as no pre-processing needs to be completed (as context strings and pre-message processing is performed when constructing `mu`).