### PR TITLE
Add proofs of XXX_make_hint() in support of proof of pack_sig()

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -250,9 +250,14 @@ unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1)
   DBENCH_START();
 
   for (i = 0; i < MLDSA_N; ++i)
+  __loop__(
+    invariant(i <= MLDSA_N)
+    invariant(s <= i)
+  )
   {
-    h->coeffs[i] = make_hint(a0->coeffs[i], a1->coeffs[i]);
-    s += h->coeffs[i];
+    const unsigned int hint_bit = make_hint(a0->coeffs[i], a1->coeffs[i]);
+    h->coeffs[i] = hint_bit;
+    s += hint_bit;
   }
 
   DBENCH_STOP(*tround);

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -53,8 +53,17 @@ void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b);
 void poly_power2round(poly *a1, poly *a0, const poly *a);
 #define poly_decompose MLD_NAMESPACE(poly_decompose)
 void poly_decompose(poly *a1, poly *a0, const poly *a);
+
 #define poly_make_hint MLD_NAMESPACE(poly_make_hint)
-unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1);
+unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1)
+__contract__(
+  requires(memory_no_alias(h,  sizeof(poly)))
+  requires(memory_no_alias(a0, sizeof(poly)))
+  requires(memory_no_alias(a1, sizeof(poly)))
+  assigns(memory_slice(h, sizeof(poly)))
+  ensures(return_value <= MLDSA_N)
+);
+
 #define poly_use_hint MLD_NAMESPACE(poly_use_hint)
 void poly_use_hint(poly *b, const poly *a, const poly *h);
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -393,7 +393,14 @@ unsigned int polyveck_make_hint(polyveck *h, const polyveck *v0,
   unsigned int i, s = 0;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    assigns(i, s, object_whole(h))
+    invariant(i <= MLDSA_K)
+    invariant(s <= i * MLDSA_N)
+  )
+  {
     s += poly_make_hint(&h->vec[i], &v0->vec[i], &v1->vec[i]);
+  }
 
   return s;
 }

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -6,6 +6,7 @@
 #define POLYVEC_H
 
 #include <stdint.h>
+#include "cbmc.h"
 #include "params.h"
 #include "poly.h"
 
@@ -86,9 +87,19 @@ int polyveck_chknorm(const polyveck *v, int32_t B);
 void polyveck_power2round(polyveck *v1, polyveck *v0, const polyveck *v);
 #define polyveck_decompose MLD_NAMESPACE(polyveck_decompose)
 void polyveck_decompose(polyveck *v1, polyveck *v0, const polyveck *v);
+
+
 #define polyveck_make_hint MLD_NAMESPACE(polyveck_make_hint)
 unsigned int polyveck_make_hint(polyveck *h, const polyveck *v0,
-                                const polyveck *v1);
+                                const polyveck *v1)
+__contract__(
+  requires(memory_no_alias(h,  sizeof(polyveck)))
+  requires(memory_no_alias(v0, sizeof(polyveck)))
+  requires(memory_no_alias(v1, sizeof(polyveck)))
+  assigns(object_whole(h))
+  ensures(return_value <= MLDSA_N * MLDSA_K)
+);
+
 #define polyveck_use_hint MLD_NAMESPACE(polyveck_use_hint)
 void polyveck_use_hint(polyveck *w, const polyveck *v, const polyveck *h);
 

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -6,6 +6,7 @@
 #define ROUNDING_H
 
 #include <stdint.h>
+#include "cbmc.h"
 #include "params.h"
 
 #define power2round MLD_NAMESPACE(power2round)
@@ -15,7 +16,10 @@ int32_t power2round(int32_t *a0, int32_t a);
 int32_t decompose(int32_t *a0, int32_t a);
 
 #define make_hint MLD_NAMESPACE(make_hint)
-unsigned int make_hint(int32_t a0, int32_t a1);
+unsigned int make_hint(int32_t a0, int32_t a1)
+__contract__(
+  ensures(return_value >= 0 && return_value <= 1)
+);
 
 #define use_hint MLD_NAMESPACE(use_hint)
 int32_t use_hint(int32_t a, unsigned int hint);

--- a/proofs/cbmc/make_hint/Makefile
+++ b/proofs/cbmc/make_hint/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = make_hint_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = make_hint
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/rounding.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)make_hint
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = make_hint
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/make_hint/make_hint_harness.c
+++ b/proofs/cbmc/make_hint/make_hint_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "rounding.h"
+
+void harness(void)
+{
+  int32_t a, b;
+  unsigned int r;
+  r = make_hint(a, b);
+}

--- a/proofs/cbmc/poly_make_hint/Makefile
+++ b/proofs/cbmc/poly_make_hint/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_make_hint_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_make_hint
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_make_hint
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)make_hint
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_make_hint
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_make_hint/poly_make_hint_harness.c
+++ b/proofs/cbmc/poly_make_hint/poly_make_hint_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+void harness(void)
+{
+  poly *a, *b, *c;
+  unsigned int r;
+  r = poly_make_hint(a, b, c);
+}

--- a/proofs/cbmc/polyveck_make_hint/Makefile
+++ b/proofs/cbmc/polyveck_make_hint/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_make_hint_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_make_hint
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_make_hint
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_make_hint
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2 --slice-formula
+
+FUNCTION_NAME = polyveck_make_hint
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_make_hint/polyveck_make_hint_harness.c
+++ b/proofs/cbmc/polyveck_make_hint/polyveck_make_hint_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyveck *a, *b, *c;
+  unsigned int r;
+  r = polyveck_make_hint(a, b, c);
+}


### PR DESCRIPTION
Add contracts and proofs of type-safety for
```
 rounding.c - make_hint()
 poly.c     - poly_make_hint()
 polyvec.c  - polyveck_make_hint()
```
The final one of those gives an upper-bound on the number of "1" bits in a hint, which
can be used in the proof of pack_sig()

Resolves #21 
