### PR TITLE
Update CBMC to 6.5.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {
-  description = "mlkem-native";
+  description = "mldsa-native";
 
   inputs = {
     nixpkgs-2405.url = "github:NixOS/nixpkgs/nixos-24.05";
@@ -23,7 +23,7 @@
           pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
           pkgs-2405 = inputs.nixpkgs-2405.legacyPackages.${system};
           util = pkgs.callPackage ./nix/util.nix {
-            cbmc = pkgs-unstable.cbmc;
+            cbmc = pkgs.cbmc;
             bitwuzla = pkgs-unstable.bitwuzla;
             z3 = pkgs-unstable.z3;
           };
@@ -114,7 +114,7 @@
             pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.x86_64-linux;
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
-              cbmc = pkgs-unstable.cbmc;
+              cbmc = pkgs.cbmc;
               bitwuzla = pkgs-unstable.bitwuzla;
               z3 = pkgs-unstable.z3;
             };

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -14,12 +14,12 @@ buildEnv {
   paths =
     builtins.attrValues {
       cbmc = cbmc.overrideAttrs (old: rec {
-        version = "6.4.1"; # remember to adjust this in ../flake.nix too
+        version = "6.5.0";
         src = fetchFromGitHub {
           owner = "diffblue";
-          repo = old.pname;
-          tag = "${old.pname}-${version}";
-          hash = "sha256-O8aZTW+Eylshl9bmm9GzbljWB0+cj2liZHs2uScERkM=";
+          repo = "cbmc";
+          rev = "32143ddf8ae93e6bd0f52189de509662348c2373";
+          hash = "sha256-uciXv4dqESQrbNz+bQFpJcqoeWO8ZaRYjxoSUBOjlNI=";
         };
       });
       litani = callPackage ./litani.nix { }; # 1.29.0

--- a/nix/hol_light/default.nix
+++ b/nix/hol_light/default.nix
@@ -10,8 +10,8 @@ hol_light.overrideAttrs (old: {
   src = fetchFromGitHub {
     owner = "jrh13";
     repo = "hol-light";
-    rev = "28e4aed1019a56fab869f752695a67a4164dd2ee";
-    hash = "sha256-Z14pED3oaz30Zp1Ue58KA5srlZc31WyDE8h9tJwCAcI=";
+    rev = "0e4b1bd8c7d400214d6fa6027f15a4221b54f8d4";
+    hash = "sha256-M6ddzqoAFyMBmaznuz31+o035xdEz4VXZMHhH4Dm4c8=";
   };
   patches = [ ./0005-Fix-hollight-path.patch ];
   propagatedBuildInputs = old.propagatedBuildInputs ++ old.nativeBuildInputs;

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -2,17 +2,17 @@
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";
-  version = "90cb5e35a823efee15cde72f0237af39a9bf7371";
+  version = "7c018f70667310c96ac5d6c27468104117bd51c0";
   src = fetchFromGitHub {
     owner = "jargh";
     repo = "s2n-bignum-dev";
     rev = "${version}";
-    hash = "sha256-6uDvLG04h8IKYln612wG/aXPsCB9k8Zsh/cE2Y980tQ=";
+    hash = "sha256-/Iyz2mnxGSbmte9lT1JbY4WcBmWWrc7tUpZ0HfAUD+4";
   };
   setupHook = writeText "setup-hook.sh" ''
     export S2N_BIGNUM_DIR="$1"
   '';
-  patches = [ ./0001-fix-script-path.patch ];
+  patches = [ ];
   dontBuild = true;
   installPhase = ''
     mkdir -p $out


### PR DESCRIPTION
This pulls in the most recent nix configuration from mlkem-native. Most notably this includes the recently released CBMC 6.5.0.

It also updates HOL-Light which is not required yet for mldsa-native, but let's keep it in sync.