### PR TITLE
CBMC: Add contracts and proofs for various polyvec functions

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -62,7 +62,10 @@ void poly_sub(poly *c, const poly *a, const poly *b)
   __loop__(
     invariant(i <= MLDSA_N)
     invariant(forall(k1, 0, i, c->coeffs[k1] == a->coeffs[k1] - b->coeffs[k1])))
-  c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+  {
+    c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+  }
+  cassert(forall(k, 0, MLDSA_N, c->coeffs[k] == a->coeffs[k] - b->coeffs[k]));
 }
 
 void poly_shiftl(poly *a)

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -50,6 +50,8 @@ void poly_add(poly *c, const poly *a, const poly *b)
   {
     c->coeffs[i] = a->coeffs[i] + b->coeffs[i];
   }
+
+  cassert(forall(k, 0, MLDSA_N, c->coeffs[k] == a->coeffs[k] + b->coeffs[k]));
 }
 
 void poly_sub(poly *c, const poly *a, const poly *b)

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -90,7 +90,6 @@ __contract__(
   requires(memory_no_alias(b, sizeof(poly)))
   requires(forall(k0, 0, MLDSA_N, (int64_t) a->coeffs[k0] - b->coeffs[k0] <= INT32_MAX))
   requires(forall(k1, 0, MLDSA_N, (int64_t) a->coeffs[k1] - b->coeffs[k1] >= INT32_MIN))
-  ensures(forall(k, 0, MLDSA_N, c->coeffs[k] == a->coeffs[k] - b->coeffs[k]))
   assigns(memory_slice(c, sizeof(poly))));
 
 #define poly_shiftl MLD_NAMESPACE(poly_shiftl)

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -68,7 +68,6 @@ __contract__(
   requires(memory_no_alias(b, sizeof(poly)))
   requires(forall(k0, 0, MLDSA_N, (int64_t) a->coeffs[k0] + b->coeffs[k0] <= INT32_MAX))
   requires(forall(k1, 0, MLDSA_N, (int64_t) a->coeffs[k1] + b->coeffs[k1] >= INT32_MIN))
-  ensures(forall(k, 0, MLDSA_N, c->coeffs[k] == a->coeffs[k] + b->coeffs[k]))
   assigns(memory_slice(c, sizeof(poly)))
 );
 

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -29,7 +29,7 @@ typedef struct
 void poly_reduce(poly *a)
 __contract__(
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(forall(k0, 0, MLDSA_N, a->coeffs[k0] <= REDUCE_DOMAIN_MAX))
+  requires(array_bound(a->coeffs, 0, MLDSA_N, INT32_MIN, REDUCE_DOMAIN_MAX))
   assigns(memory_slice(a, sizeof(poly)))
   ensures(array_bound(a->coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX))
 );

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -65,8 +65,18 @@ void polyvecl_reduce(polyvecl *v)
   unsigned int i;
 
   for (i = 0; i < MLDSA_L; ++i)
+  __loop__(
+    invariant(i <= MLDSA_L)
+    invariant(forall(k0, i, MLDSA_L, forall(k1, 0, MLDSA_N, v->vec[k0].coeffs[k1] == loop_entry(*v).vec[k0].coeffs[k1])))
+    invariant(forall(k2, 0, i,
+      array_bound(v->vec[k2].coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX))))
   {
-    poly_reduce(&v->vec[i]);
+    poly t = v->vec[i];
+    poly_reduce(&t);
+    /* Full struct assignment from local variables to simplify proof */
+    /* TODO: eliminate once CBMC resolves
+     * https://github.com/diffblue/cbmc/issues/8617 */
+    v->vec[i] = t;
   }
 }
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -178,8 +178,19 @@ void polyveck_reduce(polyveck *v)
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    invariant(i <= MLDSA_K)
+    invariant(forall(k0, i, MLDSA_K, forall(k1, 0, MLDSA_N, v->vec[k0].coeffs[k1] == loop_entry(*v).vec[k0].coeffs[k1])))
+    invariant(forall(k2, 0, i,
+      array_bound(v->vec[k2].coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX)))
+  )
   {
-    poly_reduce(&v->vec[i]);
+    poly t = v->vec[i];
+    poly_reduce(&t);
+    /* Full struct assignment from local variables to simplify proof */
+    /* TODO: eliminate once CBMC resolves
+     * https://github.com/diffblue/cbmc/issues/8617 */
+    v->vec[i] = t;
   }
 }
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -354,8 +354,15 @@ void polyveck_use_hint(polyveck *w, const polyveck *u, const polyveck *h)
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    invariant(i <= MLDSA_K))
   {
-    poly_use_hint(&w->vec[i], &u->vec[i], &h->vec[i]);
+    poly t;
+    poly_use_hint(&t, &u->vec[i], &h->vec[i]);
+    /* Full struct assignment from local variables to simplify proof */
+    /* TODO: eliminate once CBMC resolves
+     * https://github.com/diffblue/cbmc/issues/8617 */
+    w->vec[i] = t;
   }
 }
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -226,8 +226,16 @@ void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v)
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    assigns(i, object_whole(w))
+    invariant(i <= MLDSA_K))
   {
-    poly_sub(&w->vec[i], &u->vec[i], &v->vec[i]);
+    poly t;
+    poly_sub(&t, &u->vec[i], &v->vec[i]);
+    /* Full struct assignment from local variables to simplify proof */
+    /* TODO: eliminate once CBMC resolves
+     * https://github.com/diffblue/cbmc/issues/8617 */
+    w->vec[i] = t;
   }
 }
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -209,8 +209,15 @@ void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v)
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    invariant(i <= MLDSA_K))
   {
-    poly_add(&w->vec[i], &u->vec[i], &v->vec[i]);
+    poly t;
+    poly_add(&t, &u->vec[i], &v->vec[i]);
+    /* Full struct assignment from local variables to simplify proof */
+    /* TODO: eliminate once CBMC resolves
+     * https://github.com/diffblue/cbmc/issues/8617 */
+    w->vec[i] = t;
   }
 }
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -85,8 +85,15 @@ void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v)
   unsigned int i;
 
   for (i = 0; i < MLDSA_L; ++i)
