### PR TITLE
CBMC: switch --native-compiler to $(CC) instead of gcc

### DIFF
--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -311,7 +311,7 @@ CHECKFLAGS += $(CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK)
 NONDET_STATIC ?=
 
 # Flags to pass to goto-cc for compilation and linking
-COMPILE_FLAGS ?= -Wall -Werror
+COMPILE_FLAGS ?= -Wall -Werror --native-compiler $(CC)
 LINK_FLAGS ?= -Wall -Werror
 EXPORT_FILE_LOCAL_SYMBOLS ?= --export-file-local-symbols
 


### PR DESCRIPTION
Currently CBMC defaults to use gcc. This is a problem when on MacOS, where
we default to clang. On these systems our CBMC proofs only work if the user
happens to have gcc in their $PATH.
This commit changes the flags for goto-cc to use the compiler set in $CC which
is clang on MacOS and gcc on other platforms.
