### PR TITLE
Add proof for poly_reduce

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -35,6 +35,10 @@ void poly_reduce(poly *a)
   DBENCH_START();
 
   for (i = 0; i < MLDSA_N; ++i)
+  __loop__(
+    invariant(i <= MLDSA_N)
+    invariant(forall(k0, i, MLDSA_N, a->coeffs[k0] == loop_entry(*a).coeffs[k0]))
+    invariant(array_bound(a->coeffs, 0, i, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX)))
   {
     a->coeffs[i] = reduce32(a->coeffs[i]);
   }

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include "cbmc.h"
 #include "params.h"
+#include "reduce.h"
 
 typedef struct
 {
@@ -15,7 +16,14 @@ typedef struct
 } poly;
 
 #define poly_reduce MLD_NAMESPACE(poly_reduce)
-void poly_reduce(poly *a);
+void poly_reduce(poly *a)
+__contract__(
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(forall(k0, 0, MLDSA_N, a->coeffs[k0] <= REDUCE_DOMAIN_MAX)) 
+  assigns(memory_slice(a, sizeof(poly)))
+  ensures(array_bound(a->coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX))
+);
+
 #define poly_caddq MLD_NAMESPACE(poly_caddq)
 void poly_caddq(poly *a);
 

--- a/mldsa/reduce.c
+++ b/mldsa/reduce.c
@@ -76,6 +76,7 @@ int32_t reduce32(int32_t a)
 
   t = (a + (1 << 22)) >> 23;
   t = a - t * MLDSA_Q;
+  cassert((t - a) % MLDSA_Q == 0);
   return t;
 }
 

--- a/mldsa/reduce.h
+++ b/mldsa/reduce.h
@@ -38,7 +38,6 @@ __contract__(
   requires(a <= REDUCE_DOMAIN_MAX)
   ensures(return_value >= -REDUCE_RANGE_MAX)
   ensures(return_value <   REDUCE_RANGE_MAX)
-  ensures((return_value - a) % MLDSA_Q == 0)
 );
 
 #define caddq MLD_NAMESPACE(caddq)

--- a/proofs/cbmc/poly_reduce/Makefile
+++ b/proofs/cbmc/poly_reduce/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_reduce_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_reduce
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_reduce
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)reduce32
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_reduce
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_reduce/poly_reduce_harness.c
+++ b/proofs/cbmc/poly_reduce/poly_reduce_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+void harness(void)
+{
+  poly *a;
+  poly_reduce(a);
+}


### PR DESCRIPTION
1. Adds spec for `poly_reduce` using proof for reduce32. Fixes #64.
2. Edits `reduce32` proof to use `cassert` instead of `ensures`.
3. Edits `cbmc.h` to ignore `cassert` statements unless doing a CBMC proof.
4. Moves `REDUCE_*` defines from `reduce.h`, `poly.h` to common header file `params.h` to avoid divergent values. The defines are renamed as per convention.