+  __loop__(
+    invariant(i <= MLDSA_L))
   {
-    poly_add(&w->vec[i], &u->vec[i], &v->vec[i]);
+    poly t;
+    poly_add(&t, &u->vec[i], &v->vec[i]);
+    /* Full struct assignment from local variables to simplify proof */
+    /* TODO: eliminate once CBMC resolves
+     * https://github.com/diffblue/cbmc/issues/8617 */
+    w->vec[i] = t;
   }
 }
 

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -339,8 +339,35 @@ __contract__(
 void polyveck_use_hint(polyveck *w, const polyveck *v, const polyveck *h);
 
 #define polyveck_pack_w1 MLD_NAMESPACE(polyveck_pack_w1)
+/*************************************************
+ * Name:        polyveck_pack_w1
+ *
+ * Description: Bit-pack polynomial vector w1 with coefficients in [0,15] or
+ *              [0,43].
+ *              Input coefficients are assumed to be standard representatives.
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array with at least
+ *                            MLDSA_K* MLDSA_POLYW1_PACKEDBYTES bytes
+ *              - const polyveck *a: pointer to input polynomial vector
+ **************************************************/
 void polyveck_pack_w1(uint8_t r[MLDSA_K * MLDSA_POLYW1_PACKEDBYTES],
-                      const polyveck *w1);
+                      const polyveck *w1)
+#if MLDSA_MODE == 2
+__contract__(
+  requires(memory_no_alias(r, MLDSA_K * MLDSA_POLYW1_PACKEDBYTES))
+  requires(memory_no_alias(w1, sizeof(polyveck)))
+  requires(forall(k1, 0, MLDSA_K,
+    array_bound(w1->vec[k1].coeffs, 0, MLDSA_N, 0, 44)))
+  assigns(object_whole(r)));
+#else  /* MLDSA_MODE == 2 */
+__contract__(
+  requires(memory_no_alias(r, MLDSA_K * MLDSA_POLYW1_PACKEDBYTES))
+  requires(memory_no_alias(w1, sizeof(polyveck)))
+  requires(forall(k1, 0, MLDSA_K,
+    array_bound(w1->vec[k1].coeffs, 0, MLDSA_N, 0, 16)))
+  assigns(object_whole(r)));
+#endif /* MLDSA_MODE != 2 */
+
 
 #define polyveck_pack_eta MLD_NAMESPACE(polyveck_pack_eta)
 void polyveck_pack_eta(uint8_t r[MLDSA_K * MLDSA_POLYETA_PACKEDBYTES],

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -336,7 +336,19 @@ __contract__(
  *              - const polyveck *u: pointer to input vector
  *              - const polyveck *h: pointer to input hint vector
  **************************************************/
-void polyveck_use_hint(polyveck *w, const polyveck *v, const polyveck *h);
+void polyveck_use_hint(polyveck *w, const polyveck *v, const polyveck *h)
+__contract__(
+  requires(memory_no_alias(w,  sizeof(polyveck)))
+  requires(memory_no_alias(v, sizeof(polyveck)))
+  requires(memory_no_alias(h, sizeof(polyveck)))
+  requires(forall(k0, 0, MLDSA_K,
+    array_bound(v->vec[k0].coeffs, 0, MLDSA_N, 0, MLDSA_Q)))
+  requires(forall(k1, 0, MLDSA_K,
+    array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
+  assigns(memory_slice(w, sizeof(polyveck)))
+  requires(forall(k2, 0, MLDSA_K,
+    array_bound(w->vec[k2].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2))))
+);
 
 #define polyveck_pack_w1 MLD_NAMESPACE(polyveck_pack_w1)
 /*************************************************

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -25,7 +25,24 @@ void polyvecl_uniform_gamma1(polyvecl *v, const uint8_t seed[MLDSA_CRHBYTES],
                              uint16_t nonce);
 
 #define polyvecl_reduce MLD_NAMESPACE(polyvecl_reduce)
-void polyvecl_reduce(polyvecl *v);
+/*************************************************
+ * Name:        polyvecl_reduce
+ *
+ * Description: Inplace reduction of all coefficients of all polynomial in a
+ *              vector of length MLDSA_L to
+ *              representative in [-6283008,6283008].
+ *
+ * Arguments:   - poly *v: pointer to input/output vector
+ **************************************************/
+void polyvecl_reduce(polyvecl *v)
+__contract__(
+  requires(memory_no_alias(v, sizeof(polyvecl)))
+  requires(forall(k0, 0, MLDSA_L,
+    array_bound(v->vec[k0].coeffs, 0, MLDSA_N, INT32_MIN, REDUCE_DOMAIN_MAX)))
+  assigns(memory_slice(v, sizeof(polyvecl)))
+  ensures(forall(k1, 0, MLDSA_L,
+    array_bound(v->vec[k1].coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX)))
+);
 
 #define polyvecl_add MLD_NAMESPACE(polyvecl_add)
 /*************************************************

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -168,7 +168,18 @@ void polyveck_caddq(polyveck *v);
  *              - const polyveck *u: pointer to first summand
  *              - const polyveck *v: pointer to second summand
  **************************************************/
-void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
+void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v)
+__contract__(
+  requires(memory_no_alias(w, sizeof(polyveck)))
+  requires(memory_no_alias(u, sizeof(polyveck)))
+  requires(memory_no_alias(v, sizeof(polyveck)))
+  requires(forall(k0, 0, MLDSA_K,
+    forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] + v->vec[k0].coeffs[k1] <= INT32_MAX)))
+  requires(forall(k2, 0, MLDSA_K,
+    forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] + v->vec[k2].coeffs[k3] >= INT32_MIN)))
+  assigns(memory_slice(w, sizeof(polyveck)))
+);
+
 /*************************************************
  * Name:        polyveck_sub
  *

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -136,7 +136,16 @@ void polyveck_uniform_eta(polyveck *v, const uint8_t seed[MLDSA_CRHBYTES],
  *
  * Arguments:   - polyveck *v: pointer to input/output vector
  **************************************************/
