### PR TITLE
Adds benchmarking on Raspberry Pi 4 (Cortex-A72)

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: Bench mlkem-native
+name: Bench mldsa-native
 description: Run benchmarking script
 
 inputs:

--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Bench mlkem-native
+description: Run benchmarking script
+
+inputs:
+  name:
+    description: Name for the benchmarking run
+    required: true
+  perf:
+    description: Method of obtaining PMU metrics
+    required: true
+    default: "PERF"
+  cflags:
+    description: CFLAGS to pass to compilation
+    default: ""
+  archflags:
+    description: ARCHFLAGS to pass to compilation
+    default: ""
+  opt:
+    description: opt flag to set for tests script
+    default: "true"
+  bench_extra_args:
+    description: Further arguments to be appended to command line for `bench` script
+    default: ""
+  store_results:
+    description: Whether to push results to GH pages
+    default: "false"
+  gh_token:
+    description: GitHub access token
+    required: true
+  nix-shell:
+    description: Run in the specified Nix environment if exists
+    default: "ci-bench"
+  nix-cache:
+    description: Determine whether to enable nix cache
+    default: 'false'
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
+  custom_shell:
+    description: The shell to use. Only relevant if no nix-shell specified
+    default: "bash"
+  cross_prefix:
+    description: "Binary prefix for cross-compilation builds"
+    default: ""
+  alert_threshold:
+    description: "Set alert threshold in percentage for benchmark result"
+    default: "103%"
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-shell
+      with:
+        nix-shell: ${{ inputs.nix-shell }}
+        nix-cache: ${{ inputs.nix-cache }}
+        nix-verbose: ${{ inputs.nix-verbose }}
+        gh_token: ${{ inputs.gh_token }}
+        custom_shell: ${{ inputs.custom_shell }}
+        script: |
+          ARCH=$(uname -m)
+          cat >> $GITHUB_STEP_SUMMARY <<-EOF
+            ## Setup
+            Architecture: $ARCH
+            - $(uname -a)
+            - $(nix --version)
+            - $(${{ matrix.target.cross_prefix }}gcc --version | grep -m1 "")
+            - $(bash --version | grep -m1 "")
+
+            ## CPU Info
+            $(cat /proc/cpuinfo)
+          EOF
+    - name: Run benchmark
+      shell: ${{ env.SHELL }}
+      run: |
+        ./scripts/tests bench -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
+              --cflags="${{ inputs.cflags }} ${{ inputs.archflags }}" \
+              --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
+              -v --output=output.json ${{ inputs.bench_extra_args }}
+
+        ./scripts/tests bench --components -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
+              --cflags="${{ inputs.cflags }} ${{ inputs.archflags }}" \
+              --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
+              -v  ${{ inputs.bench_extra_args }}
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+      with:
+        name: ${{ inputs.name }}
+        tool: "customSmallerIsBetter"
+        output-file-path: output.json
+        github-token: ${{ inputs.gh_token }}
+        auto-push: ${{ inputs.store_results == 'true' }}
+        comment-on-alert: true
+        summary-always: true
+        alert-threshold: ${{ inputs.alert_threshold }}
+        comment-always: true
+    - name: Reset gh-pages if result is not pushed to gh-pages
+      shell: ${{ env.SHELL }}
+      if: ${{ inputs.store_results != 'true' }}
+      run: |
+        git -c advice.detachedHead=false switch gh-pages
+        git reset --hard HEAD~1
+        git checkout -

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Bench
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [ "labeled" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  bench:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: ${{ matrix.target.name }}
+    strategy:
+      fail-fast: true
+      matrix:
+       target:
+        - system: rpi4
+          name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
+          bench_pmu: PMU
+          archflags: -mcpu=cortex-a72 -DMLK_SYS_AARCH64_SLOW_BARREL_SHIFTER
+          cflags: "-flto"
+          bench_extra_args: ""
+    if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
+    runs-on: self-hosted-${{ matrix.target.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/bench
+        with:
+          name: ${{ matrix.target.name }} (opt)
+          cflags: ${{ matrix.target.cflags }}
+          archflags: ${{ matrix.target.archflags }}
+          perf: ${{ matrix.target.bench_pmu }}
+          store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
+          bench_extra_args: ${{ matrix.target.bench_extra_args }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci-bench' }}
+          cross_prefix: ${{ matrix.target.cross_prefix }}
+          opt: true
+      - uses: ./.github/actions/bench
+        with:
+          name: ${{ matrix.target.name }} (no-opt)
+          cflags: ${{ matrix.target.cflags }}
+          archflags: ${{ matrix.target.archflags }}
+          perf: ${{ matrix.target.bench_pmu }}
+          store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
+          bench_extra_args: ${{ matrix.target.bench_extra_args }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci-bench' }}
+          cross_prefix: ${{ matrix.target.cross_prefix }}
+          opt: false


### PR DESCRIPTION
Depends on #49.

Once merged to main, this should create a website in the [gh-pages branch ](https://github.com/pq-code-package/mldsa-native/tree/gh-pages) similar to https://pq-code-package.github.io/mlkem-native/dev/bench/ that we can use to keep track of performance changes over time. 
Once we have a baseline the bechmarks will trigger comments in pull requests showing the performance change.

If that all works I can easily add Raspberry Pi5, Cortex-A55, and Banana Pi F3 (rv64) benchmarks. We can also add the AWS EC2-based benchmarks then, but that's a bit more work. 