### PR TITLE
Move all docstrings to header files

### DIFF
--- a/mldsa/ntt.h
+++ b/mldsa/ntt.h
@@ -42,6 +42,17 @@ __contract__(
 );
 
 #define invntt_tomont MLD_NAMESPACE(invntt_tomont)
+/*************************************************
+ * Name:        invntt_tomont
+ *
+ * Description: Inverse NTT and multiplication by Montgomery factor 2^32.
+ *              In-place. No modular reductions after additions or
+ *              subtractions; input coefficients need to be smaller than
+ *              MLDSA_Q in absolute value. Output coefficient are smaller than
+ *              MLDSA_Q in absolute value.
+ *
+ * Arguments:   - uint32_t p[MLDSA_N]: input/output coefficient array
+ **************************************************/
 void invntt_tomont(int32_t a[MLDSA_N]);
 
 #endif

--- a/mldsa/packing.c
+++ b/mldsa/packing.c
@@ -8,15 +8,6 @@
 #include "poly.h"
 #include "polyvec.h"
 
-/*************************************************
- * Name:        pack_pk
- *
- * Description: Bit-pack public key pk = (rho, t1).
- *
- * Arguments:   - uint8_t pk[]: output byte array
- *              - const uint8_t rho[]: byte array containing rho
- *              - const polyveck *t1: pointer to vector t1
- **************************************************/
 void pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
              const uint8_t rho[MLDSA_SEEDBYTES], const polyveck *t1)
 {
@@ -31,15 +22,6 @@ void pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
   }
 }
 
-/*************************************************
- * Name:        unpack_pk
- *
- * Description: Unpack public key pk = (rho, t1).
- *
- * Arguments:   - const uint8_t rho[]: output byte array for rho
- *              - const polyveck *t1: pointer to output vector t1
- *              - uint8_t pk[]: byte array containing bit-packed pk
- **************************************************/
 void unpack_pk(uint8_t rho[MLDSA_SEEDBYTES], polyveck *t1,
                const uint8_t pk[CRYPTO_PUBLICKEYBYTES])
 {
@@ -54,19 +36,6 @@ void unpack_pk(uint8_t rho[MLDSA_SEEDBYTES], polyveck *t1,
   }
 }
 
-/*************************************************
- * Name:        pack_sk
- *
- * Description: Bit-pack secret key sk = (rho, tr, key, t0, s1, s2).
- *
- * Arguments:   - uint8_t sk[]: output byte array
- *              - const uint8_t rho[]: byte array containing rho
- *              - const uint8_t tr[]: byte array containing tr
- *              - const uint8_t key[]: byte array containing key
- *              - const polyveck *t0: pointer to vector t0
- *              - const polyvecl *s1: pointer to vector s1
- *              - const polyveck *s2: pointer to vector s2
- **************************************************/
 void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
              const uint8_t rho[MLDSA_SEEDBYTES],
              const uint8_t tr[MLDSA_TRBYTES],
@@ -91,19 +60,6 @@ void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
   polyveck_pack_t0(sk, t0);
 }
 
-/*************************************************
- * Name:        unpack_sk
- *
- * Description: Unpack secret key sk = (rho, tr, key, t0, s1, s2).
- *
- * Arguments:   - const uint8_t rho[]: output byte array for rho
- *              - const uint8_t tr[]: output byte array for tr
- *              - const uint8_t key[]: output byte array for key
- *              - const polyveck *t0: pointer to output vector t0
- *              - const polyvecl *s1: pointer to output vector s1
- *              - const polyveck *s2: pointer to output vector s2
- *              - uint8_t sk[]: byte array containing bit-packed sk
- **************************************************/
 void unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
                uint8_t key[MLDSA_SEEDBYTES], polyveck *t0, polyvecl *s1,
                polyveck *s2, const uint8_t sk[CRYPTO_SECRETKEYBYTES])
@@ -126,23 +82,6 @@ void unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
   polyveck_unpack_t0(t0, sk);
 }
 
-/*************************************************
- * Name:        pack_sig
- *
- * Description: Bit-pack signature sig = (c, z, h).
- *
- * Arguments:   - uint8_t sig[]: output byte array
- *              - const uint8_t *c:  pointer to challenge hash length
- *                                   MLDSA_SEEDBYTES
- *              - const polyvecl *z: pointer to vector z
- *              - const polyveck *h: pointer to hint vector h
- *              - const unsigned int number_of_hints: total
- *                                   hints in *h
- *
- * Note that the number_of_hints argument is not present
- * in the reference implementation. It is added here to ease
- * proof of type safety.
- **************************************************/
 void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
               const polyvecl *z, const polyveck *h,
               const unsigned int number_of_hints)
@@ -212,19 +151,6 @@ void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
   }
 }
 
-/*************************************************
- * Name:        unpack_sig
- *
- * Description: Unpack signature sig = (c, z, h).
- *
- * Arguments:   - uint8_t *c: pointer to output challenge hash
- *              - polyvecl *z: pointer to output vector z
- *              - polyveck *h: pointer to output hint vector h
- *              - const uint8_t sig[]: byte array containing
- *                bit-packed signature
- *
- * Returns 1 in case of malformed signature; otherwise 0.
- **************************************************/
 int unpack_sig(uint8_t c[MLDSA_CTILDEBYTES], polyvecl *z, polyveck *h,
                const uint8_t sig[CRYPTO_BYTES])
 {

--- a/mldsa/packing.h
+++ b/mldsa/packing.h
@@ -10,6 +10,15 @@
 #include "polyvec.h"
 
 #define pack_pk MLD_NAMESPACE(pack_pk)
+/*************************************************
+ * Name:        pack_pk
+ *
+ * Description: Bit-pack public key pk = (rho, t1).
+ *
+ * Arguments:   - uint8_t pk[]: output byte array
+ *              - const uint8_t rho[]: byte array containing rho
+ *              - const polyveck *t1: pointer to vector t1
+ **************************************************/
 void pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
              const uint8_t rho[MLDSA_SEEDBYTES], const polyveck *t1)
 __contract__(
@@ -23,6 +32,19 @@ __contract__(
 
 
 #define pack_sk MLD_NAMESPACE(pack_sk)
+/*************************************************
+ * Name:        pack_sk
+ *
+ * Description: Bit-pack secret key sk = (rho, tr, key, t0, s1, s2).
+ *
+ * Arguments:   - uint8_t sk[]: output byte array
+ *              - const uint8_t rho[]: byte array containing rho
+ *              - const uint8_t tr[]: byte array containing tr
+ *              - const uint8_t key[]: byte array containing key
+ *              - const polyveck *t0: pointer to vector t0
+ *              - const polyvecl *s1: pointer to vector s1
+ *              - const polyveck *s2: pointer to vector s2
+ **************************************************/
 void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
              const uint8_t rho[MLDSA_SEEDBYTES],
              const uint8_t tr[MLDSA_TRBYTES],
@@ -47,6 +69,23 @@ __contract__(
 
 
 #define pack_sig MLD_NAMESPACE(pack_sig)
+/*************************************************
+ * Name:        pack_sig
+ *
+ * Description: Bit-pack signature sig = (c, z, h).
+ *
+ * Arguments:   - uint8_t sig[]: output byte array
+ *              - const uint8_t *c:  pointer to challenge hash length
+ *                                   MLDSA_SEEDBYTES
+ *              - const polyvecl *z: pointer to vector z
+ *              - const polyveck *h: pointer to hint vector h
+ *              - const unsigned int number_of_hints: total
+ *                                   hints in *h
+ *
+ * Note that the number_of_hints argument is not present
+ * in the reference implementation. It is added here to ease
+ * proof of type safety.
+ **************************************************/
 void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
               const polyvecl *z, const polyveck *h,
               const unsigned int number_of_hints)
@@ -64,6 +103,15 @@ __contract__(
 );
 
 #define unpack_pk MLD_NAMESPACE(unpack_pk)
+/*************************************************
+ * Name:        unpack_pk
+ *
+ * Description: Unpack public key pk = (rho, t1).
+ *
+ * Arguments:   - const uint8_t rho[]: output byte array for rho
+ *              - const polyveck *t1: pointer to output vector t1
+ *              - uint8_t pk[]: byte array containing bit-packed pk
+ **************************************************/
 void unpack_pk(uint8_t rho[MLDSA_SEEDBYTES], polyveck *t1,
                const uint8_t pk[CRYPTO_PUBLICKEYBYTES])
 __contract__(
@@ -78,6 +126,19 @@ __contract__(
 
 
 #define unpack_sk MLD_NAMESPACE(unpack_sk)
+/*************************************************
+ * Name:        unpack_sk
+ *
+ * Description: Unpack secret key sk = (rho, tr, key, t0, s1, s2).
+ *
+ * Arguments:   - const uint8_t rho[]: output byte array for rho
+ *              - const uint8_t tr[]: output byte array for tr
+ *              - const uint8_t key[]: output byte array for key
+ *              - const polyveck *t0: pointer to output vector t0
+ *              - const polyvecl *s1: pointer to output vector s1
+ *              - const polyveck *s2: pointer to output vector s2
+ *              - uint8_t sk[]: byte array containing bit-packed sk
+ **************************************************/
 void unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
                uint8_t key[MLDSA_SEEDBYTES], polyveck *t0, polyvecl *s1,
                polyveck *s2, const uint8_t sk[CRYPTO_SECRETKEYBYTES])
@@ -104,6 +165,19 @@ __contract__(
 );
 
 #define unpack_sig MLD_NAMESPACE(unpack_sig)
+/*************************************************
+ * Name:        unpack_sig
+ *
+ * Description: Unpack signature sig = (c, z, h).
+ *
+ * Arguments:   - uint8_t *c: pointer to output challenge hash
+ *              - polyvecl *z: pointer to output vector z
+ *              - polyveck *h: pointer to output hint vector h
+ *              - const uint8_t sig[]: byte array containing
+ *                bit-packed signature
+ *
+ * Returns 1 in case of malformed signature; otherwise 0.
+ **************************************************/
 int unpack_sig(uint8_t c[MLDSA_CTILDEBYTES], polyvecl *z, polyveck *h,
                const uint8_t sig[CRYPTO_BYTES]);
 

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -10,14 +10,6 @@
 #include "rounding.h"
 #include "symmetric.h"
 
-/*************************************************
- * Name:        poly_reduce
- *
- * Description: Inplace reduction of all coefficients of polynomial to
- *              representative in [-6283008,6283008].
- *
- * Arguments:   - poly *a: pointer to input/output polynomial
- **************************************************/
 void poly_reduce(poly *a)
 {
   unsigned int i;
@@ -32,14 +24,6 @@ void poly_reduce(poly *a)
   }
 }
 
-/*************************************************
- * Name:        poly_caddq
- *
- * Description: For all coefficients of in/out polynomial add MLDSA_Q if
- *              coefficient is negative.
- *
- * Arguments:   - poly *a: pointer to input/output polynomial
- **************************************************/
 void poly_caddq(poly *a)
 {
   unsigned int i;
@@ -50,15 +34,6 @@ void poly_caddq(poly *a)
   }
 }
 
-/*************************************************
- * Name:        poly_add
- *
- * Description: Add polynomials. No modular reduction is performed.
- *
- * Arguments:   - poly *c: pointer to output polynomial
- *              - const poly *a: pointer to first summand
- *              - const poly *b: pointer to second summand
- **************************************************/
 void poly_add(poly *c, const poly *a, const poly *b)
 {
   unsigned int i;
@@ -72,17 +47,6 @@ void poly_add(poly *c, const poly *a, const poly *b)
   }
 }
 