-void polyveck_reduce(polyveck *v);
+void polyveck_reduce(polyveck *v)
+__contract__(
+  requires(memory_no_alias(v, sizeof(polyveck)))
+  requires(forall(k0, 0, MLDSA_K,
+    array_bound(v->vec[k0].coeffs, 0, MLDSA_N, INT32_MIN, REDUCE_DOMAIN_MAX)))
+  assigns(memory_slice(v, sizeof(polyveck)))
+  ensures(forall(k1, 0, MLDSA_K,
+    array_bound(v->vec[k1].coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX)))
+);
+
 #define polyveck_caddq MLD_NAMESPACE(polyveck_caddq)
 /*************************************************
  * Name:        polyveck_caddq

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -55,7 +55,17 @@ __contract__(
  *              - const polyvecl *u: pointer to first summand
  *              - const polyvecl *v: pointer to second summand
  **************************************************/
-void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
+void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v)
+__contract__(
+  requires(memory_no_alias(w, sizeof(polyvecl)))
+  requires(memory_no_alias(u, sizeof(polyvecl)))
+  requires(memory_no_alias(v, sizeof(polyvecl)))
+  requires(forall(k0, 0, MLDSA_L,
+    forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] + v->vec[k0].coeffs[k1] <= INT32_MAX)))
+  requires(forall(k2, 0, MLDSA_L,
+    forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] + v->vec[k2].coeffs[k3] >= INT32_MIN)))
+  assigns(memory_slice(w, sizeof(polyvecl)))
+);
 
 #define polyvecl_ntt MLD_NAMESPACE(polyvecl_ntt)
 /*************************************************

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -180,6 +180,7 @@ __contract__(
   assigns(memory_slice(w, sizeof(polyveck)))
 );
 
+#define polyveck_sub MLD_NAMESPACE(polyveck_sub)
 /*************************************************
  * Name:        polyveck_sub
  *
@@ -191,8 +192,18 @@ __contract__(
  *              - const polyveck *v: pointer to second input vector to be
  *                                   subtracted from first input vector
  **************************************************/
