### PR TITLE
Add spec and proof for poly_sub

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -13,7 +13,7 @@
 #ifdef DBENCH
 #include "test/cpucycles.h"
 extern const uint64_t timing_overhead;
-extern uint64_t *tred, *tadd, *tmul, *tround, *tsample, *tpack;
+extern uint64_t *tred, *tadd, *tsub, *tmul, *tround, *tsample, *tpack;
 #define DBENCH_START() uint64_t time = cpucycles()
 #define DBENCH_STOP(t) t += cpucycles() - time - timing_overhead
 #else
@@ -98,9 +98,12 @@ void poly_sub(poly *c, const poly *a, const poly *b)
   DBENCH_START();
 
   for (i = 0; i < MLDSA_N; ++i)
-    c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+  __loop__(
+    invariant(i <= MLDSA_N)
+    invariant(forall(k1, 0, i, c->coeffs[k1] == a->coeffs[k1] - b->coeffs[k1])))
+  c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
 
-  DBENCH_STOP(*tadd);
+  DBENCH_STOP(*tsub);
 }
 
 /*************************************************

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -32,7 +32,15 @@ __contract__(
 );
 
 #define poly_sub MLD_NAMESPACE(poly_sub)
-void poly_sub(poly *c, const poly *a, const poly *b);
+void poly_sub(poly *c, const poly *a, const poly *b)
+__contract__(
+  requires(memory_no_alias(c, sizeof(poly)))
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(memory_no_alias(b, sizeof(poly)))
+  requires(forall(k0, 0, MLDSA_N, (int64_t) a->coeffs[k0] - b->coeffs[k0] <= INT32_MAX))
+  requires(forall(k1, 0, MLDSA_N, (int64_t) a->coeffs[k1] - b->coeffs[k1] >= INT32_MIN))
+  ensures(forall(k, 0, MLDSA_N, c->coeffs[k] == a->coeffs[k] - b->coeffs[k]))
+  assigns(memory_slice(c, sizeof(poly))));
 
 #define poly_shiftl MLD_NAMESPACE(poly_shiftl)
 void poly_shiftl(poly *a)

--- a/proofs/cbmc/poly_sub/Makefile
+++ b/proofs/cbmc/poly_sub/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_sub_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_sub
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_sub
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_sub
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_sub/poly_sub_harness.c
+++ b/proofs/cbmc/poly_sub/poly_sub_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+void harness(void)
+{
+  poly *c, *a, *b;
+  poly_sub(c, a, b);
+}


### PR DESCRIPTION
This PR adds the spec and proof for `poly_sub` function. 
This PR does _not_ remove `poly_sub` benchmarking `DBENCH_START();` and `DBENCH_STOP(*tsub);` calls.

Solves https://github.com/pq-code-package/mldsa-native/issues/22.

