### PR TITLE
CBMC: Add contracts and proofs for various poly functions

### DIFF
--- a/mldsa/cbmc.h
+++ b/mldsa/cbmc.h
@@ -84,7 +84,7 @@
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==> (predicate)   \
   }
 
-#define EXISTS(qvar, qvar_lb, qvar_ub, predicate)         \
+#define exists(qvar, qvar_lb, qvar_ub, predicate)         \
   __CPROVER_exists                                              \
   {                                                             \
     unsigned qvar;                                              \

--- a/mldsa/cbmc.h
+++ b/mldsa/cbmc.h
@@ -119,8 +119,10 @@
 
 /* Wrapper around array_bound operating on absolute values.
  *
- * Note that since the absolute bound is inclusive, but the lower
- * bound in array_bound is inclusive, we have to raise it by 1.
+ * The absolute value bound `k` is exclusive.
+ *
+ * Note that since the lower bound in array_bound is inclusive, we have to
+ * raise it by 1 here.
  */
 #define array_abs_bound(arr, lb, ub, k) \
   array_bound((arr), (lb), (ub), -((int)(k)) + 1, (k))

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -89,6 +89,8 @@ void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b)
   unsigned int i;
 
   for (i = 0; i < MLDSA_N; ++i)
+  __loop__(
+    invariant(i <= MLDSA_N))
   {
     c->coeffs[i] = montgomery_reduce((int64_t)a->coeffs[i] * b->coeffs[i]);
   }

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -30,6 +30,11 @@ void poly_caddq(poly *a)
   unsigned int i;
 
   for (i = 0; i < MLDSA_N; ++i)
+  __loop__(
+    invariant(i <= MLDSA_N)
+    invariant(forall(k0, i, MLDSA_N, a->coeffs[k0] == loop_entry(*a).coeffs[k0]))
+    invariant(array_bound(a->coeffs, 0, i, 0, MLDSA_Q))
+    )
   {
     a->coeffs[i] = caddq(a->coeffs[i]);
   }

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -94,6 +94,12 @@ void poly_power2round(poly *a1, poly *a0, const poly *a)
   unsigned int i;
 
   for (i = 0; i < MLDSA_N; ++i)