-#define polyveck_sub MLD_NAMESPACE(polyveck_sub)
-void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);
+void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v)
+__contract__(
+  requires(memory_no_alias(w, sizeof(polyveck)))
+  requires(memory_no_alias(u, sizeof(polyveck)))
+  requires(memory_no_alias(v, sizeof(polyveck)))
+  requires(forall(k0, 0, MLDSA_K,
+    forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] - v->vec[k0].coeffs[k1] <= INT32_MAX)))
+  requires(forall(k2, 0, MLDSA_K,
+    forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] - v->vec[k2].coeffs[k3] >= INT32_MIN)))
+  assigns(memory_slice(w, sizeof(polyveck)))
+);
+
 #define polyveck_shiftl MLD_NAMESPACE(polyveck_shiftl)
 /*************************************************
  * Name:        polyveck_shiftl

--- a/proofs/cbmc/polyveck_add/Makefile
+++ b/proofs/cbmc/polyveck_add/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_add_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_add
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_add
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_add
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyveck_add
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_add/polyveck_add_harness.c
+++ b/proofs/cbmc/polyveck_add/polyveck_add_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyveck *a, *b, *c;
+  polyveck_add(a, b, c);
+}

--- a/proofs/cbmc/polyveck_pack_w1/Makefile
+++ b/proofs/cbmc/polyveck_pack_w1/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_pack_w1_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_pack_w1
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_w1.0:8 # Largest value of MLDSA_K
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_pack_w1
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyw1_pack
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyveck_pack_w1
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_pack_w1/polyveck_pack_w1_harness.c
+++ b/proofs/cbmc/polyveck_pack_w1/polyveck_pack_w1_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyveck *a;
+  uint8_t *b;
+  polyveck_pack_w1(b, a);
+}

--- a/proofs/cbmc/polyveck_reduce/Makefile
+++ b/proofs/cbmc/polyveck_reduce/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_reduce_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_reduce
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_reduce
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_reduce
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyveck_reduce
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_reduce/polyveck_reduce_harness.c
+++ b/proofs/cbmc/polyveck_reduce/polyveck_reduce_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyveck *a;
+  polyveck_reduce(a);
+}

--- a/proofs/cbmc/polyveck_sub/Makefile
+++ b/proofs/cbmc/polyveck_sub/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_sub_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_sub
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET += 
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_sub
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_sub
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyveck_sub
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_sub/polyveck_sub_harness.c
+++ b/proofs/cbmc/polyveck_sub/polyveck_sub_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyveck *a, *b, *c;
+  polyveck_sub(a, b, c);
+}

--- a/proofs/cbmc/polyveck_use_hint/Makefile
+++ b/proofs/cbmc/polyveck_use_hint/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_use_hint_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_use_hint
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_use_hint
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_use_hint
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyveck_use_hint
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_use_hint/polyveck_use_hint_harness.c
+++ b/proofs/cbmc/polyveck_use_hint/polyveck_use_hint_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyveck *a, *b, *c;
+  polyveck_use_hint(a, b, c);
+}

--- a/proofs/cbmc/polyvecl_add/Makefile
+++ b/proofs/cbmc/polyvecl_add/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvecl_add_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvecl_add
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_add
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_add
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvecl_add
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvecl_add/polyvecl_add_harness.c
+++ b/proofs/cbmc/polyvecl_add/polyvecl_add_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyvecl *a, *b, *c;
+  polyvecl_add(a, b, c);
+}

--- a/proofs/cbmc/polyvecl_reduce/Makefile
+++ b/proofs/cbmc/polyvecl_reduce/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvecl_reduce_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvecl_reduce
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_reduce
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_reduce
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvecl_reduce
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvecl_reduce/polyvecl_reduce_harness.c
+++ b/proofs/cbmc/polyvecl_reduce/polyvecl_reduce_harness.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  polyvecl *a;
+  polyvecl_reduce(a);
+}


### PR DESCRIPTION
- Depends on https://github.com/pq-code-package/mldsa-native/pull/140
- Resolves https://github.com/pq-code-package/mldsa-native/issues/116
- Resolves https://github.com/pq-code-package/mldsa-native/issues/117
- Resolves https://github.com/pq-code-package/mldsa-native/issues/124
- Resolves https://github.com/pq-code-package/mldsa-native/issues/126
- Resolves https://github.com/pq-code-package/mldsa-native/issues/127
- Resolves https://github.com/pq-code-package/mldsa-native/issues/136
- Resolves https://github.com/pq-code-package/mldsa-native/issues/135

`polyvecl_add`, `polyveck_add`, `polyveck_sub`,`polyveck_use_hint`, `polyveck_reduce`, `polyvecl_reduce` were too slow when using unrolling - I instead did a direct proof with the workaround from #92. I added them to #102 to remove the whole-struct assignments once the corresponding CBMC issue is resolved.