-/*************************************************
- * Name:        poly_sub
- *
- * Description: Subtract polynomials. No modular reduction is
- *              performed.
- *
- * Arguments:   - poly *c: pointer to output polynomial
- *              - const poly *a: pointer to first input polynomial
- *              - const poly *b: pointer to second input polynomial to be
- *                               subtraced from first input polynomial
- **************************************************/
 void poly_sub(poly *c, const poly *a, const poly *b)
 {
   unsigned int i;
@@ -94,14 +58,6 @@ void poly_sub(poly *c, const poly *a, const poly *b)
   c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
 }
 
-/*************************************************
- * Name:        poly_shiftl
- *
- * Description: Multiply polynomial by 2^MLDSA_D without modular reduction.
- *Assumes input coefficients to be less than 2^{31-MLDSA_D} in absolute value.
- *
- * Arguments:   - poly *a: pointer to input/output polynomial
- **************************************************/
 void poly_shiftl(poly *a)
 {
   unsigned int i;
@@ -118,38 +74,10 @@ void poly_shiftl(poly *a)
   }
 }
 
-/*************************************************
- * Name:        poly_ntt
- *
- * Description: Inplace forward NTT. Coefficients can grow by
- *              8*MLDSA_Q in absolute value.
- *
- * Arguments:   - poly *a: pointer to input/output polynomial
- **************************************************/
 void poly_ntt(poly *a) { ntt(a->coeffs); }
 
-/*************************************************
- * Name:        poly_invntt_tomont
- *
- * Description: Inplace inverse NTT and multiplication by 2^{32}.
- *              Input coefficients need to be less than MLDSA_Q in absolute
- *              value and output coefficients are again bounded by MLDSA_Q.
- *
- * Arguments:   - poly *a: pointer to input/output polynomial
- **************************************************/
 void poly_invntt_tomont(poly *a) { invntt_tomont(a->coeffs); }
 
-/*************************************************
- * Name:        poly_pointwise_montgomery
- *
- * Description: Pointwise multiplication of polynomials in NTT domain
- *              representation and multiplication of resulting polynomial
- *              by 2^{-32}.
- *
- * Arguments:   - poly *c: pointer to output polynomial
- *              - const poly *a: pointer to first input polynomial
- *              - const poly *b: pointer to second input polynomial
- **************************************************/
 void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b)
 {
   unsigned int i;
@@ -160,18 +88,6 @@ void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b)
   }
 }
 
-/*************************************************
- * Name:        poly_power2round
- *
- * Description: For all coefficients c of the input polynomial,
- *              compute c0, c1 such that c mod MLDSA_Q = c1*2^MLDSA_D + c0
- *              with -2^{MLDSA_D-1} < c0 <= 2^{MLDSA_D-1}. Assumes coefficients
- *to be standard representatives.
- *
- * Arguments:   - poly *a1: pointer to output polynomial with coefficients c1
- *              - poly *a0: pointer to output polynomial with coefficients c0
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void poly_power2round(poly *a1, poly *a0, const poly *a)
 {
   unsigned int i;
@@ -182,19 +98,6 @@ void poly_power2round(poly *a1, poly *a0, const poly *a)
   }
 }
 
-/*************************************************
- * Name:        poly_decompose
- *
- * Description: For all coefficients c of the input polynomial,
- *              compute high and low bits c0, c1 such c mod MLDSA_Q = c1*ALPHA +
- *c0 with -ALPHA/2 < c0 <= ALPHA/2 except c1 = (MLDSA_Q-1)/ALPHA where we set c1
- *= 0 and -ALPHA/2 <= c0 = c mod MLDSA_Q - MLDSA_Q < 0. Assumes coefficients to
- *be standard representatives.
- *
- * Arguments:   - poly *a1: pointer to output polynomial with coefficients c1
- *              - poly *a0: pointer to output polynomial with coefficients c0
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void poly_decompose(poly *a1, poly *a0, const poly *a)
 {
   unsigned int i;
@@ -211,19 +114,6 @@ void poly_decompose(poly *a1, poly *a0, const poly *a)
   }
 }
 
-/*************************************************
- * Name:        poly_make_hint
- *
- * Description: Compute hint polynomial. The coefficients of which indicate
- *              whether the low bits of the corresponding coefficient of
- *              the input polynomial overflow into the high bits.
- *
- * Arguments:   - poly *h: pointer to output hint polynomial
- *              - const poly *a0: pointer to low part of input polynomial
- *              - const poly *a1: pointer to high part of input polynomial
- *
- * Returns number of 1 bits.
- **************************************************/
 unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1)
 {
   unsigned int i, s = 0;
@@ -242,15 +132,6 @@ unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1)
   return s;
 }
 
-/*************************************************
- * Name:        poly_use_hint
- *
- * Description: Use hint polynomial to correct the high bits of a polynomial.
- *
- * Arguments:   - poly *b: pointer to output polynomial with corrected high bits
- *              - const poly *a: pointer to input polynomial
- *              - const poly *h: pointer to input hint polynomial
- **************************************************/
 void poly_use_hint(poly *b, const poly *a, const poly *h)
 {
   unsigned int i;
@@ -265,18 +146,6 @@ void poly_use_hint(poly *b, const poly *a, const poly *h)
   }
 }
 
-/*************************************************
- * Name:        poly_chknorm
- *
- * Description: Check infinity norm of polynomial against given bound.
- *              Assumes input coefficients were reduced by reduce32().
- *
- * Arguments:   - const poly *a: pointer to polynomial
- *              - int32_t B: norm bound
- *
- * Returns 0 if norm is strictly smaller than B <= (MLDSA_Q-1)/8 and 1
- *otherwise.
- **************************************************/
 int poly_chknorm(const poly *a, int32_t B)
 {
   unsigned int i;
@@ -359,18 +228,6 @@ __contract__(
   return ctr;
 }
 
-/*************************************************
- * Name:        poly_uniform
- *
- * Description: Sample polynomial with uniformly random coefficients
- *              in [0,MLDSA_Q-1] by performing rejection sampling on the
- *              output stream of SHAKE128(seed|nonce)
- *
- * Arguments:   - poly *a: pointer to output polynomial
- *              - const uint8_t seed[]: byte array with seed of length
- *MLDSA_SEEDBYTES
- *              - uint16_t nonce: 2-byte nonce
- **************************************************/
 void poly_uniform(poly *a, const uint8_t seed[MLDSA_SEEDBYTES], uint16_t nonce)
 {
   unsigned int i, ctr, off;
@@ -473,18 +330,7 @@ __contract__(
   return ctr;
 }
 
-/*************************************************
- * Name:        poly_uniform_eta
- *
- * Description: Sample polynomial with uniformly random coefficients
- *              in [-MLDSA_ETA,MLDSA_ETA] by performing rejection sampling on
- *the output stream from SHAKE256(seed|nonce)
- *
- * Arguments:   - poly *a: pointer to output polynomial
- *              - const uint8_t seed[]: byte array with seed of length
- *MLDSA_CRHBYTES
- *              - uint16_t nonce: 2-byte nonce
- **************************************************/
+
 void poly_uniform_eta(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                       uint16_t nonce)
 {
@@ -505,18 +351,6 @@ void poly_uniform_eta(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
   }
 }
 
-/*************************************************
- * Name:        poly_uniform_gamma1m1
- *
- * Description: Sample polynomial with uniformly random coefficients
- *              in [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1] by unpacking output
- *stream of SHAKE256(seed|nonce)
- *
- * Arguments:   - poly *a: pointer to output polynomial
- *              - const uint8_t seed[]: byte array with seed of length
- *MLDSA_CRHBYTES
- *              - uint16_t nonce: 16-bit nonce
- **************************************************/
 #define POLY_UNIFORM_GAMMA1_NBLOCKS \
   ((MLDSA_POLYZ_PACKEDBYTES + STREAM256_BLOCKBYTES - 1) / STREAM256_BLOCKBYTES)
 void poly_uniform_gamma1(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
@@ -530,17 +364,6 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
   polyz_unpack(a, buf);
 }
 
-/*************************************************
- * Name:        challenge
- *
- * Description: Implementation of H. Samples polynomial with MLDSA_TAU nonzero
- *              coefficients in {-1,1} using the output stream of
- *              SHAKE256(seed).
- *
- * Arguments:   - poly *c: pointer to output polynomial
- *              - const uint8_t mu[]: byte array containing seed of length
- *MLDSA_CTILDEBYTES
- **************************************************/
 void poly_challenge(poly *c, const uint8_t seed[MLDSA_CTILDEBYTES])
 {
   unsigned int i, b, pos;
@@ -583,15 +406,6 @@ void poly_challenge(poly *c, const uint8_t seed[MLDSA_CTILDEBYTES])
   }
 }
 
-/*************************************************
- * Name:        polyeta_pack
- *
- * Description: Bit-pack polynomial with coefficients in [-MLDSA_ETA,MLDSA_ETA].
- *
- * Arguments:   - uint8_t *r: pointer to output byte array with at least
- *                            MLDSA_POLYETA_PACKEDBYTES bytes
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void polyeta_pack(uint8_t *r, const poly *a)
 {
   unsigned int i;
@@ -630,14 +444,6 @@ void polyeta_pack(uint8_t *r, const poly *a)
 #endif
 }
 
-/*************************************************
- * Name:        polyeta_unpack
- *
- * Description: Unpack polynomial with coefficients in [-MLDSA_ETA,MLDSA_ETA].
- *
- * Arguments:   - poly *r: pointer to output polynomial
- *              - const uint8_t *a: byte array with bit-packed polynomial
- **************************************************/
 void polyeta_unpack(poly *r, const uint8_t *a)
 {
   unsigned int i;
@@ -682,16 +488,6 @@ void polyeta_unpack(poly *r, const uint8_t *a)
 #endif
 }
 
-/*************************************************
- * Name:        polyt1_pack
- *
- * Description: Bit-pack polynomial t1 with coefficients fitting in 10 bits.
- *              Input coefficients are assumed to be standard representatives.
- *
- * Arguments:   - uint8_t *r: pointer to output byte array with at least
- *                            MLDSA_POLYT1_PACKEDBYTES bytes
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void polyt1_pack(uint8_t *r, const poly *a)
 {
   unsigned int i;
@@ -711,15 +507,6 @@ void polyt1_pack(uint8_t *r, const poly *a)
   }
 }
 
-/*************************************************
- * Name:        polyt1_unpack
- *
- * Description: Unpack polynomial t1 with 10-bit coefficients.
- *              Output coefficients are standard representatives.
- *
- * Arguments:   - poly *r: pointer to output polynomial
- *              - const uint8_t *a: byte array with bit-packed polynomial
- **************************************************/
 void polyt1_unpack(poly *r, const uint8_t *a)
 {
   unsigned int i;
@@ -740,16 +527,6 @@ void polyt1_unpack(poly *r, const uint8_t *a)
   }
 }
 