+  __loop__(
+    assigns(i, memory_slice(a0, sizeof(poly)), memory_slice(a1, sizeof(poly)))
+    invariant(i <= MLDSA_N)
+    invariant(array_bound(a0->coeffs, 0, i, -(MLD_2_POW_D/2)+1, (MLD_2_POW_D/2)+1))
+    invariant(array_bound(a1->coeffs, 0, i, 0, (MLD_2_POW_D/2)+1))
+  )
   {
     power2round(&a0->coeffs[i], &a1->coeffs[i], a->coeffs[i]);
   }

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -42,7 +42,13 @@ __contract__(
  *
  * Arguments:   - poly *a: pointer to input/output polynomial
  **************************************************/
-void poly_caddq(poly *a);
+void poly_caddq(poly *a)
+__contract__(
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(array_abs_bound(a->coeffs, 0, MLDSA_N, MLDSA_Q))
+  assigns(memory_slice(a, sizeof(poly)))
+  ensures(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
+);
 
 #define poly_add MLD_NAMESPACE(poly_add)
 /*************************************************

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -9,6 +9,7 @@
 #include "cbmc.h"
 #include "params.h"
 #include "reduce.h"
+#include "rounding.h"
 
 typedef struct
 {
@@ -152,7 +153,18 @@ void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b);
  *              - poly *a0: pointer to output polynomial with coefficients c0
  *              - const poly *a: pointer to input polynomial
  **************************************************/
-void poly_power2round(poly *a1, poly *a0, const poly *a);
+void poly_power2round(poly *a1, poly *a0, const poly *a)
+__contract__(
+  requires(memory_no_alias(a0, sizeof(poly)))
+  requires(memory_no_alias(a1, sizeof(poly)))
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
+  assigns(memory_slice(a1, sizeof(poly)))
+  assigns(memory_slice(a0, sizeof(poly)))
+  ensures(array_bound(a0->coeffs, 0, MLDSA_N, -(MLD_2_POW_D/2)+1, (MLD_2_POW_D/2)+1))
+  ensures(array_bound(a1->coeffs, 0, MLDSA_N, 0, (MLD_2_POW_D/2)+1))
+);
+
 
 #define poly_decompose MLD_NAMESPACE(poly_decompose)
 /*************************************************

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include "cbmc.h"
+#include "ntt.h"
 #include "params.h"
 #include "reduce.h"
 #include "rounding.h"
@@ -118,7 +119,14 @@ __contract__(
  *
  * Arguments:   - poly *a: pointer to input/output polynomial
  **************************************************/
-void poly_ntt(poly *a);
+void poly_ntt(poly *a)
+__contract__(
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(array_abs_bound(a->coeffs, 0, MLDSA_N, MLDSA_Q))
+  assigns(memory_slice(a, sizeof(poly)))
+  ensures(array_abs_bound(a->coeffs, 0, MLDSA_N, MLD_NTT_BOUND))
+);
+
 
 #define poly_invntt_tomont MLD_NAMESPACE(poly_invntt_tomont)
 /*************************************************

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -152,7 +152,13 @@ void poly_invntt_tomont(poly *a);
  *              - const poly *a: pointer to first input polynomial
  *              - const poly *b: pointer to second input polynomial
  **************************************************/
-void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b);
+void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b)
+__contract__(
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(memory_no_alias(b, sizeof(poly)))
+  requires(memory_no_alias(c, sizeof(poly)))
+  assigns(memory_slice(c, sizeof(poly)))
+);
 
 #define poly_power2round MLD_NAMESPACE(poly_power2round)
 /*************************************************

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -270,7 +270,15 @@ __contract__(
  * Returns 0 if norm is strictly smaller than B <= (MLDSA_Q-1)/8 and 1
  *otherwise.
  **************************************************/
-int poly_chknorm(const poly *a, int32_t B);
+int poly_chknorm(const poly *a, int32_t B)
+__contract__(
+  requires(memory_no_alias(a, sizeof(poly)))
+  requires(0 <= B && B <= (MLDSA_Q - 1) / 8)
+  requires(array_bound(a->coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX))
+  ensures(return_value == 0 || return_value == 1)
+  ensures((return_value == 0) == array_abs_bound(a->coeffs, 0, MLDSA_N, B))
+);
+
 
 #define poly_uniform MLD_NAMESPACE(poly_uniform)
 /*************************************************

--- a/mldsa/reduce.h
+++ b/mldsa/reduce.h
@@ -12,7 +12,7 @@
 #define MONT -4186625 /* 2^32 % MLDSA_Q */
 #define REDUCE_DOMAIN_MAX (INT32_MAX - (1 << 22))
 #define REDUCE_RANGE_MAX 6283009
