### PR TITLE
CBMC: Contract and proof for poly_shiftl

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -114,12 +114,16 @@ void poly_sub(poly *c, const poly *a, const poly *b)
 void poly_shiftl(poly *a)
 {
   unsigned int i;
-  DBENCH_START();
 
-  for (i = 0; i < N; ++i)
-    a->coeffs[i] <<= D;
-
-  DBENCH_STOP(*tmul);
+  for (i = 0; i < N; i++)
+  __loop__(
+    invariant(i <= N)
+    invariant(forall(k0, i, N, a->coeffs[k0] == loop_entry(*a).coeffs[k0])))
+  {
+    /* Reference: uses a left shift by D which is undefined behaviour in C90/C99
+     */
+    a->coeffs[i] *= (1 << D);
+  }
 }
 
 /*************************************************

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -33,8 +33,14 @@ __contract__(
 
 #define poly_sub DILITHIUM_NAMESPACE(poly_sub)
 void poly_sub(poly *c, const poly *a, const poly *b);
+
 #define poly_shiftl DILITHIUM_NAMESPACE(poly_shiftl)
-void poly_shiftl(poly *a);
+void poly_shiftl(poly *a)
+__contract__(
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(array_abs_bound(a->coeffs, 0, N, 1 << (31 - D) - 1))
+  assigns(memory_slice(a, sizeof(poly)))
+);
 
 #define poly_ntt DILITHIUM_NAMESPACE(poly_ntt)
 void poly_ntt(poly *a);

--- a/proofs/cbmc/poly_shiftl/Makefile
+++ b/proofs/cbmc/poly_shiftl/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_shiftl_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_shiftl
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLS_NAMESPACE)poly_shiftl
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_shiftl
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_shiftl/poly_shiftl_harness.c
+++ b/proofs/cbmc/poly_shiftl/poly_shiftl_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+void harness(void)
+{
+  poly *a;
+  poly_shiftl(a);
+}


### PR DESCRIPTION
Resolves #23. Depends on #53.

This commit adds the CBMC proof for poly_shiftl.

The reference implementation is using an explicit left shift - this has
undefined behaviour for negative values in C90/C99.
This commit instead uses an explicit multiplication.
Both gcc14 and clang20 turn this into a logical shift even with -O0.