-/*************************************************
- * Name:        polyt0_pack
- *
- * Description: Bit-pack polynomial t0 with coefficients in ]-2^{MLDSA_D-1},
- *2^{MLDSA_D-1}].
- *
- * Arguments:   - uint8_t *r: pointer to output byte array with at least
- *                            MLDSA_POLYT0_PACKEDBYTES bytes
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void polyt0_pack(uint8_t *r, const poly *a)
 {
   unsigned int i;
@@ -791,15 +568,6 @@ void polyt0_pack(uint8_t *r, const poly *a)
   }
 }
 
-/*************************************************
- * Name:        polyt0_unpack
- *
- * Description: Unpack polynomial t0 with coefficients in ]-2^{MLDSA_D-1},
- *2^{MLDSA_D-1}].
- *
- * Arguments:   - poly *r: pointer to output polynomial
- *              - const uint8_t *a: byte array with bit-packed polynomial
- **************************************************/
 void polyt0_unpack(poly *r, const uint8_t *a)
 {
   unsigned int i;
@@ -856,16 +624,6 @@ void polyt0_unpack(poly *r, const uint8_t *a)
   }
 }
 
-/*************************************************
- * Name:        polyz_pack
- *
- * Description: Bit-pack polynomial with coefficients
- *              in [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1].
- *
- * Arguments:   - uint8_t *r: pointer to output byte array with at least
- *                            MLDSA_POLYZ_PACKEDBYTES bytes
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void polyz_pack(uint8_t *r, const poly *a)
 {
   unsigned int i;
@@ -914,15 +672,6 @@ void polyz_pack(uint8_t *r, const poly *a)
 #endif
 }
 
-/*************************************************
- * Name:        polyz_unpack
- *
- * Description: Unpack polynomial z with coefficients
- *              in [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1].
- *
- * Arguments:   - poly *r: pointer to output polynomial
- *              - const uint8_t *a: byte array with bit-packed polynomial
- **************************************************/
 void polyz_unpack(poly *r, const uint8_t *a)
 {
   unsigned int i;
@@ -983,16 +732,6 @@ void polyz_unpack(poly *r, const uint8_t *a)
 #endif
 }
 
-/*************************************************
- * Name:        polyw1_pack
- *
- * Description: Bit-pack polynomial w1 with coefficients in [0,15] or [0,43].
- *              Input coefficients are assumed to be standard representatives.
- *
- * Arguments:   - uint8_t *r: pointer to output byte array with at least
- *                            MLDSA_POLYW1_PACKEDBYTES bytes
- *              - const poly *a: pointer to input polynomial
- **************************************************/
 void polyw1_pack(uint8_t *r, const poly *a)
 {
   unsigned int i;

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -16,6 +16,14 @@ typedef struct
 } poly;
 
 #define poly_reduce MLD_NAMESPACE(poly_reduce)
