### PR TITLE
CBMC: Add contract and proof for `montgomery_reduce` and `fqmul`

### DIFF
--- a/mldsa/params.h
+++ b/mldsa/params.h
@@ -13,6 +13,7 @@
 #define MLDSA_RNDBYTES 32
 #define MLDSA_N 256
 #define MLDSA_Q 8380417
+#define MLDSA_Q_HALF ((MLDSA_Q + 1) / 2) /* 4190209 */
 #define MLDSA_D 13
 
 #if MLDSA_MODE == 2

--- a/mldsa/reduce.h
+++ b/mldsa/reduce.h
@@ -10,12 +10,27 @@
 #include "params.h"
 
 #define MONT -4186625 /* 2^32 % MLDSA_Q */
-#define QINV 58728449 /* q^(-1) mod 2^32 */
 #define REDUCE_DOMAIN_MAX (INT32_MAX - (1 << 22))
 #define REDUCE_RANGE_MAX 6283009
+#define MONTGOMERY_REDUCE_DOMAIN_MAX (MLDSA_Q * (1LL << 31))
 
 #define montgomery_reduce MLD_NAMESPACE(montgomery_reduce)
-int32_t montgomery_reduce(int64_t a);
+/*************************************************
+ * Name:        montgomery_reduce
+ *
+ * Description: For finite field element a with
+ *              -2^{31}MLDSA_Q <= a <= MLDSA_Q*2^31,
+ *              compute r \equiv a*2^{-32} (mod MLDSA_Q) such that
+ *              -MLDSA_Q < r < MLDSA_Q.
+ *
+ * Arguments:   - int64_t: finite field element a
+ *
+ * Returns r.
+ **************************************************/
+int32_t montgomery_reduce(int64_t a)
+__contract__(
+  requires(a >= -MONTGOMERY_REDUCE_DOMAIN_MAX && a <= MONTGOMERY_REDUCE_DOMAIN_MAX)
+);
 
 #define reduce32 MLD_NAMESPACE(reduce32)
 int32_t reduce32(int32_t a)

--- a/proofs/cbmc/fqmul/Makefile
+++ b/proofs/cbmc/fqmul/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = fqmul_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = fqmul
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/ntt.c $(SRCDIR)/mldsa/reduce.c
+
+CHECK_FUNCTION_CONTRACTS=mld_fqmul
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = mld_fqmul
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/fqmul/fqmul_harness.c
+++ b/proofs/cbmc/fqmul/fqmul_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ntt.h"
+
+int32_t mld_fqmul(int32_t a, int32_t b);
+void harness(void)
+{
+  int32_t a, b, r;
+  r = mld_fqmul(a, b);
+}

--- a/proofs/cbmc/montgomery_reduce/Makefile
+++ b/proofs/cbmc/montgomery_reduce/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = montgomery_reduce_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = montgomery_reduce
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/reduce.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)montgomery_reduce
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = montgomery_reduce
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/montgomery_reduce/montgomery_reduce_harness.c
+++ b/proofs/cbmc/montgomery_reduce/montgomery_reduce_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce.h"
+
+void harness(void)
+{
+  int64_t a;
+  int32_t r;
+  r = montgomery_reduce(a);
+}


### PR DESCRIPTION
Resolves https://github.com/pq-code-package/mldsa-native/issues/14

This follows closely montgomery_reduce in mlkem-native: https://github.com/pq-code-package/mlkem-native/blob/83d85fe224bd6cf1b75f096a2b2fa01033b3dfda/mlkem/poly.h#L80

@hanno-becker @rod-chapman - can we prove anything else about this montgomery_reduction? The contract right now is rather weak. Do you remember why it is this weak in mlkem-native?