-#define MONTGOMERY_REDUCE_DOMAIN_MAX (MLDSA_Q * (1LL << 31))
+#define MONTGOMERY_REDUCE_DOMAIN_MAX ((int64_t)INT32_MIN * INT32_MIN)
 
 #define montgomery_reduce MLD_NAMESPACE(montgomery_reduce)
 /*************************************************
@@ -22,6 +22,8 @@
  *              -2^{31}MLDSA_Q <= a <= MLDSA_Q*2^31,
  *              compute r \equiv a*2^{-32} (mod MLDSA_Q) such that
  *              -MLDSA_Q < r < MLDSA_Q.
+ *              If the output bounds are not required, the inputs can be larger
+ *              (up to INT64_MAX - (2^31 * MLDSA_Q) > INT32_MAX^2)
  *
  * Arguments:   - int64_t: finite field element a
  *

--- a/proofs/cbmc/poly_caddq/Makefile
+++ b/proofs/cbmc/poly_caddq/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE =poly_caddq_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_caddq
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_caddq
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)caddq
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_caddq
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_caddq/poly_caddq_harness.c
+++ b/proofs/cbmc/poly_caddq/poly_caddq_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+
+void harness(void)
+{
+  poly *a;
+  poly_caddq(a);
+}

--- a/proofs/cbmc/poly_chknorm/Makefile
+++ b/proofs/cbmc/poly_chknorm/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE =poly_chknorm_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_chknorm
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_chknorm
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_chknorm
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_chknorm/poly_chknorm_harness.c
+++ b/proofs/cbmc/poly_chknorm/poly_chknorm_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+
+void harness(void)
+{
+  poly *a;
+  int r;
+  int32_t B;
+  r = poly_chknorm(a, B);
+}

--- a/proofs/cbmc/poly_ntt/Makefile
+++ b/proofs/cbmc/poly_ntt/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_ntt_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_ntt
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_ntt
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)ntt
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_ntt
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_ntt/poly_ntt_harness.c
+++ b/proofs/cbmc/poly_ntt/poly_ntt_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+void harness(void)
+{
+  poly *a;
+  poly_ntt(a);
+}

--- a/proofs/cbmc/poly_pointwise_montgomery/Makefile
+++ b/proofs/cbmc/poly_pointwise_montgomery/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_pointwise_montgomery_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_pointwise_montgomery
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_pointwise_montgomery
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)montgomery_reduce
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_pointwise_montgomery
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_pointwise_montgomery/poly_pointwise_montgomery_harness.c
+++ b/proofs/cbmc/poly_pointwise_montgomery/poly_pointwise_montgomery_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+void harness(void)
+{
+  poly *a, *b, *c;
+  poly_pointwise_montgomery(c, a, b);
+}

--- a/proofs/cbmc/poly_power2round/Makefile
+++ b/proofs/cbmc/poly_power2round/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE =poly_power2round_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_power2round
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_power2round
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)power2round
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_power2round
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_power2round/poly_power2round_harness.c
+++ b/proofs/cbmc/poly_power2round/poly_power2round_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "poly.h"
+
+
+void harness(void)
+{
+  poly *a, *a0, *a1;
+  poly_power2round(a0, a1, a);
+}


### PR DESCRIPTION
This adds specs + proofs for all remaining `poly_` that don't have a dependency on Keccak. 

Resolves https://github.com/pq-code-package/mldsa-native/issues/108
Resolves https://github.com/pq-code-package/mldsa-native/issues/104
Resolves https://github.com/pq-code-package/mldsa-native/issues/105
Resolves https://github.com/pq-code-package/mldsa-native/issues/107
Resolves https://github.com/pq-code-package/mldsa-native/issues/109

The last one is by far the most intersting one. I'd actually like some help from the CBMC experts: What I have now seems to work fine: 

```c
int poly_chknorm(const poly *a, int32_t B)
__contract__(
  requires(memory_no_alias(a, sizeof(poly)))
  requires(B <= (MLDSA_Q - 1) / 8)
  requires(array_bound(a->coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX))
  ensures(return_value == 0 || return_value == 1)
  ensures(return_value == 0 ==> array_abs_bound(a->coeffs, 0, MLDSA_N, B))
  ensures(return_value == 1 ==> exists(k0, 0, MLDSA_N, (a->coeffs[k0] < 0 ? -a->coeffs[k0] : a->coeffs[k0]) >= B))
);
```

but neither 
```
ensures(return_value == 1 ==> exists(k0, 0, MLDSA_N, a->coeffs[k0] <= -B || a->coeffs[k0] >= B))
```
nor
```
ensures(return_value == 1 ==> exists(k0, 0, MLDSA_N, a->coeffs[k0] <= -B) || exists(k0, 0, MLDSA_N, a->coeffs[k0] >= B))
```
works - those would be much easier to read. Any ideas @rod-chapman @hanno-becker?

Furthermore, currently both bounds (for rc=0 and rc=1) are __inclusive__ of B. It should be inclusive for `rc=1`, but exclusive for `rc=0` - but I cannot get it to work. 