### PR TITLE
Simplification and proof of unpack_sig() and supporting functions.

### DIFF
--- a/mldsa/packing.c
+++ b/mldsa/packing.c
@@ -152,58 +152,105 @@ void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
   }
 }
 
-int unpack_sig(uint8_t c[MLDSA_CTILDEBYTES], polyvecl *z, polyveck *h,
-               const uint8_t sig[CRYPTO_BYTES])
+/*************************************************
+ * Name:        unpack_hints
+ *
+ * Description: Unpack raw hint bytes into a polyveck
+ *              struct
+ *
+ * Arguments:   - polyveck *h: pointer to output hint vector h
+ *              - const uint8_t packed_hints[MLDSA_POLYVECH_PACKEDBYTES]:
+ *                raw hint bytes
+ *
+ * Returns 1 in case of malformed hints; otherwise 0.
+ **************************************************/
+static int unpack_hints(polyveck *h,
+                        const uint8_t packed_hints[MLDSA_POLYVECH_PACKEDBYTES])
+__contract__(
+  requires(memory_no_alias(packed_hints, MLDSA_POLYVECH_PACKEDBYTES))
+  requires(memory_no_alias(h, sizeof(polyveck)))
+  assigns(object_whole(h))
+  /* All returned coefficients are either 0 or 1 */
+  ensures(forall(k1, 0, MLDSA_K,
+    array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+  ensures(return_value >= 0 && return_value <= 1)
+)
 {
-  unsigned int i, j, k;
+  unsigned int i, j;
+  unsigned int old_hint_count;
 
-  for (i = 0; i < MLDSA_CTILDEBYTES; ++i)
-  {
-    c[i] = sig[i];
-  }
-  sig += MLDSA_CTILDEBYTES;
+  /* Set all coefficients of all polynomials to 0.    */
+  /* Only those that are actually non-zero hints will */
+  /* be overwritten below.                            */
+  memset(h, 0, sizeof(polyveck));
 
-  for (i = 0; i < MLDSA_L; ++i)
-  {
-    polyz_unpack(&z->vec[i], sig + i * MLDSA_POLYZ_PACKEDBYTES);
-  }
-  sig += MLDSA_L * MLDSA_POLYZ_PACKEDBYTES;
-
-  /* Decode h */
-  k = 0;
+  old_hint_count = 0;
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    invariant(i <= MLDSA_K)
+    /* Maintain the post-condition */
+    invariant(forall(k1, 0, MLDSA_K, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+  )
   {
-    for (j = 0; j < MLDSA_N; ++j)
-    {
-      h->vec[i].coeffs[j] = 0;
-    }
+    /* Grab the hint count for the i'th polynomial */
+    const unsigned int new_hint_count = packed_hints[MLDSA_OMEGA + i];
 
-    if (sig[MLDSA_OMEGA + i] < k || sig[MLDSA_OMEGA + i] > MLDSA_OMEGA)
+    /* new_hint_count must increase or stay the same, but also remain */
+    /* less than or equal to MLDSA_OMEGA                              */
+    if (new_hint_count < old_hint_count || new_hint_count > MLDSA_OMEGA)
     {
+      /* Error - new_hint_count is invalid */
       return 1;
     }
 
-    for (j = k; j < sig[MLDSA_OMEGA + i]; ++j)
+    /* If new_hint_count == old_hint_count, then this polynomial has */
+    /* zero hints, so this loop executes zero times and we move      */
+    /* straight on to the next polynomial.                           */
+    for (j = old_hint_count; j < new_hint_count; ++j)
+    __loop__(
+        invariant(i <= MLDSA_K)
+        /* Maintain the post-condition */
+        invariant(forall(k1, 0, MLDSA_K, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+      )
     {
-      /* Coefficients are ordered for strong unforgeability */
-      if (j > k && sig[j] <= sig[j - 1])
+      const uint8_t this_hint_index = packed_hints[j];
+
+      /* Coefficients must be ordered for strong unforgeability */
+      if (j > old_hint_count && this_hint_index <= packed_hints[j - 1])
       {
         return 1;
       }
-      h->vec[i].coeffs[sig[j]] = 1;
+      h->vec[i].coeffs[this_hint_index] = 1;
     }
 
-    k = sig[MLDSA_OMEGA + i];
+    old_hint_count = new_hint_count;
   }
 
-  /* Extra indices are zero for strong unforgeability */
-  for (j = k; j < MLDSA_OMEGA; ++j)
+  /* Extra indices must be zero for strong unforgeability */
+  for (j = old_hint_count; j < MLDSA_OMEGA; ++j)
+  __loop__(
+    invariant(j <= MLDSA_OMEGA)
+    /* Maintain the post-condition */
+    invariant(forall(k1, 0, MLDSA_K, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+  )
   {
-    if (sig[j])
+    if (packed_hints[j] != 0)
     {
       return 1;
     }
   }
 
   return 0;
+}
+
+int unpack_sig(uint8_t c[MLDSA_CTILDEBYTES], polyvecl *z, polyveck *h,
+               const uint8_t sig[CRYPTO_BYTES])
+{
+  memcpy(c, sig, MLDSA_CTILDEBYTES);
+  sig += MLDSA_CTILDEBYTES;
+
+  polyvecl_unpack_z(z, sig);
+  sig += MLDSA_L * MLDSA_POLYZ_PACKEDBYTES;
+
+  return unpack_hints(h, sig);
 }

--- a/mldsa/packing.h
+++ b/mldsa/packing.h
@@ -178,6 +178,19 @@ __contract__(
  * Returns 1 in case of malformed signature; otherwise 0.
  **************************************************/
 int unpack_sig(uint8_t c[MLDSA_CTILDEBYTES], polyvecl *z, polyveck *h,
-               const uint8_t sig[CRYPTO_BYTES]);
-
+               const uint8_t sig[CRYPTO_BYTES])
+__contract__(
+  requires(memory_no_alias(sig, CRYPTO_BYTES))
+  requires(memory_no_alias(c, MLDSA_CTILDEBYTES))
+  requires(memory_no_alias(z, sizeof(polyvecl)))
+  requires(memory_no_alias(h, sizeof(polyveck)))
+  assigns(object_whole(c))
+  assigns(object_whole(z))
+  assigns(object_whole(h))
+  ensures(forall(k0, 0, MLDSA_L,
+    array_bound(z->vec[k0].coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1)))
+  ensures(forall(k1, 0, MLDSA_K,
+    array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+  ensures(return_value >= 0 && return_value <= 1)
+);
 #endif /* !MLD_PACKING_H */

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -498,7 +498,7 @@ void polyz_unpack(poly *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(a, MLDSA_POLYZ_PACKEDBYTES))
-  assigns(object_whole(r))
+  assigns(memory_slice(r, sizeof(poly)))
   ensures(array_bound(r->coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1))
 );
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -428,6 +428,16 @@ void polyvecl_unpack_eta(polyvecl *p,
   }
 }
 
+void polyvecl_unpack_z(polyvecl *z,
+                       const uint8_t r[MLDSA_L * MLDSA_POLYZ_PACKEDBYTES])
+{
+  unsigned int i;
+  for (i = 0; i < MLDSA_L; ++i)
+  {
+    polyz_unpack(&z->vec[i], r + i * MLDSA_POLYZ_PACKEDBYTES);
+  }
+}
+
 void polyveck_unpack_eta(polyveck *p,
                          const uint8_t r[MLDSA_K * MLDSA_POLYETA_PACKEDBYTES])
 {

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -436,6 +436,17 @@ __contract__(
     array_bound(p->vec[k1].coeffs, 0, MLDSA_N, MLD_POLYETA_UNPACK_LOWER_BOUND, MLDSA_ETA + 1)))
 );
 
+#define polyvecl_unpack_z MLD_NAMESPACE(polyvecl_unpack_z)
+void polyvecl_unpack_z(polyvecl *z,
+                       const uint8_t r[MLDSA_L * MLDSA_POLYZ_PACKEDBYTES])
+__contract__(
+  requires(memory_no_alias(r,  MLDSA_L * MLDSA_POLYZ_PACKEDBYTES))
+  requires(memory_no_alias(z, sizeof(polyvecl)))
+  assigns(object_whole(z))
+  ensures(forall(k1, 0, MLDSA_L,
+    array_bound(z->vec[k1].coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1)))
+);
+
 #define polyveck_unpack_eta MLD_NAMESPACE(polyveck_unpack_eta)
 void polyveck_unpack_eta(polyveck *p,
                          const uint8_t r[MLDSA_K * MLDSA_POLYETA_PACKEDBYTES])

--- a/proofs/cbmc/polyveck_pack_eta/Makefile
+++ b/proofs/cbmc/polyveck_pack_eta/Makefile
@@ -36,7 +36,7 @@ FUNCTION_NAME = polyveck_pack_eta
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 9
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyveck_pack_t0/Makefile
+++ b/proofs/cbmc/polyveck_pack_t0/Makefile
@@ -36,7 +36,7 @@ FUNCTION_NAME = polyveck_pack_t0
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 9
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyveck_unpack_eta/Makefile
+++ b/proofs/cbmc/polyveck_unpack_eta/Makefile
@@ -36,7 +36,7 @@ FUNCTION_NAME = polyveck_unpack_eta
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 9
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyveck_unpack_t0/Makefile
+++ b/proofs/cbmc/polyveck_unpack_t0/Makefile
@@ -36,7 +36,7 @@ FUNCTION_NAME = polyveck_unpack_t0
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 9
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyvecl_unpack_z/Makefile
+++ b/proofs/cbmc/polyvecl_unpack_z/Makefile
@@ -3,31 +3,31 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = polyveck_pack_w1_harness
+HARNESS_FILE = polyvecl_unpack_z_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = polyveck_pack_w1
+PROOF_UID = polyvecl_unpack_z
 
 DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_w1.0:8 # Largest value of MLDSA_K
+UNWINDSET += $(MLD_NAMESPACE)polyvecl_unpack_z.0:7 # Largest value of MLDSA_L
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_pack_w1
-USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyw1_pack
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_unpack_z
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyz_unpack
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
-FUNCTION_NAME = polyveck_pack_w1
+FUNCTION_NAME = polyvecl_unpack_z
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
@@ -36,7 +36,7 @@ FUNCTION_NAME = polyveck_pack_w1
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 9
+CBMC_OBJECT_BITS = 8
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyvecl_unpack_z/polyvecl_unpack_z_harness.c
+++ b/proofs/cbmc/polyvecl_unpack_z/polyvecl_unpack_z_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyvecl *a;
+  uint8_t *b;
+  polyvecl_unpack_z(a, b);
+}

--- a/proofs/cbmc/unpack_hints/Makefile
+++ b/proofs/cbmc/unpack_hints/Makefile
@@ -3,31 +3,31 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = polyveck_pack_w1_harness
+HARNESS_FILE = unpack_hints_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = polyveck_pack_w1
+PROOF_UID = unpack_hints
 
 DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_w1.0:8 # Largest value of MLDSA_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
-PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/packing.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_pack_w1
-USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyw1_pack
+CHECK_FUNCTION_CONTRACTS=unpack_hints
+USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS+=--slice-formula
 
-FUNCTION_NAME = polyveck_pack_w1
+FUNCTION_NAME = unpack_hints
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/proofs/cbmc/unpack_hints/unpack_hints_harness.c
+++ b/proofs/cbmc/unpack_hints/unpack_hints_harness.c
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "packing.h"
+
+int unpack_hints(polyveck *h,
+                 const uint8_t packed_hints[MLDSA_POLYVECH_PACKEDBYTES]);
+
+void harness(void)
+{
+  uint8_t *sig;
+  polyveck *h;
+  int r;
+  r = unpack_hints(h, sig);
+}

--- a/proofs/cbmc/unpack_sig/Makefile
+++ b/proofs/cbmc/unpack_sig/Makefile
@@ -3,31 +3,31 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = polyveck_pack_w1_harness
+HARNESS_FILE = unpack_sig_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = polyveck_pack_w1
+PROOF_UID = unpack_sig
 
 DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_w1.0:8 # Largest value of MLDSA_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
-PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/packing.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_pack_w1
-USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyw1_pack
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)unpack_sig
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_unpack_z unpack_hints
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS+=--slice-formula
 
-FUNCTION_NAME = polyveck_pack_w1
+FUNCTION_NAME = unpack_sig
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/proofs/cbmc/unpack_sig/unpack_sig_harness.c
+++ b/proofs/cbmc/unpack_sig/unpack_sig_harness.c
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "packing.h"
+
+
+void harness(void)
+{
+  uint8_t *c;
+  uint8_t *sig;
+  polyveck *h;
+  polyvecl *z;
+  int r;
+  r = unpack_sig(c, z, h, sig);
+}


### PR DESCRIPTION
Re-factors unpack_sig() to make it much simplifer, and isolates unpacking of hints into new, static unpack_hints() function

Adds supporting functions and their proofs:
 poly_clear() - zeroes a polynomial
 polyveck_clear() - zeroes a vector of K polynomials
 polyvecl_unpack_z() - unpacks the L z components of a signature
 unpack_hints() - the inverse of the "hint packing" algorithm in pack_sig()

All proofs OK. All tests OK. Lint OK.