+/*************************************************
+ * Name:        poly_reduce
+ *
+ * Description: Inplace reduction of all coefficients of polynomial to
+ *              representative in [-6283008,6283008].
+ *
+ * Arguments:   - poly *a: pointer to input/output polynomial
+ **************************************************/
 void poly_reduce(poly *a)
 __contract__(
   requires(memory_no_alias(a, sizeof(poly)))
@@ -25,9 +33,26 @@ __contract__(
 );
 
 #define poly_caddq MLD_NAMESPACE(poly_caddq)
+/*************************************************
+ * Name:        poly_caddq
+ *
+ * Description: For all coefficients of in/out polynomial add MLDSA_Q if
+ *              coefficient is negative.
+ *
+ * Arguments:   - poly *a: pointer to input/output polynomial
+ **************************************************/
 void poly_caddq(poly *a);
 
 #define poly_add MLD_NAMESPACE(poly_add)
+/*************************************************
+ * Name:        poly_add
+ *
+ * Description: Add polynomials. No modular reduction is performed.
+ *
+ * Arguments:   - poly *c: pointer to output polynomial
+ *              - const poly *a: pointer to first summand
+ *              - const poly *b: pointer to second summand
+ **************************************************/
 void poly_add(poly *c, const poly *a, const poly *b)
 __contract__(
   requires(memory_no_alias(c, sizeof(poly)))
@@ -40,6 +65,17 @@ __contract__(
 );
 
 #define poly_sub MLD_NAMESPACE(poly_sub)
+/*************************************************
+ * Name:        poly_sub
+ *
+ * Description: Subtract polynomials. No modular reduction is
+ *              performed.
+ *
+ * Arguments:   - poly *c: pointer to output polynomial
+ *              - const poly *a: pointer to first input polynomial
+ *              - const poly *b: pointer to second input polynomial to be
+ *                               subtraced from first input polynomial
+ **************************************************/
 void poly_sub(poly *c, const poly *a, const poly *b)
 __contract__(
   requires(memory_no_alias(c, sizeof(poly)))
@@ -51,6 +87,14 @@ __contract__(
   assigns(memory_slice(c, sizeof(poly))));
 
 #define poly_shiftl MLD_NAMESPACE(poly_shiftl)
+/*************************************************
+ * Name:        poly_shiftl
+ *
+ * Description: Multiply polynomial by 2^MLDSA_D without modular reduction.
+ *Assumes input coefficients to be less than 2^{31-MLDSA_D} in absolute value.
+ *
+ * Arguments:   - poly *a: pointer to input/output polynomial
+ **************************************************/
 void poly_shiftl(poly *a)
 __contract__(
   requires(memory_no_alias(a, sizeof(poly)))
@@ -59,16 +103,72 @@ __contract__(
 );
 
 #define poly_ntt MLD_NAMESPACE(poly_ntt)
+/*************************************************
+ * Name:        poly_ntt
+ *
+ * Description: Inplace forward NTT. Coefficients can grow by
+ *              8*MLDSA_Q in absolute value.
+ *
+ * Arguments:   - poly *a: pointer to input/output polynomial
+ **************************************************/
 void poly_ntt(poly *a);
+
 #define poly_invntt_tomont MLD_NAMESPACE(poly_invntt_tomont)
+/*************************************************
+ * Name:        poly_invntt_tomont
+ *
+ * Description: Inplace inverse NTT and multiplication by 2^{32}.
+ *              Input coefficients need to be less than MLDSA_Q in absolute
+ *              value and output coefficients are again bounded by MLDSA_Q.
+ *
+ * Arguments:   - poly *a: pointer to input/output polynomial
+ **************************************************/
 void poly_invntt_tomont(poly *a);
+
 #define poly_pointwise_montgomery MLD_NAMESPACE(poly_pointwise_montgomery)
+/*************************************************
+ * Name:        poly_pointwise_montgomery
+ *
+ * Description: Pointwise multiplication of polynomials in NTT domain
+ *              representation and multiplication of resulting polynomial
+ *              by 2^{-32}.
+ *
+ * Arguments:   - poly *c: pointer to output polynomial
+ *              - const poly *a: pointer to first input polynomial
+ *              - const poly *b: pointer to second input polynomial
+ **************************************************/
 void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b);
 
 #define poly_power2round MLD_NAMESPACE(poly_power2round)
+/*************************************************
+ * Name:        poly_power2round
+ *
+ * Description: For all coefficients c of the input polynomial,
+ *              compute c0, c1 such that c mod MLDSA_Q = c1*2^MLDSA_D + c0
+ *              with -2^{MLDSA_D-1} < c0 <= 2^{MLDSA_D-1}. Assumes coefficients
+ *to be standard representatives.
+ *
+ * Arguments:   - poly *a1: pointer to output polynomial with coefficients c1
+ *              - poly *a0: pointer to output polynomial with coefficients c0
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void poly_power2round(poly *a1, poly *a0, const poly *a);
 
 #define poly_decompose MLD_NAMESPACE(poly_decompose)
+/*************************************************
+ * Name:        poly_decompose
+ *
+ * Description: For all coefficients c of the input polynomial,
+ *              compute high and low bits c0, c1 such c mod MLDSA_Q = c1*ALPHA +
+ *              c0 with -ALPHA/2 < c0 <= ALPHA/2 except
+ *              c1 = (MLDSA_Q-1)/ALPHA where we set
+ *              c1 = 0 and -ALPHA/2 <= c0 = c mod MLDSA_Q - MLDSA_Q < 0.
+ *              Assumes coefficients to be standard representatives.
+ *
+ * Arguments:   - poly *a1: pointer to output polynomial with coefficients c1
+ *              - poly *a0: pointer to output polynomial with coefficients c0
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void poly_decompose(poly *a1, poly *a0, const poly *a)
 __contract__(
   requires(memory_no_alias(a1,  sizeof(poly)))
@@ -82,6 +182,19 @@ __contract__(
 );
 
 #define poly_make_hint MLD_NAMESPACE(poly_make_hint)
+/*************************************************
+ * Name:        poly_make_hint
+ *
+ * Description: Compute hint polynomial. The coefficients of which indicate
+ *              whether the low bits of the corresponding coefficient of
+ *              the input polynomial overflow into the high bits.
+ *
+ * Arguments:   - poly *h: pointer to output hint polynomial
+ *              - const poly *a0: pointer to low part of input polynomial
+ *              - const poly *a1: pointer to high part of input polynomial
+ *
+ * Returns number of 1 bits.
+ **************************************************/
 unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1)
 __contract__(
   requires(memory_no_alias(h,  sizeof(poly)))
@@ -92,6 +205,15 @@ __contract__(
 );
 
 #define poly_use_hint MLD_NAMESPACE(poly_use_hint)
+/*************************************************
+ * Name:        poly_use_hint
+ *
+ * Description: Use hint polynomial to correct the high bits of a polynomial.
+ *
+ * Arguments:   - poly *b: pointer to output polynomial with corrected high bits
+ *              - const poly *a: pointer to input polynomial
+ *              - const poly *h: pointer to input hint polynomial
+ **************************************************/
 void poly_use_hint(poly *b, const poly *a, const poly *h)
 __contract__(
   requires(memory_no_alias(a,  sizeof(poly)))
@@ -104,23 +226,91 @@ __contract__(
 );
 
 #define poly_chknorm MLD_NAMESPACE(poly_chknorm)
+/*************************************************
+ * Name:        poly_chknorm
+ *
+ * Description: Check infinity norm of polynomial against given bound.
+ *              Assumes input coefficients were reduced by reduce32().
+ *
+ * Arguments:   - const poly *a: pointer to polynomial
+ *              - int32_t B: norm bound
+ *
+ * Returns 0 if norm is strictly smaller than B <= (MLDSA_Q-1)/8 and 1
+ *otherwise.
+ **************************************************/
 int poly_chknorm(const poly *a, int32_t B);
 
 #define poly_uniform MLD_NAMESPACE(poly_uniform)
+/*************************************************
+ * Name:        poly_uniform
+ *
+ * Description: Sample polynomial with uniformly random coefficients
+ *              in [0,MLDSA_Q-1] by performing rejection sampling on the
+ *              output stream of SHAKE128(seed|nonce)
+ *
+ * Arguments:   - poly *a: pointer to output polynomial
+ *              - const uint8_t seed[]: byte array with seed of length
+ *                MLDSA_SEEDBYTES
+ *              - uint16_t nonce: 2-byte nonce
+ **************************************************/
 void poly_uniform(poly *a, const uint8_t seed[MLDSA_SEEDBYTES], uint16_t nonce);
 
 #define poly_uniform_eta MLD_NAMESPACE(poly_uniform_eta)
+/*************************************************
+ * Name:        poly_uniform_eta
+ *
+ * Description: Sample polynomial with uniformly random coefficients
+ *              in [-MLDSA_ETA,MLDSA_ETA] by performing rejection sampling on
+ *              the output stream from SHAKE256(seed|nonce)
+ *
+ * Arguments:   - poly *a: pointer to output polynomial
+ *              - const uint8_t seed[]: byte array with seed of length
+ *                MLDSA_CRHBYTES
+ *              - uint16_t nonce: 2-byte nonce
+ **************************************************/
 void poly_uniform_eta(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                       uint16_t nonce);
 
 #define poly_uniform_gamma1 MLD_NAMESPACE(poly_uniform_gamma1)
+/*************************************************
+ * Name:        poly_uniform_gamma1m1
+ *
+ * Description: Sample polynomial with uniformly random coefficients
+ *              in [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1] by unpacking output
+ *              stream of SHAKE256(seed|nonce)
+ *
+ * Arguments:   - poly *a: pointer to output polynomial
+ *              - const uint8_t seed[]: byte array with seed of length
+ *                MLDSA_CRHBYTES
+ *              - uint16_t nonce: 16-bit nonce
+ **************************************************/
 void poly_uniform_gamma1(poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                          uint16_t nonce);
 
 #define poly_challenge MLD_NAMESPACE(poly_challenge)
+/*************************************************
+ * Name:        poly_challenge
+ *
+ * Description: Implementation of H. Samples polynomial with MLDSA_TAU nonzero
+ *              coefficients in {-1,1} using the output stream of
+ *              SHAKE256(seed).
+ *
+ * Arguments:   - poly *c: pointer to output polynomial
+ *              - const uint8_t mu[]: byte array containing seed of length
+ *                MLDSA_CTILDEBYTES
+ **************************************************/
 void poly_challenge(poly *c, const uint8_t seed[MLDSA_CTILDEBYTES]);
 
 #define polyeta_pack MLD_NAMESPACE(polyeta_pack)
+/*************************************************
+ * Name:        polyeta_pack
+ *
+ * Description: Bit-pack polynomial with coefficients in [-MLDSA_ETA,MLDSA_ETA].
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array with at least
+ *                            MLDSA_POLYETA_PACKEDBYTES bytes
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void polyeta_pack(uint8_t *r, const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLDSA_POLYETA_PACKEDBYTES))
@@ -146,6 +336,14 @@ __contract__(
 #endif
 
 #define polyeta_unpack MLD_NAMESPACE(polyeta_unpack)
+/*************************************************
+ * Name:        polyeta_unpack
+ *
+ * Description: Unpack polynomial with coefficients in [-MLDSA_ETA,MLDSA_ETA].
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *a: byte array with bit-packed polynomial
+ **************************************************/
 void polyeta_unpack(poly *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -155,6 +353,16 @@ __contract__(
 );
 
 #define polyt1_pack MLD_NAMESPACE(polyt1_pack)
+/*************************************************
+ * Name:        polyt1_pack
+ *
+ * Description: Bit-pack polynomial t1 with coefficients fitting in 10 bits.
+ *              Input coefficients are assumed to be standard representatives.
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array with at least
+ *                            MLDSA_POLYT1_PACKEDBYTES bytes
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void polyt1_pack(uint8_t *r, const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLDSA_POLYT1_PACKEDBYTES))
@@ -164,6 +372,15 @@ __contract__(
 );
 
 #define polyt1_unpack MLD_NAMESPACE(polyt1_unpack)
+/*************************************************
+ * Name:        polyt1_unpack
+ *
+ * Description: Unpack polynomial t1 with 10-bit coefficients.
+ *              Output coefficients are standard representatives.
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *a: byte array with bit-packed polynomial
+ **************************************************/
 void polyt1_unpack(poly *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -173,6 +390,16 @@ __contract__(
 );
 
 #define polyt0_pack MLD_NAMESPACE(polyt0_pack)
+/*************************************************
+ * Name:        polyt0_pack
+ *
+ * Description: Bit-pack polynomial t0 with coefficients in ]-2^{MLDSA_D-1},
+ *              2^{MLDSA_D-1}].
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array with at least
+ *                            MLDSA_POLYT0_PACKEDBYTES bytes
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void polyt0_pack(uint8_t *r, const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLDSA_POLYT0_PACKEDBYTES))
@@ -183,6 +410,15 @@ __contract__(
 
 
 #define polyt0_unpack MLD_NAMESPACE(polyt0_unpack)
+/*************************************************
+ * Name:        polyt0_unpack
+ *
+ * Description: Unpack polynomial t0 with coefficients in ]-2^{MLDSA_D-1},
+ *2^{MLDSA_D-1}].
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *a: byte array with bit-packed polynomial
+ **************************************************/
 void polyt0_unpack(poly *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -192,6 +428,16 @@ __contract__(
 );
 
 #define polyz_pack MLD_NAMESPACE(polyz_pack)
+/*************************************************
+ * Name:        polyz_pack
+ *
+ * Description: Bit-pack polynomial with coefficients
+ *              in [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1].
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array with at least
+ *                            MLDSA_POLYZ_PACKEDBYTES bytes
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void polyz_pack(uint8_t *r, const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLDSA_POLYZ_PACKEDBYTES))
@@ -201,6 +447,15 @@ __contract__(
 );
 
 #define polyz_unpack MLD_NAMESPACE(polyz_unpack)
+/*************************************************
+ * Name:        polyz_unpack
+ *
+ * Description: Unpack polynomial z with coefficients
+ *              in [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1].
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *a: byte array with bit-packed polynomial
+ **************************************************/
 void polyz_unpack(poly *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -211,6 +466,16 @@ __contract__(
 
 
 #define polyw1_pack MLD_NAMESPACE(polyw1_pack)
+/*************************************************
+ * Name:        polyw1_pack
+ *
+ * Description: Bit-pack polynomial w1 with coefficients in [0,15] or [0,43].
+ *              Input coefficients are assumed to be standard representatives.
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array with at least
+ *                            MLDSA_POLYW1_PACKEDBYTES bytes
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
 void polyw1_pack(uint8_t *r, const poly *a)
 #if MLDSA_GAMMA2 == (MLDSA_Q - 1) / 32
 __contract__(

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -7,16 +7,6 @@
 #include "params.h"
 #include "poly.h"
 
-/*************************************************
- * Name:        expand_mat
- *
- * Description: Implementation of ExpandA. Generates matrix A with uniformly
- *              random coefficients a_{i,j} by performing rejection
- *              sampling on the output stream of SHAKE128(rho|j|i)
- *
- * Arguments:   - polyvecl mat[MLDSA_K]: output matrix
- *              - const uint8_t rho[]: byte array containing seed rho
- **************************************************/
 void polyvec_matrix_expand(polyvecl mat[MLDSA_K],
                            const uint8_t rho[MLDSA_SEEDBYTES])
 {
@@ -79,16 +69,6 @@ void polyvecl_reduce(polyvecl *v)
   }
 }
 
-/*************************************************
- * Name:        polyvecl_add
- *
- * Description: Add vectors of polynomials of length MLDSA_L.
- *              No modular reduction is performed.
- *
- * Arguments:   - polyvecl *w: pointer to output vector
- *              - const polyvecl *u: pointer to first summand
- *              - const polyvecl *v: pointer to second summand
- **************************************************/
 void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v)
 {
   unsigned int i;
@@ -99,14 +79,6 @@ void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v)
   }
 }
 
-/*************************************************
- * Name:        polyvecl_ntt
- *
- * Description: Forward NTT of all polynomials in vector of length MLDSA_L.
- *Output coefficients can be up to 16*MLDSA_Q larger than input coefficients.
- *
- * Arguments:   - polyvecl *v: pointer to input/output vector
- **************************************************/
 void polyvecl_ntt(polyvecl *v)
 {
   unsigned int i;
@@ -138,17 +110,6 @@ void polyvecl_pointwise_poly_montgomery(polyvecl *r, const poly *a,
   }
 }
 
-/*************************************************
- * Name:        polyvecl_pointwise_acc_montgomery
- *
- * Description: Pointwise multiply vectors of polynomials of length MLDSA_L,
- *multiply resulting vector by 2^{-32} and add (accumulate) polynomials in it.
- *Input/output vectors are in NTT domain representation.
- *
- * Arguments:   - poly *w: output polynomial
- *              - const polyvecl *u: pointer to first input vector
- *              - const polyvecl *v: pointer to second input vector
- **************************************************/
 void polyvecl_pointwise_acc_montgomery(poly *w, const polyvecl *u,
                                        const polyvecl *v)
 {
@@ -163,18 +124,7 @@ void polyvecl_pointwise_acc_montgomery(poly *w, const polyvecl *u,
   }
 }
 
-/*************************************************
- * Name:        polyvecl_chknorm
- *
- * Description: Check infinity norm of polynomials in vector of length MLDSA_L.
- *              Assumes input polyvecl to be reduced by polyvecl_reduce().
- *
- * Arguments:   - const polyvecl *v: pointer to vector
- *              - int32_t B: norm bound
- *
- * Returns 0 if norm of all polynomials is strictly smaller than B <=
- *(MLDSA_Q-1)/8 and 1 otherwise.
- **************************************************/
+
 int polyvecl_chknorm(const polyvecl *v, int32_t bound)
 {
   unsigned int i;
@@ -205,14 +155,6 @@ void polyveck_uniform_eta(polyveck *v, const uint8_t seed[MLDSA_CRHBYTES],
   }
 }
 
-/*************************************************
- * Name:        polyveck_reduce
- *
- * Description: Reduce coefficients of polynomials in vector of length MLDSA_K
- *              to representatives in [-6283008,6283008].
- *
- * Arguments:   - polyveck *v: pointer to input/output vector
- **************************************************/
 void polyveck_reduce(polyveck *v)
 {
   unsigned int i;
@@ -223,14 +165,6 @@ void polyveck_reduce(polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_caddq
- *
- * Description: For all coefficients of polynomials in vector of length MLDSA_K
- *              add MLDSA_Q if coefficient is negative.
- *
- * Arguments:   - polyveck *v: pointer to input/output vector
- **************************************************/
 void polyveck_caddq(polyveck *v)
 {
   unsigned int i;
@@ -241,16 +175,6 @@ void polyveck_caddq(polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_add
- *
- * Description: Add vectors of polynomials of length MLDSA_K.
- *              No modular reduction is performed.
- *
- * Arguments:   - polyveck *w: pointer to output vector
- *              - const polyveck *u: pointer to first summand
- *              - const polyveck *v: pointer to second summand
- **************************************************/
 void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v)
 {
   unsigned int i;
@@ -261,17 +185,6 @@ void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_sub
- *
- * Description: Subtract vectors of polynomials of length MLDSA_K.
- *              No modular reduction is performed.
- *
- * Arguments:   - polyveck *w: pointer to output vector
- *              - const polyveck *u: pointer to first input vector
- *              - const polyveck *v: pointer to second input vector to be
- *                                   subtracted from first input vector
- **************************************************/
 void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v)
 {
   unsigned int i;
@@ -282,15 +195,6 @@ void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_shiftl
- *
- * Description: Multiply vector of polynomials of Length MLDSA_K by 2^MLDSA_D
- *without modular reduction. Assumes input coefficients to be less than
- *2^{31-MLDSA_D}.
- *
- * Arguments:   - polyveck *v: pointer to input/output vector
- **************************************************/
 void polyveck_shiftl(polyveck *v)
 {
   unsigned int i;
@@ -301,14 +205,6 @@ void polyveck_shiftl(polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_ntt
- *
- * Description: Forward NTT of all polynomials in vector of length MLDSA_K.
- *Output coefficients can be up to 16*MLDSA_Q larger than input coefficients.
- *
- * Arguments:   - polyveck *v: pointer to input/output vector
- **************************************************/
 void polyveck_ntt(polyveck *v)
 {
   unsigned int i;
@@ -319,15 +215,6 @@ void polyveck_ntt(polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_invntt_tomont
- *
- * Description: Inverse NTT and multiplication by 2^{32} of polynomials
- *              in vector of length MLDSA_K. Input coefficients need to be less
- *              than 2*MLDSA_Q.
- *
- * Arguments:   - polyveck *v: pointer to input/output vector
- **************************************************/
 void polyveck_invntt_tomont(polyveck *v)
 {
   unsigned int i;
@@ -350,18 +237,6 @@ void polyveck_pointwise_poly_montgomery(polyveck *r, const poly *a,
 }
 
 
-/*************************************************
- * Name:        polyveck_chknorm
- *
- * Description: Check infinity norm of polynomials in vector of length MLDSA_K.
- *              Assumes input polyveck to be reduced by polyveck_reduce().
- *
- * Arguments:   - const polyveck *v: pointer to vector
- *              - int32_t B: norm bound
- *
- * Returns 0 if norm of all polynomials are strictly smaller than B <=
- *(MLDSA_Q-1)/8 and 1 otherwise.
- **************************************************/
 int polyveck_chknorm(const polyveck *v, int32_t bound)
 {
   unsigned int i;
@@ -377,20 +252,6 @@ int polyveck_chknorm(const polyveck *v, int32_t bound)
   return 0;
 }
 
-/*************************************************
- * Name:        polyveck_power2round
- *
- * Description: For all coefficients a of polynomials in vector of length
- *MLDSA_K, compute a0, a1 such that a mod^+ MLDSA_Q = a1*2^MLDSA_D + a0 with
- *-2^{MLDSA_D-1} < a0 <= 2^{MLDSA_D-1}. Assumes coefficients to be standard
- *representatives.
- *
- * Arguments:   - polyveck *v1: pointer to output vector of polynomials with
- *                              coefficients a1
- *              - polyveck *v0: pointer to output vector of polynomials with
- *                              coefficients a0
- *              - const polyveck *v: pointer to input vector
- **************************************************/
 void polyveck_power2round(polyveck *v1, polyveck *v0, const polyveck *v)
 {
   unsigned int i;
@@ -401,21 +262,6 @@ void polyveck_power2round(polyveck *v1, polyveck *v0, const polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_decompose
- *
- * Description: For all coefficients a of polynomials in vector of length
- *MLDSA_K, compute high and low bits a0, a1 such a mod^+ MLDSA_Q = a1*ALPHA
- *+ a0 with -ALPHA/2 < a0 <= ALPHA/2 except a1 = (MLDSA_Q-1)/ALPHA where we set
- *a1 = 0 and -ALPHA/2 <= a0 = a mod MLDSA_Q - MLDSA_Q < 0. Assumes coefficients
- *to be standard representatives.
- *
- * Arguments:   - polyveck *v1: pointer to output vector of polynomials with
- *                              coefficients a1
- *              - polyveck *v0: pointer to output vector of polynomials with
- *                              coefficients a0
- *              - const polyveck *v: pointer to input vector
- **************************************************/
 void polyveck_decompose(polyveck *v1, polyveck *v0, const polyveck *v)
 {
   unsigned int i;
@@ -426,17 +272,6 @@ void polyveck_decompose(polyveck *v1, polyveck *v0, const polyveck *v)
   }
 }
 
-/*************************************************
- * Name:        polyveck_make_hint
- *
- * Description: Compute hint vector.
- *
- * Arguments:   - polyveck *h: pointer to output vector
- *              - const polyveck *v0: pointer to low part of input vector
- *              - const polyveck *v1: pointer to high part of input vector
- *
- * Returns number of 1 bits.
- **************************************************/
 unsigned int polyveck_make_hint(polyveck *h, const polyveck *v0,
                                 const polyveck *v1)
 {
@@ -455,16 +290,6 @@ unsigned int polyveck_make_hint(polyveck *h, const polyveck *v0,
   return s;
 }
 
-/*************************************************
- * Name:        polyveck_use_hint
- *
- * Description: Use hint vector to correct the high bits of input vector.
- *
- * Arguments:   - polyveck *w: pointer to output vector of polynomials with
- *                             corrected high bits
- *              - const polyveck *u: pointer to input vector
- *              - const polyveck *h: pointer to input hint vector
- **************************************************/
 void polyveck_use_hint(polyveck *w, const polyveck *u, const polyveck *h)
 {
   unsigned int i;

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -28,9 +28,27 @@ void polyvecl_uniform_gamma1(polyvecl *v, const uint8_t seed[MLDSA_CRHBYTES],
 void polyvecl_reduce(polyvecl *v);
 
 #define polyvecl_add MLD_NAMESPACE(polyvecl_add)
+/*************************************************
+ * Name:        polyvecl_add
+ *
+ * Description: Add vectors of polynomials of length MLDSA_L.
+ *              No modular reduction is performed.
+ *
+ * Arguments:   - polyvecl *w: pointer to output vector
+ *              - const polyvecl *u: pointer to first summand
+ *              - const polyvecl *v: pointer to second summand
+ **************************************************/
 void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 #define polyvecl_ntt MLD_NAMESPACE(polyvecl_ntt)
+/*************************************************
+ * Name:        polyvecl_ntt
+ *
+ * Description: Forward NTT of all polynomials in vector of length MLDSA_L.
+ *Output coefficients can be up to 16*MLDSA_Q larger than input coefficients.
+ *
+ * Arguments:   - polyvecl *v: pointer to input/output vector
+ **************************************************/
 void polyvecl_ntt(polyvecl *v);
 #define polyvecl_invntt_tomont MLD_NAMESPACE(polyvecl_invntt_tomont)
 void polyvecl_invntt_tomont(polyvecl *v);
@@ -40,11 +58,34 @@ void polyvecl_pointwise_poly_montgomery(polyvecl *r, const poly *a,
                                         const polyvecl *v);
 #define polyvecl_pointwise_acc_montgomery \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery)
+/*************************************************
+ * Name:        polyvecl_pointwise_acc_montgomery
+ *
+ * Description: Pointwise multiply vectors of polynomials of length MLDSA_L,
+ *multiply resulting vector by 2^{-32} and add (accumulate) polynomials in it.
+ *Input/output vectors are in NTT domain representation.
+ *
+ * Arguments:   - poly *w: output polynomial
+ *              - const polyvecl *u: pointer to first input vector
+ *              - const polyvecl *v: pointer to second input vector
+ **************************************************/
 void polyvecl_pointwise_acc_montgomery(poly *w, const polyvecl *u,
                                        const polyvecl *v);
 
 
 #define polyvecl_chknorm MLD_NAMESPACE(polyvecl_chknorm)
+/*************************************************
+ * Name:        polyvecl_chknorm
+ *
+ * Description: Check infinity norm of polynomials in vector of length MLDSA_L.
+ *              Assumes input polyvecl to be reduced by polyvecl_reduce().
+ *
+ * Arguments:   - const polyvecl *v: pointer to vector
+ *              - int32_t B: norm bound
+ *
+ * Returns 0 if norm of all polynomials is strictly smaller than B <=
+ *(MLDSA_Q-1)/8 and 1 otherwise.
+ **************************************************/
 int polyvecl_chknorm(const polyvecl *v, int32_t B);
 
 
@@ -60,20 +101,83 @@ void polyveck_uniform_eta(polyveck *v, const uint8_t seed[MLDSA_CRHBYTES],
                           uint16_t nonce);
 
 #define polyveck_reduce MLD_NAMESPACE(polyveck_reduce)
+/*************************************************
+ * Name:        polyveck_reduce
+ *
+ * Description: Reduce coefficients of polynomials in vector of length MLDSA_K
+ *              to representatives in [-6283008,6283008].
+ *
+ * Arguments:   - polyveck *v: pointer to input/output vector
+ **************************************************/
 void polyveck_reduce(polyveck *v);
 #define polyveck_caddq MLD_NAMESPACE(polyveck_caddq)
+/*************************************************
+ * Name:        polyveck_caddq
+ *
+ * Description: For all coefficients of polynomials in vector of length MLDSA_K
+ *              add MLDSA_Q if coefficient is negative.
+ *
+ * Arguments:   - polyveck *v: pointer to input/output vector
+ **************************************************/
 void polyveck_caddq(polyveck *v);
 
 #define polyveck_add MLD_NAMESPACE(polyveck_add)
+/*************************************************
+ * Name:        polyveck_add
+ *
+ * Description: Add vectors of polynomials of length MLDSA_K.
+ *              No modular reduction is performed.
+ *
+ * Arguments:   - polyveck *w: pointer to output vector
+ *              - const polyveck *u: pointer to first summand
+ *              - const polyveck *v: pointer to second summand
+ **************************************************/
 void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
+/*************************************************
+ * Name:        polyveck_sub
+ *
+ * Description: Subtract vectors of polynomials of length MLDSA_K.
+ *              No modular reduction is performed.
+ *
+ * Arguments:   - polyveck *w: pointer to output vector
+ *              - const polyveck *u: pointer to first input vector
+ *              - const polyveck *v: pointer to second input vector to be
+ *                                   subtracted from first input vector
+ **************************************************/
 #define polyveck_sub MLD_NAMESPACE(polyveck_sub)
 void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);
 #define polyveck_shiftl MLD_NAMESPACE(polyveck_shiftl)
+/*************************************************
+ * Name:        polyveck_shiftl
+ *
+ * Description: Multiply vector of polynomials of Length MLDSA_K by 2^MLDSA_D
+ *without modular reduction. Assumes input coefficients to be less than
+ *2^{31-MLDSA_D}.
+ *
+ * Arguments:   - polyveck *v: pointer to input/output vector
+ **************************************************/
 void polyveck_shiftl(polyveck *v);
 
 #define polyveck_ntt MLD_NAMESPACE(polyveck_ntt)
+/*************************************************
+ * Name:        polyveck_ntt
+ *
+ * Description: Forward NTT of all polynomials in vector of length MLDSA_K.
+ *Output coefficients can be up to 16*MLDSA_Q larger than input coefficients.
+ *
+ * Arguments:   - polyveck *v: pointer to input/output vector
+ **************************************************/
 void polyveck_ntt(polyveck *v);
 #define polyveck_invntt_tomont MLD_NAMESPACE(polyveck_invntt_tomont)
+/*************************************************
+ * Name:        polyveck_invntt_tomont
+ *
+ * Description: Inverse NTT and multiplication by 2^{32} of polynomials
+ *              in vector of length MLDSA_K. Input coefficients need to be less
+ *              than 2*MLDSA_Q.
+ *
+ * Arguments:   - polyveck *v: pointer to input/output vector
+ **************************************************/
 void polyveck_invntt_tomont(polyveck *v);
 #define polyveck_pointwise_poly_montgomery \
   MLD_NAMESPACE(polyveck_pointwise_poly_montgomery)
@@ -81,15 +185,67 @@ void polyveck_pointwise_poly_montgomery(polyveck *r, const poly *a,
                                         const polyveck *v);
 
 #define polyveck_chknorm MLD_NAMESPACE(polyveck_chknorm)
+/*************************************************
+ * Name:        polyveck_chknorm
+ *
+ * Description: Check infinity norm of polynomials in vector of length MLDSA_K.
+ *              Assumes input polyveck to be reduced by polyveck_reduce().
+ *
+ * Arguments:   - const polyveck *v: pointer to vector
+ *              - int32_t B: norm bound
+ *
+ * Returns 0 if norm of all polynomials are strictly smaller than B <=
+ *(MLDSA_Q-1)/8 and 1 otherwise.
+ **************************************************/
 int polyveck_chknorm(const polyveck *v, int32_t B);
 
 #define polyveck_power2round MLD_NAMESPACE(polyveck_power2round)
+/*************************************************
+ * Name:        polyveck_power2round
+ *
+ * Description: For all coefficients a of polynomials in vector of length
+ *MLDSA_K, compute a0, a1 such that a mod^+ MLDSA_Q = a1*2^MLDSA_D + a0 with
+ *-2^{MLDSA_D-1} < a0 <= 2^{MLDSA_D-1}. Assumes coefficients to be standard
+ *representatives.
+ *
+ * Arguments:   - polyveck *v1: pointer to output vector of polynomials with
+ *                              coefficients a1
+ *              - polyveck *v0: pointer to output vector of polynomials with
+ *                              coefficients a0
+ *              - const polyveck *v: pointer to input vector
+ **************************************************/
 void polyveck_power2round(polyveck *v1, polyveck *v0, const polyveck *v);
 #define polyveck_decompose MLD_NAMESPACE(polyveck_decompose)
+/*************************************************
+ * Name:        polyveck_decompose
+ *
+ * Description: For all coefficients a of polynomials in vector of length
+ *MLDSA_K, compute high and low bits a0, a1 such a mod^+ MLDSA_Q = a1*ALPHA
+ *+ a0 with -ALPHA/2 < a0 <= ALPHA/2 except a1 = (MLDSA_Q-1)/ALPHA where we set
+ *a1 = 0 and -ALPHA/2 <= a0 = a mod MLDSA_Q - MLDSA_Q < 0. Assumes coefficients
+ *to be standard representatives.
+ *
+ * Arguments:   - polyveck *v1: pointer to output vector of polynomials with
+ *                              coefficients a1
+ *              - polyveck *v0: pointer to output vector of polynomials with
+ *                              coefficients a0
+ *              - const polyveck *v: pointer to input vector
+ **************************************************/
 void polyveck_decompose(polyveck *v1, polyveck *v0, const polyveck *v);
 
 
 #define polyveck_make_hint MLD_NAMESPACE(polyveck_make_hint)
+/*************************************************
+ * Name:        polyveck_make_hint
+ *
+ * Description: Compute hint vector.
+ *
+ * Arguments:   - polyveck *h: pointer to output vector
+ *              - const polyveck *v0: pointer to low part of input vector
+ *              - const polyveck *v1: pointer to high part of input vector
+ *
+ * Returns number of 1 bits.
+ **************************************************/
 unsigned int polyveck_make_hint(polyveck *h, const polyveck *v0,
                                 const polyveck *v1)
 __contract__(
@@ -101,6 +257,16 @@ __contract__(
 );
 
 #define polyveck_use_hint MLD_NAMESPACE(polyveck_use_hint)
+/*************************************************
+ * Name:        polyveck_use_hint
+ *
+ * Description: Use hint vector to correct the high bits of input vector.
+ *
+ * Arguments:   - polyveck *w: pointer to output vector of polynomials with
+ *                             corrected high bits
+ *              - const polyveck *u: pointer to input vector
+ *              - const polyveck *h: pointer to input hint vector
+ **************************************************/
 void polyveck_use_hint(polyveck *w, const polyveck *v, const polyveck *h);
 
 #define polyveck_pack_w1 MLD_NAMESPACE(polyveck_pack_w1)
@@ -185,6 +351,16 @@ __contract__(
 );
 
 #define polyvec_matrix_expand MLD_NAMESPACE(polyvec_matrix_expand)
+/*************************************************
+ * Name:        polyvec_matrix_expand
+ *
+ * Description: Implementation of ExpandA. Generates matrix A with uniformly
+ *              random coefficients a_{i,j} by performing rejection
+ *              sampling on the output stream of SHAKE128(rho|j|i)
+ *
+ * Arguments:   - polyvecl mat[MLDSA_K]: output matrix
+ *              - const uint8_t rho[]: byte array containing seed rho
+ **************************************************/
 void polyvec_matrix_expand(polyvecl mat[MLDSA_K],
                            const uint8_t rho[MLDSA_SEEDBYTES]);
 

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -14,21 +14,6 @@
 #include "randombytes.h"
 #include "symmetric.h"
 
-/*************************************************
- * Name:        crypto_sign_keypair_internal
- *
- * Description: FIPS 204: Algorithm 6 ML-DSA.KeyGen_internal.
- *              Generates public and private key. Internal API.
- *
- * Arguments:   - uint8_t *pk:   pointer to output public key (allocated
- *                               array of CRYPTO_PUBLICKEYBYTES bytes)
- *              - uint8_t *sk:   pointer to output private key (allocated
- *                               array of CRYPTO_SECRETKEYBYTES bytes)
- *              - uint8_t *seed: pointer to input random seed (MLDSA_SEEDBYTES
- *bytes)
- *
- * Returns 0 (success)
- **************************************************/
 int crypto_sign_keypair_internal(uint8_t *pk, uint8_t *sk,
                                  const uint8_t seed[MLDSA_SEEDBYTES])
 {
@@ -77,19 +62,6 @@ int crypto_sign_keypair_internal(uint8_t *pk, uint8_t *sk,
   return 0;
 }
 
-/*************************************************
- * Name:        crypto_sign_keypair
- *
- * Description: FIPS 204: Algorithm 1 ML-DSA.KeyGen
- *              Generates public and private key.
- *
- * Arguments:   - uint8_t *pk:   pointer to output public key (allocated
- *                               array of CRYPTO_PUBLICKEYBYTES bytes)
- *              - uint8_t *sk:   pointer to output private key (allocated
- *                               array of CRYPTO_SECRETKEYBYTES bytes)
- *
- * Returns 0 (success)
- **************************************************/
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk)
 {
   uint8_t seed[MLDSA_SEEDBYTES];
@@ -97,24 +69,6 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk)
   return crypto_sign_keypair_internal(pk, sk, seed);
 }
 
-/*************************************************
- * Name:        crypto_sign_signature_internal
- *
- * Description: Computes signature. Internal API.
- *
- * Arguments:   - uint8_t *sig:   pointer to output signature (of length
- *CRYPTO_BYTES)
- *              - size_t *siglen: pointer to output length of signature
- *              - uint8_t *m:     pointer to message to be signed
- *              - size_t mlen:    length of message
- *              - uint8_t *pre:   pointer to prefix string
- *              - size_t prelen:  length of prefix string
- *              - uint8_t *rnd:   pointer to random seed
- *              - uint8_t *sk:    pointer to bit-packed secret key
- *              - int externalmu: indicates input message m is processed as mu
- *
- * Returns 0 (success)
- **************************************************/
 int crypto_sign_signature_internal(uint8_t *sig, size_t *siglen,
                                    const uint8_t *m, size_t mlen,
                                    const uint8_t *pre, size_t prelen,
@@ -234,23 +188,6 @@ rej:
   return 0;
 }
 
-/*************************************************
- * Name:        crypto_sign_signature
- *
- * Description: FIPS 204: Algorithm 2 ML-DSA.Sign.
- *              Computes signature.
- *
- * Arguments:   - uint8_t *sig:   pointer to output signature (of length
- *CRYPTO_BYTES)
- *              - size_t *siglen: pointer to output length of signature
- *              - uint8_t *m:     pointer to message to be signed
- *              - size_t mlen:    length of message
- *              - uint8_t *ctx:   pointer to contex string
- *              - size_t ctxlen:  length of contex string
- *              - uint8_t *sk:    pointer to bit-packed secret key
- *
- * Returns 0 (success) or -1 (context string too long)
- **************************************************/
 int crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
                           size_t mlen, const uint8_t *ctx, size_t ctxlen,
                           const uint8_t *sk)
@@ -286,20 +223,6 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
   return 0;
 }
 
-/*************************************************
- * Name:        crypto_sign_signature_extmu
- *
- * Description:  FIPS 204: Algorithm 2 ML-DSA.Sign external mu variant.
- *               Computes signature.
- *
- * Arguments:   - uint8_t *sig:   pointer to output signature (of length
- *CRYPTO_BYTES)
- *              - size_t *siglen: pointer to output length of signature
- *              - uint8_t mu:     input mu to be signed of size MLDSA_CRHBYTES
- *              - uint8_t *sk:    pointer to bit-packed secret key
- *
- * Returns 0 (success) or -1 (context string too long)
- **************************************************/
 int crypto_sign_signature_extmu(uint8_t *sig, size_t *siglen,
                                 const uint8_t mu[MLDSA_CRHBYTES],
                                 const uint8_t *sk)
@@ -320,24 +243,6 @@ int crypto_sign_signature_extmu(uint8_t *sig, size_t *siglen,
   return 0;
 }
 
-/*************************************************
- * Name:        crypto_sign
- *
- * Description: Compute signed message.
- *
- * Arguments:   - uint8_t *sm: pointer to output signed message (allocated
- *                             array with CRYPTO_BYTES + mlen bytes),
- *                             can be equal to m
- *              - size_t *smlen: pointer to output length of signed
- *                               message
- *              - const uint8_t *m: pointer to message to be signed
- *              - size_t mlen: length of message
- *              - const uint8_t *ctx: pointer to context string
- *              - size_t ctxlen: length of context string
- *              - const uint8_t *sk: pointer to bit-packed secret key
- *
- * Returns 0 (success) or -1 (context string too long)
- **************************************************/
 int crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen,
                 const uint8_t *ctx, size_t ctxlen, const uint8_t *sk)
 {
@@ -354,22 +259,6 @@ int crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen,
   return ret;
 }
 
-/*************************************************
- * Name:        crypto_sign_verify_internal
- *
- * Description: FIPS 204: Algorithm 8 ML-DSA.Verify_internal.
- *              Verifies signature. Internal API.
- * Arguments:   - uint8_t *m: pointer to input signature
- *              - size_t siglen: length of signature
- *              - const uint8_t *m: pointer to message
- *              - size_t mlen: length of message
- *              - const uint8_t *pre: pointer to prefix string
- *              - size_t prelen: length of prefix string
- *              - const uint8_t *pk: pointer to bit-packed public key
- *               - int externalmu: indicates input message m is processed as mu
- *
- * Returns 0 if signature could be verified correctly and -1 otherwise
- **************************************************/
 int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
                                 const uint8_t *m, size_t mlen,
                                 const uint8_t *pre, size_t prelen,
@@ -456,22 +345,6 @@ int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
   return 0;
 }
 
-/*************************************************
- * Name:        crypto_sign_verify
- *
- * Description: FIPS 204: Algorithm 3 ML-DSA.Verify.
- *              Verifies signature.
- *
- * Arguments:   - uint8_t *m: pointer to input signature
- *              - size_t siglen: length of signature
- *              - const uint8_t *m: pointer to message
- *              - size_t mlen: length of message
- *              - const uint8_t *ctx: pointer to context string
- *              - size_t ctxlen: length of context string
- *              - const uint8_t *pk: pointer to bit-packed public key
- *
- * Returns 0 if signature could be verified correctly and -1 otherwise
- **************************************************/
 int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
                        size_t mlen, const uint8_t *ctx, size_t ctxlen,
                        const uint8_t *pk)
@@ -495,19 +368,6 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
                                      0);
 }
 
-/*************************************************
- * Name:        crypto_sign_verify_extmu
- *
- * Description: FIPS 204: Algorithm 3 ML-DSA.Verify external mu variant.
- *              Verifies signature.
- *
- * Arguments:   - uint8_t *m: pointer to input signature
- *              - size_t siglen: length of signature
- *              - const uint8_t mu: input mu of size MLDSA_CRHBYTES
- *              - const uint8_t *pk: pointer to bit-packed public key
- *
- * Returns 0 if signature could be verified correctly and -1 otherwise
- **************************************************/
 int crypto_sign_verify_extmu(const uint8_t *sig, size_t siglen,
                              const uint8_t mu[MLDSA_CRHBYTES],
                              const uint8_t *pk)
@@ -515,22 +375,6 @@ int crypto_sign_verify_extmu(const uint8_t *sig, size_t siglen,
   return crypto_sign_verify_internal(sig, siglen, mu, 0, NULL, 0, pk, 1);
 }
 
-/*************************************************
- * Name:        crypto_sign_open
- *
- * Description: Verify signed message.
- *
- * Arguments:   - uint8_t *m: pointer to output message (allocated
- *                            array with smlen bytes), can be equal to sm
- *              - size_t *mlen: pointer to output length of message
- *              - const uint8_t *sm: pointer to signed message
- *              - size_t smlen: length of signed message
- *              - const uint8_t *ctx: pointer to context tring
- *              - size_t ctxlen: length of context string
- *              - const uint8_t *pk: pointer to bit-packed public key
- *
- * Returns 0 if signed message could be verified correctly and -1 otherwise
- **************************************************/
 int crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen,
                      const uint8_t *ctx, size_t ctxlen, const uint8_t *pk)
 {

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -12,13 +12,59 @@
 #include "polyvec.h"
 
 #define crypto_sign_keypair_internal MLD_NAMESPACE(keypair_internal)
+/*************************************************
+ * Name:        crypto_sign_keypair_internal
+ *
+ * Description: FIPS 204: Algorithm 6 ML-DSA.KeyGen_internal.
+ *              Generates public and private key. Internal API.
+ *
+ * Arguments:   - uint8_t *pk:   pointer to output public key (allocated
+ *                               array of CRYPTO_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk:   pointer to output private key (allocated
+ *                               array of CRYPTO_SECRETKEYBYTES bytes)
+ *              - uint8_t *seed: pointer to input random seed (MLDSA_SEEDBYTES
+ *bytes)
+ *
+ * Returns 0 (success)
+ **************************************************/
 int crypto_sign_keypair_internal(uint8_t *pk, uint8_t *sk,
                                  const uint8_t seed[MLDSA_SEEDBYTES]);
 
 #define crypto_sign_keypair MLD_NAMESPACE(keypair)
+/*************************************************
+ * Name:        crypto_sign_keypair
+ *
+ * Description: FIPS 204: Algorithm 1 ML-DSA.KeyGen
+ *              Generates public and private key.
+ *
+ * Arguments:   - uint8_t *pk:   pointer to output public key (allocated
+ *                               array of CRYPTO_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk:   pointer to output private key (allocated
+ *                               array of CRYPTO_SECRETKEYBYTES bytes)
+ *
+ * Returns 0 (success)
+ **************************************************/
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 #define crypto_sign_signature_internal MLD_NAMESPACE(signature_internal)
+/*************************************************
+ * Name:        crypto_sign_signature_internal
+ *
+ * Description: Computes signature. Internal API.
+ *
+ * Arguments:   - uint8_t *sig:   pointer to output signature (of length
+ *CRYPTO_BYTES)
+ *              - size_t *siglen: pointer to output length of signature
+ *              - uint8_t *m:     pointer to message to be signed
+ *              - size_t mlen:    length of message
+ *              - uint8_t *pre:   pointer to prefix string
+ *              - size_t prelen:  length of prefix string
+ *              - uint8_t *rnd:   pointer to random seed
+ *              - uint8_t *sk:    pointer to bit-packed secret key
+ *              - int externalmu: indicates input message m is processed as mu
+ *
+ * Returns 0 (success)
+ **************************************************/
 int crypto_sign_signature_internal(uint8_t *sig, size_t *siglen,
                                    const uint8_t *m, size_t mlen,
                                    const uint8_t *pre, size_t prelen,
@@ -26,36 +72,146 @@ int crypto_sign_signature_internal(uint8_t *sig, size_t *siglen,
                                    const uint8_t *sk, int externalmu);
 
 #define crypto_sign_signature MLD_NAMESPACE(signature)
+/*************************************************
+ * Name:        crypto_sign_signature
+ *
+ * Description: FIPS 204: Algorithm 2 ML-DSA.Sign.
+ *              Computes signature.
+ *
+ * Arguments:   - uint8_t *sig:   pointer to output signature (of length
+ *CRYPTO_BYTES)
+ *              - size_t *siglen: pointer to output length of signature
+ *              - uint8_t *m:     pointer to message to be signed
+ *              - size_t mlen:    length of message
+ *              - uint8_t *ctx:   pointer to contex string
+ *              - size_t ctxlen:  length of contex string
+ *              - uint8_t *sk:    pointer to bit-packed secret key
+ *
+ * Returns 0 (success) or -1 (context string too long)
+ **************************************************/
 int crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
                           size_t mlen, const uint8_t *ctx, size_t ctxlen,
                           const uint8_t *sk);
 
 #define crypto_sign_signature_extmu MLD_NAMESPACE(signature_extmu)
+/*************************************************
+ * Name:        crypto_sign_signature_extmu
+ *
+ * Description:  FIPS 204: Algorithm 2 ML-DSA.Sign external mu variant.
+ *               Computes signature.
+ *
+ * Arguments:   - uint8_t *sig:   pointer to output signature (of length
+ *CRYPTO_BYTES)
+ *              - size_t *siglen: pointer to output length of signature
+ *              - uint8_t mu:     input mu to be signed of size MLDSA_CRHBYTES
+ *              - uint8_t *sk:    pointer to bit-packed secret key
+ *
+ * Returns 0 (success) or -1 (context string too long)
+ **************************************************/
 int crypto_sign_signature_extmu(uint8_t *sig, size_t *siglen,
                                 const uint8_t mu[MLDSA_CRHBYTES],
                                 const uint8_t *sk);
 
 #define crypto_sign MLD_NAMESPACETOP
+/*************************************************
+ * Name:        crypto_sign
+ *
+ * Description: Compute signed message.
+ *
+ * Arguments:   - uint8_t *sm: pointer to output signed message (allocated
+ *                             array with CRYPTO_BYTES + mlen bytes),
+ *                             can be equal to m
+ *              - size_t *smlen: pointer to output length of signed
+ *                               message
+ *              - const uint8_t *m: pointer to message to be signed
+ *              - size_t mlen: length of message
+ *              - const uint8_t *ctx: pointer to context string
+ *              - size_t ctxlen: length of context string
+ *              - const uint8_t *sk: pointer to bit-packed secret key
+ *
+ * Returns 0 (success) or -1 (context string too long)
+ **************************************************/
 int crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen,
                 const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 
 #define crypto_sign_verify_internal MLD_NAMESPACE(verify_internal)
+/*************************************************
+ * Name:        crypto_sign_verify_internal
+ *
+ * Description: FIPS 204: Algorithm 8 ML-DSA.Verify_internal.
+ *              Verifies signature. Internal API.
+ * Arguments:   - uint8_t *m: pointer to input signature
+ *              - size_t siglen: length of signature
+ *              - const uint8_t *m: pointer to message
+ *              - size_t mlen: length of message
+ *              - const uint8_t *pre: pointer to prefix string
+ *              - size_t prelen: length of prefix string
+ *              - const uint8_t *pk: pointer to bit-packed public key
+ *               - int externalmu: indicates input message m is processed as mu
+ *
+ * Returns 0 if signature could be verified correctly and -1 otherwise
+ **************************************************/
 int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
                                 const uint8_t *m, size_t mlen,
                                 const uint8_t *pre, size_t prelen,
                                 const uint8_t *pk, int externalmu);
 
 #define crypto_sign_verify MLD_NAMESPACE(verify)
+/*************************************************
+ * Name:        crypto_sign_verify
+ *
+ * Description: FIPS 204: Algorithm 3 ML-DSA.Verify.
+ *              Verifies signature.
+ *
+ * Arguments:   - uint8_t *m: pointer to input signature
+ *              - size_t siglen: length of signature
+ *              - const uint8_t *m: pointer to message
+ *              - size_t mlen: length of message
+ *              - const uint8_t *ctx: pointer to context string
+ *              - size_t ctxlen: length of context string
+ *              - const uint8_t *pk: pointer to bit-packed public key
+ *
+ * Returns 0 if signature could be verified correctly and -1 otherwise
+ **************************************************/
 int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
                        size_t mlen, const uint8_t *ctx, size_t ctxlen,
                        const uint8_t *pk);
 
 #define crypto_sign_verify_extmu MLD_NAMESPACE(verify_extmu)
+/*************************************************
+ * Name:        crypto_sign_verify_extmu
+ *
+ * Description: FIPS 204: Algorithm 3 ML-DSA.Verify external mu variant.
+ *              Verifies signature.
+ *
+ * Arguments:   - uint8_t *m: pointer to input signature
+ *              - size_t siglen: length of signature
+ *              - const uint8_t mu: input mu of size MLDSA_CRHBYTES
+ *              - const uint8_t *pk: pointer to bit-packed public key
+ *
+ * Returns 0 if signature could be verified correctly and -1 otherwise
+ **************************************************/
 int crypto_sign_verify_extmu(const uint8_t *sig, size_t siglen,
                              const uint8_t mu[MLDSA_CRHBYTES],
                              const uint8_t *pk);
 
 #define crypto_sign_open MLD_NAMESPACE(open)
+/*************************************************
+ * Name:        crypto_sign_open
+ *
+ * Description: Verify signed message.
+ *
+ * Arguments:   - uint8_t *m: pointer to output message (allocated
+ *                            array with smlen bytes), can be equal to sm
+ *              - size_t *mlen: pointer to output length of message
+ *              - const uint8_t *sm: pointer to signed message
+ *              - size_t smlen: length of signed message
+ *              - const uint8_t *ctx: pointer to context tring
+ *              - size_t ctxlen: length of context string
+ *              - const uint8_t *pk: pointer to bit-packed public key
+ *
+ * Returns 0 if signed message could be verified correctly and -1 otherwise
+ **************************************************/
 int crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen,
                      const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 


### PR DESCRIPTION
Following https://github.com/pq-code-package/mldsa-native/pull/97, this commit moves _all_ comments documenting function signatures into the corresponding header files.
Note that there are still some functions that do not have a documenting comment.
I have not changed any comments except for alignment.