### PR TITLE
proof of pack_sig

### DIFF
--- a/mldsa/packing.h
+++ b/mldsa/packing.h
@@ -48,7 +48,20 @@ __contract__(
 
 #define pack_sig MLD_NAMESPACE(pack_sig)
 void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
-              const polyvecl *z, const polyveck *h);
+              const polyvecl *z, const polyveck *h,
+              const unsigned int number_of_hints)
+__contract__(
+  requires(memory_no_alias(sig, CRYPTO_BYTES))
+  requires(memory_no_alias(c, MLDSA_CTILDEBYTES))
+  requires(memory_no_alias(z, sizeof(polyvecl)))
+  requires(memory_no_alias(h, sizeof(polyveck)))
+  requires(forall(k0, 0, MLDSA_L,
+    array_bound(z->vec[k0].coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1)))
+  requires(forall(k1, 0, MLDSA_K,
+    array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+  requires(number_of_hints <= MLDSA_OMEGA)
+  assigns(object_whole(sig))
+);
 
 #define unpack_pk MLD_NAMESPACE(unpack_pk)
 void unpack_pk(uint8_t rho[MLDSA_SEEDBYTES], polyveck *t1,

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -452,6 +452,17 @@ void polyvecl_pack_eta(uint8_t r[MLDSA_L * MLDSA_POLYETA_PACKEDBYTES],
   }
 }
 
+void polyvecl_pack_z(uint8_t r[MLDSA_L * MLDSA_POLYZ_PACKEDBYTES],
+                     const polyvecl *p)
+{
+  unsigned int i;
+  for (i = 0; i < MLDSA_L; ++i)
+  {
+    polyz_pack(r + i * MLDSA_POLYZ_PACKEDBYTES, &p->vec[i]);
+  }
+}
+
+
 void polyveck_pack_t0(uint8_t r[MLDSA_K * MLDSA_POLYT0_PACKEDBYTES],
                       const polyveck *p)
 {

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -129,6 +129,17 @@ __contract__(
   assigns(object_whole(r))
 );
 
+#define polyvecl_pack_z MLD_NAMESPACE(polyvecl_pack_z)
+void polyvecl_pack_z(uint8_t r[MLDSA_L * MLDSA_POLYZ_PACKEDBYTES],
+                     const polyvecl *p)
+__contract__(                 
+  requires(memory_no_alias(r,  MLDSA_L * MLDSA_POLYZ_PACKEDBYTES))
+  requires(memory_no_alias(p, sizeof(polyvecl)))
+  requires(forall(k1, 0, MLDSA_L,
+                  array_bound(p->vec[k1].coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1)))
+  assigns(object_whole(r))
+);
+
 #define polyveck_pack_t0 MLD_NAMESPACE(polyveck_pack_t0)
 void polyveck_pack_t0(uint8_t r[MLDSA_K * MLDSA_POLYT0_PACKEDBYTES],
                       const polyveck *p)

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -5,6 +5,7 @@
 #include "sign.h"
 #include <stdint.h>
 #include <string.h>
+#include "cbmc.h"
 #include "fips202/fips202.h"
 #include "packing.h"
 #include "params.h"
@@ -220,7 +221,7 @@ rej:
     goto rej;
 
   /* Write signature */
-  pack_sig(sig, sig, &z, &h);
+  pack_sig(sig, sig, &z, &h, n);
   *siglen = CRYPTO_BYTES;
   return 0;
 }

--- a/proofs/cbmc/pack_sig/Makefile
+++ b/proofs/cbmc/pack_sig/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = pack_sig_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = pack_sig
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/packing.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)pack_sig
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_pack_z
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS+=--slice-formula
+
+FUNCTION_NAME = pack_sig
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 9
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/pack_sig/pack_sig_harness.c
+++ b/proofs/cbmc/pack_sig/pack_sig_harness.c
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "packing.h"
+
+
+void harness(void)
+{
+  uint8_t *a, *b;
+  polyveck *h;
+  polyvecl *z;
+  unsigned int nh;
+  pack_sig(a, b, z, h, nh);
+}

--- a/proofs/cbmc/polyvecl_pack_z/Makefile
+++ b/proofs/cbmc/polyvecl_pack_z/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvecl_pack_z_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvecl_pack_z
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET += $(MLD_NAMESPACE)polyvecl_pack_z.0:7 # Largest value of MLDSA_L
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_pack_z
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyz_pack
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvecl_pack_z
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvecl_pack_z/polyvecl_pack_z_harness.c
+++ b/proofs/cbmc/polyvecl_pack_z/polyvecl_pack_z_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyvecl *a;
+  uint8_t *b;
+  polyvecl_pack_z(b, a);
+}


### PR DESCRIPTION
Fixes #72 
1. Simplifies pack_sig() through use of memcpy() and memset() where possible.
2. Introduces new function polyvecl_pack_z() in polyvec.[hc] and its proof.
3. Adds formal parameter "number_of_hints" to pack_sig() and pre-condition that can be used to ensure type-safety.
4. Updates call to pack_sig() in sign.c appropriately.
5. Proof of pack_sig() updated.

Please review explanatory comments in body of pack_sig()

