### PR TITLE
Add spec and proofs for load64 and store64

### DIFF
--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -25,11 +25,17 @@
  * Returns the loaded 64-bit unsigned integer
  **************************************************/
 static uint64_t load64(const uint8_t x[8])
+__contract__(
+  requires(memory_no_alias(x, sizeof(uint8_t) * 8))
+)
 {
   unsigned int i;
   uint64_t r = 0;
 
   for (i = 0; i < 8; i++)
+  __loop__(
+    invariant(i <= 8)
+  )
   {
     r |= (uint64_t)x[i] << 8 * i;
   }
@@ -47,12 +53,20 @@ static uint64_t load64(const uint8_t x[8])
  *              - uint64_t u: input 64-bit unsigned integer
  **************************************************/
 static void store64(uint8_t x[8], uint64_t u)
+__contract__(
+  requires(memory_no_alias(x, sizeof(uint8_t) * 8))
+  assigns(memory_slice(x, sizeof(uint8_t) * 8))
+)
 {
   unsigned int i;
 
   for (i = 0; i < 8; i++)
+  __loop__(
+    invariant(i <= 8)
+  )
   {
-    x[i] = u >> 8 * i;
+    /* Explicitly truncate to uint8_t */
+    x[i] = (uint8_t)((u >> (8 * i)) & 0xFF);
   }
 }
 

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "../cbmc.h"
 
 #define SHAKE128_RATE 168
 #define SHAKE256_RATE 136

--- a/proofs/cbmc/load64/Makefile
+++ b/proofs/cbmc/load64/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = load64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = load64
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=load64
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = load64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/load64/load64_harness.c
+++ b/proofs/cbmc/load64/load64_harness.c
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+extern uint64_t load64(const uint8_t x[8]);
+
+void harness(void)
+{
+  const uint8_t *x;
+  load64(x);
+}

--- a/proofs/cbmc/store64/Makefile
+++ b/proofs/cbmc/store64/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = store64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = store64
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=store64
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = store64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/store64/store64_harness.c
+++ b/proofs/cbmc/store64/store64_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+extern void store64(uint8_t x[8], uint64_t u);
+
+void harness(void)
+{
+  uint8_t *x;
+  uint64_t u;
+  store64(x, u);
+}


### PR DESCRIPTION
This PR adds the spec and proofs for load64 and store64.

Notes::
	- Change the signature of function `store64` from `static void store64(uint8_t x[8], uint64_t u)` to `static void store64(uint8_t x[8], const uint64_t u)`, marking the input as a `const`.
	-  Add explicit `& 0xFF` before casting `uint64_t u` to `uint8_t x[i]` to prevent overlflows