### PR TITLE
Proofs of `use_hint()` and `poly_use_hint()`

### DIFF
--- a/mldsa/cbmc.h
+++ b/mldsa/cbmc.h
@@ -13,6 +13,7 @@
 
 #define __contract__(x)
 #define __loop__(x)
+#define cassert(x)
 
 #else /* CBMC _is_ defined, therefore we're doing proof */
 

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -295,6 +295,10 @@ void poly_use_hint(poly *b, const poly *a, const poly *h)
   DBENCH_START();
 
   for (i = 0; i < MLDSA_N; ++i)
+  __loop__(
+    invariant(i <= MLDSA_N)
+    invariant(array_bound(b->coeffs, 0, i, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)))
+  )
   {
     b->coeffs[i] = use_hint(a->coeffs[i], h->coeffs[i]);
   }

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -84,18 +84,31 @@ __contract__(
 );
 
 #define poly_use_hint MLD_NAMESPACE(poly_use_hint)
-void poly_use_hint(poly *b, const poly *a, const poly *h);
+void poly_use_hint(poly *b, const poly *a, const poly *h)
+__contract__(
+  requires(memory_no_alias(a,  sizeof(poly)))
+  requires(memory_no_alias(b, sizeof(poly)))
+  requires(memory_no_alias(h, sizeof(poly)))
+  requires(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
+  requires(array_bound(h->coeffs, 0, MLDSA_N, 0, 2))
+  assigns(memory_slice(b, sizeof(poly)))
+  ensures(array_bound(b->coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)))
+);
 
 #define poly_chknorm MLD_NAMESPACE(poly_chknorm)
 int poly_chknorm(const poly *a, int32_t B);
+
 #define poly_uniform MLD_NAMESPACE(poly_uniform)
 void poly_uniform(poly *a, const uint8_t seed[MLDSA_SEEDBYTES], uint16_t nonce);
+
 #define poly_uniform_eta MLD_NAMESPACE(poly_uniform_eta)
 void poly_uniform_eta(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                       uint16_t nonce);
+
 #define poly_uniform_gamma1 MLD_NAMESPACE(poly_uniform_gamma1)
 void poly_uniform_gamma1(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                          uint16_t nonce);
+
 #define poly_challenge MLD_NAMESPACE(poly_challenge)
 void poly_challenge(poly *c, const uint8_t seed[MLDSA_CTILDEBYTES]);
 

--- a/mldsa/rounding.c
+++ b/mldsa/rounding.c
@@ -16,12 +16,22 @@ void power2round(int32_t *a0, int32_t *a1, const int32_t a)
 void decompose(int32_t *a0, int32_t *a1, int32_t a)
 {
   *a1 = (a + 127) >> 7;
+  /* We know a >= 0 and a < MLDSA_Q, so... */
+  cassert(*a1 >= 0 && *a1 <= 65472);
+
 #if MLDSA_GAMMA2 == (MLDSA_Q - 1) / 32
   *a1 = (*a1 * 1025 + (1 << 21)) >> 22;
+  cassert(*a1 >= 0 && *a1 <= 16);
+
   *a1 &= 15;
+  cassert(*a1 >= 0 && *a1 <= 15);
+
 #elif MLDSA_GAMMA2 == (MLDSA_Q - 1) / 88
   *a1 = (*a1 * 11275 + (1 << 23)) >> 24;
+  cassert(*a1 >= 0 && *a1 <= 44);
+
   *a1 ^= ((43 - *a1) >> 31) & *a1;
+  cassert(*a1 >= 0 && *a1 <= 43);
 #endif
 
   *a0 = a - *a1 * 2 * MLDSA_GAMMA2;

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -62,7 +62,7 @@ __contract__(
   requires(a >= 0 && a < MLDSA_Q)
   assigns(memory_slice(a0, sizeof(int32_t)))
   assigns(memory_slice(a1, sizeof(int32_t)))
-  /* a0 = -MLDSA_GAMMA2 can only occur when (q-1) = a - (a mod MLDSA_GAMMA2), 
+  /* a0 = -MLDSA_GAMMA2 can only occur when (q-1) = a - (a mod MLDSA_GAMMA2),
    * then a1=1; and a0 = a - (a mod MLDSA_GAMMA2) - 1 (See Alg. 36, FIPS204) */
   ensures(*a0 >= -MLDSA_GAMMA2  && *a0 <= MLDSA_GAMMA2)
   ensures(*a1 >= 0 && *a1 < (MLDSA_Q-1)/(2*MLDSA_GAMMA2))
@@ -76,6 +76,11 @@ __contract__(
 );
 
 #define use_hint MLD_NAMESPACE(use_hint)
-int32_t use_hint(int32_t a, unsigned int hint);
+int32_t use_hint(int32_t a, unsigned int hint)
+__contract__(
+  requires(hint >= 0 && hint <= 1)
+  requires(a >= 0 && a < MLDSA_Q)
+  ensures(return_value >= 0 && return_value < (MLDSA_Q-1)/(2*MLDSA_GAMMA2))
+);
 
 #endif

--- a/proofs/cbmc/poly_use_hint/Makefile
+++ b/proofs/cbmc/poly_use_hint/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_use_hint_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_use_hint
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_use_hint
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)use_hint
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_use_hint
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_use_hint/poly_use_hint_harness.c
+++ b/proofs/cbmc/poly_use_hint/poly_use_hint_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+
+void harness(void)
+{
+  poly *a, *b, *h;
+  poly_use_hint(b, a, h);
+}

--- a/proofs/cbmc/use_hint/Makefile
+++ b/proofs/cbmc/use_hint/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = use_hint_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = use_hint
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/rounding.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)use_hint
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)decompose
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = use_hint
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/use_hint/use_hint_harness.c
+++ b/proofs/cbmc/use_hint/use_hint_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "rounding.h"
+
+void harness(void)
+{
+  int32_t a, r;
+  unsigned int hint;
+  r = use_hint(a, hint);
+}


### PR DESCRIPTION
Fixes #20 

Adds contracts and CBMC proofs of use_hint() and poly_use_hint()

polyveck_use_hint() will be attempted separately.

All tests, proofs, and lint OK.

 

