### PR TITLE
Fix bug in tests script

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -621,7 +621,7 @@ class Tests:
             if nistkat is True:
                 self._run_schemes(TEST_TYPES.NISTKAT, opt)
             if acvp is True:
-                self._run_schemes(TEST_TYPES.ACVP, opt)
+                self._run_scheme(TEST_TYPES.ACVP, opt, None)
 
         if self.do_no_opt():
             _all(False)


### PR DESCRIPTION
This PR fixes the tests script for ACVP tests with 'all' argument.

Solves https://github.com/pq-code-package/mldsa-native/issues/81.

```
./scripts/tests all
INFO  > Functional Test    Compile     (native no_opt):  make func OPT=0 AUTO=1 -j16
INFO  > Kat Test           Compile     (native no_opt):  make kat OPT=0 AUTO=1 -j16
INFO  > Nistkat Test       Compile     (native no_opt):  make nistkat OPT=0 AUTO=1 -j16
INFO  > ACVP Test          Compile     (native no_opt):  make acvp OPT=0 AUTO=1 -j16
INFO  > Functional Test    ML-DSA-44   (native no_opt):  make run_func_44 -j16
INFO  > Functional Test    ML-DSA-65   (native no_opt):  make run_func_65 -j16
INFO  > Functional Test    ML-DSA-87   (native no_opt):  make run_func_87 -j16
INFO  > Kat Test           ML-DSA-44   (native no_opt):  make run_kat_44 -j16
INFO  > Kat Test           ML-DSA-65   (native no_opt):  make run_kat_65 -j16
INFO  > Kat Test           ML-DSA-87   (native no_opt):  make run_kat_87 -j16
INFO  > Nistkat Test       ML-DSA-44   (native no_opt):  make run_nistkat_44 -j16
INFO  > Nistkat Test       ML-DSA-65   (native no_opt):  make run_nistkat_65 -j16
INFO  > Nistkat Test       ML-DSA-87   (native no_opt):  make run_nistkat_87 -j16
INFO  > ACVP Test          All         (native no_opt):  make run_acvp -j16
INFO  > Functional Test    Compile     (native opt):     make func OPT=1 AUTO=1 -j16
INFO  > Kat Test           Compile     (native opt):     make kat OPT=1 AUTO=1 -j16
INFO  > Nistkat Test       Compile     (native opt):     make nistkat OPT=1 AUTO=1 -j16
INFO  > ACVP Test          Compile     (native opt):     make acvp OPT=1 AUTO=1 -j16
INFO  > Functional Test    ML-DSA-44   (native opt):     make run_func_44 -j16
INFO  > Functional Test    ML-DSA-65   (native opt):     make run_func_65 -j16
INFO  > Functional Test    ML-DSA-87   (native opt):     make run_func_87 -j16
INFO  > Kat Test           ML-DSA-44   (native opt):     make run_kat_44 -j16
INFO  > Kat Test           ML-DSA-65   (native opt):     make run_kat_65 -j16
INFO  > Kat Test           ML-DSA-87   (native opt):     make run_kat_87 -j16
INFO  > Nistkat Test       ML-DSA-44   (native opt):     make run_nistkat_44 -j16
INFO  > Nistkat Test       ML-DSA-65   (native opt):     make run_nistkat_65 -j16
INFO  > Nistkat Test       ML-DSA-87   (native opt):     make run_nistkat_87 -j16
INFO  > ACVP Test          All         (native opt):     make run_acvp -j16
All good!
```