### PR TITLE
Move and clarify comments in rounding.c to rounding.h

### DIFF
--- a/mldsa/rounding.c
+++ b/mldsa/rounding.c
@@ -38,17 +38,6 @@ void decompose(int32_t *a0, int32_t *a1, int32_t a)
   *a0 -= (((MLDSA_Q - 1) / 2 - *a0) >> 31) & MLDSA_Q;
 }
 
-/*************************************************
- * Name:        make_hint
- *
- * Description: Compute hint bit indicating whether the low bits of the
- *              input element overflow into the high bits.
- *
- * Arguments:   - int32_t a0: low bits of input element
- *              - int32_t a1: high bits of input element
- *
- * Returns 1 if overflow.
- **************************************************/
 unsigned int make_hint(int32_t a0, int32_t a1)
 {
   if (a0 > MLDSA_GAMMA2 || a0 < -MLDSA_GAMMA2 ||
@@ -60,16 +49,6 @@ unsigned int make_hint(int32_t a0, int32_t a1)
   return 0;
 }
 
-/*************************************************
- * Name:        use_hint
- *
- * Description: Correct high bits according to hint.
- *
- * Arguments:   - int32_t a: input element
- *              - unsigned int hint: hint bit
- *
- * Returns corrected high bits.
- **************************************************/
 int32_t use_hint(int32_t a, unsigned int hint)
 {
   int32_t a0, a1;

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -23,7 +23,8 @@
  *              - int32_t *a0: pointer to output element a0
  *              - int32_t *a1: pointer to output element a1
  *
- * Reference: a1 is passed as a return value instead
+ * In the reference implementation, a1 is passed as a
+ * return value instead.
  **************************************************/
 void power2round(int32_t *a0, int32_t *a1, int32_t a)
 __contract__(
@@ -70,12 +71,33 @@ __contract__(
 );
 
 #define make_hint MLD_NAMESPACE(make_hint)
+/*************************************************
+ * Name:        make_hint
+ *
+ * Description: Compute hint bit indicating whether the low bits of the
+ *              input element overflow into the high bits.
+ *
+ * Arguments:   - int32_t a0: low bits of input element
+ *              - int32_t a1: high bits of input element
+ *
+ * Returns 1 if overflow, 0 otherwise
+ **************************************************/
 unsigned int make_hint(int32_t a0, int32_t a1)
 __contract__(
   ensures(return_value >= 0 && return_value <= 1)
 );
 
 #define use_hint MLD_NAMESPACE(use_hint)
+/*************************************************
+ * Name:        use_hint
+ *
+ * Description: Correct high bits according to hint.
+ *
+ * Arguments:   - int32_t a: input element
+ *              - unsigned int hint: hint bit
+ *
+ * Returns corrected high bits.
+ **************************************************/
 int32_t use_hint(int32_t a, unsigned int hint)
 __contract__(
   requires(hint >= 0 && hint <= 1)

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -23,7 +23,7 @@
  *              - int32_t *a0: pointer to output element a0
  *              - int32_t *a1: pointer to output element a1
  *
- * In the reference implementation, a1 is passed as a
+ * Reference: In the reference implementation, a1 is passed as a
  * return value instead.
  **************************************************/
 void power2round(int32_t *a0, int32_t *a1, int32_t a)


### PR DESCRIPTION
Moves comments from rounding.c to their correct place in rounding.h
Clarifies wording in 2 places.

Lint OK. Tests OK.

