### PR TITLE
Add spec and proof for rej_uniform

### DIFF
--- a/proofs/cbmc/rej_uniform/Makefile
+++ b/proofs/cbmc/rej_uniform/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = rej_uniform_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = rej_uniform
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=rej_uniform
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = rej_uniform
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/rej_uniform/rej_uniform_harness.c
+++ b/proofs/cbmc/rej_uniform/rej_uniform_harness.c
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+unsigned rej_uniform(int32_t *a, unsigned int len, const uint8_t *buf,
+                     unsigned int buflen);
+
+void harness(void)
+{
+  int32_t *a;
+  unsigned int len;
+  const uint8_t *buf;
+  unsigned int buflen;
+
+  rej_uniform(a, len, buf, buflen);
+}


### PR DESCRIPTION
This PR adds the contract and proof for rej_uniform function.

Notes::
- `rej_uniform` is static, thus, `CHECK_FUNCTION_CONTRACTS` is defined as `rej_uniform` instead of $`(MLD_NAMESPACE)rej_uniform` in the `Makefile`.
- `rej_uniform` is static, thus, additional assumptions, such as `requires(len <= MLDSA_N && buflen <= (POLY_UNIFORM_NBLOCKS * STREAM128_BLOCKBYTES))` are made. This accelerates the performance of CBMC proofs.


Solves https://github.com/pq-code-package/mldsa-native/issues/25.