### PR TITLE
Add spec and proof for rej_eta

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -435,15 +435,37 @@ void poly_uniform(poly *a, const uint8_t seed[MLDSA_SEEDBYTES], uint16_t nonce)
  * Returns number of sampled coefficients. Can be smaller than len if not enough
  * random bytes were given.
  **************************************************/
+#if MLDSA_ETA == 2
+#define POLY_UNIFORM_ETA_NBLOCKS \
+  ((136 + STREAM256_BLOCKBYTES - 1) / STREAM256_BLOCKBYTES)
+#elif MLDSA_ETA == 4
+#define POLY_UNIFORM_ETA_NBLOCKS \
+  ((227 + STREAM256_BLOCKBYTES - 1) / STREAM256_BLOCKBYTES)
+#else
+#error "Invalid value of MLDSA_ETA"
+#endif
 static unsigned int rej_eta(int32_t *a, unsigned int len, const uint8_t *buf,
                             unsigned int buflen)
+__contract__(
+  requires(len <= buflen && len <= MLDSA_N && \
+                  buflen <= (POLY_UNIFORM_ETA_NBLOCKS * STREAM256_BLOCKBYTES))
+  requires(memory_no_alias(a, sizeof(int32_t) * len))
+  requires(memory_no_alias(buf, buflen))
+  assigns(memory_slice(a, sizeof(int32_t) * len))
+  ensures(return_value <= len)
+  ensures(array_abs_bound(a, 0, return_value, MLDSA_ETA + 1))
+)
 {
   unsigned int ctr, pos;
-  uint32_t t0, t1;
+  int32_t t0, t1;
   DBENCH_START();
 
   ctr = pos = 0;
   while (ctr < len && pos < buflen)
+  __loop__(
+    invariant(0 <= ctr && ctr <= len && pos <= buflen)
+    invariant(ctr > 0 ==> array_abs_bound(a, 0, ctr, MLDSA_ETA + 1))
+  )
   {
     t0 = buf[pos] & 0x0F;
     t1 = buf[pos++] >> 4;
@@ -489,15 +511,6 @@ static unsigned int rej_eta(int32_t *a, unsigned int len, const uint8_t *buf,
  *MLDSA_CRHBYTES
  *              - uint16_t nonce: 2-byte nonce
  **************************************************/
-#if MLDSA_ETA == 2
-#define POLY_UNIFORM_ETA_NBLOCKS \
-  ((136 + STREAM256_BLOCKBYTES - 1) / STREAM256_BLOCKBYTES)
-#elif MLDSA_ETA == 4
-#define POLY_UNIFORM_ETA_NBLOCKS \
-  ((227 + STREAM256_BLOCKBYTES - 1) / STREAM256_BLOCKBYTES)
-#else
-#error "Invalid value of MLDSA_ETA"
-#endif
 void poly_uniform_eta(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                       uint16_t nonce)
 {

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -457,14 +457,14 @@ __contract__(
 )
 {
   unsigned int ctr, pos;
-  int32_t t0, t1;
+  uint32_t t0, t1;
   DBENCH_START();
 
   ctr = pos = 0;
   while (ctr < len && pos < buflen)
   __loop__(
     invariant(0 <= ctr && ctr <= len && pos <= buflen)
-    invariant(ctr > 0 ==> array_abs_bound(a, 0, ctr, MLDSA_ETA + 1))
+    invariant(array_abs_bound(a, 0, ctr, MLDSA_ETA + 1))
   )
   {
     t0 = buf[pos] & 0x0F;
@@ -474,21 +474,21 @@ __contract__(
     if (t0 < 15)
     {
       t0 = t0 - (205 * t0 >> 10) * 5;
-      a[ctr++] = 2 - t0;
+      a[ctr++] = 2 - (int32_t)t0;
     }
     if (t1 < 15 && ctr < len)
     {
       t1 = t1 - (205 * t1 >> 10) * 5;
-      a[ctr++] = 2 - t1;
+      a[ctr++] = 2 - (int32_t)t1;
     }
 #elif MLDSA_ETA == 4
     if (t0 < 9)
     {
-      a[ctr++] = 4 - t0;
+      a[ctr++] = 4 - (int32_t)t0;
     }
     if (t1 < 9 && ctr < len)
     {
-      a[ctr++] = 4 - t1;
+      a[ctr++] = 4 - (int32_t)t1;
     }
 #else
 #error "Invalid value of MLDSA_ETA"

--- a/proofs/cbmc/rej_eta/Makefile
+++ b/proofs/cbmc/rej_eta/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = rej_eta_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = rej_eta
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=rej_eta
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = rej_eta
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/rej_eta/rej_eta_harness.c
+++ b/proofs/cbmc/rej_eta/rej_eta_harness.c
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+unsigned rej_eta(int32_t *a, unsigned int len, const uint8_t *buf,
+                 unsigned int buflen);
+
+void harness(void)
+{
+  int32_t *a;
+  unsigned int len;
+  const uint8_t *buf;
+  unsigned int buflen;
+
+  rej_eta(a, len, buf, buflen);
+}


### PR DESCRIPTION
This PR adds the spec and proof for rej_eta function.

Notes::
- `rej_eta` is static, thus, `CHECK_FUNCTION_CONTRACTS` is defined as `rej_eta` instead of $`(MLD_NAMESPACE)rej_eta` in the `Makefile`.
- `rej_eta` is static, thus, additional assumptions, such as `requires(len <= MLDSA_N && buflen <= (POLY_UNIFORM_ETA_NBLOCKS * STREAM256_BLOCKBYTES))` are made. This accelerates the performance of CBMC proofs.


Another Note::
- [change types](https://github.com/manastasova/mldsa-native/blob/783550404c42fa5659f4116d8b7c177c32a4d2b6/mldsa/poly.c#L442) `uint32_t t0, t1;` to `int32_t t0, t1;` due to [potential overflow in](https://github.com/manastasova/mldsa-native/blob/783550404c42fa5659f4116d8b7c177c32a4d2b6/mldsa/poly.c#L467) `if (t0 < 9){a[ctr++] = 4 - t0;}` causing cbmc fail.

Solves https://github.com/pq-code-package/mldsa-native/issues/26.