### PR TITLE
Add spec and proofs for Keccak dependent functions

### DIFF
--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -815,6 +815,9 @@ void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen)
   keccak_absorb_once(s, SHA3_256_RATE, in, inlen, 0x06);
   KeccakF1600_StatePermute(s);
   for (i = 0; i < 4; i++)
+  __loop__(
+    invariant(i <= 4)
+  )
   {
     store64(h + 8 * i, s[i]);
   }

--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -807,7 +807,7 @@ void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
  *              - const uint8_t *in: pointer to input
  *              - size_t inlen: length of input in bytes
  **************************************************/
-void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen)
+void sha3_256(uint8_t h[SHA3_256_HASHBYTES], const uint8_t *in, size_t inlen)
 {
   unsigned int i;
   uint64_t s[25];
@@ -832,14 +832,17 @@ void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen)
  *              - const uint8_t *in: pointer to input
  *              - size_t inlen: length of input in bytes
  **************************************************/
-void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen)
+void sha3_512(uint8_t h[SHA3_512_HASHBYTES], const uint8_t *in, size_t inlen)
 {
   unsigned int i;
-  uint64_t s[25];
+  uint64_t s[MLD_KECCAK_LANES];
 
   keccak_absorb_once(s, SHA3_512_RATE, in, inlen, 0x06);
   KeccakF1600_StatePermute(s);
   for (i = 0; i < 8; i++)
+  __loop__(
+    invariant(i <= 8)
+  )
   {
     store64(h + 8 * i, s[i]);
   }

--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -92,7 +92,11 @@ const uint64_t KeccakF_RoundConstants[NROUNDS] = {
  *
  * Arguments:   - uint64_t *state: pointer to input/output Keccak state
  **************************************************/
-static void KeccakF1600_StatePermute(uint64_t state[25])
+static void KeccakF1600_StatePermute(uint64_t state[MLD_KECCAK_LANES])
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * MLD_KECCAK_LANES))
+  assigns(memory_slice(state, sizeof(uint64_t) * MLD_KECCAK_LANES))
+)
 {
   int round;
 
@@ -137,6 +141,10 @@ static void KeccakF1600_StatePermute(uint64_t state[25])
   Asu = state[24];
 
   for (round = 0; round < NROUNDS; round += 2)
+  __loop__(
+    invariant(round >= 0)
+    invariant(round <= NROUNDS && round % 2 == 0)
+  )
   {
     /* prepareTheta */
     BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -14,6 +14,7 @@
 #define SHA3_256_RATE 136
 #define SHA3_512_RATE 72
 #define MLD_KECCAK_LANES 25
+#define SHA3_256_HASHBYTES 32
 
 #define FIPS202_NAMESPACE(s) mldsa_fips202_ref_##s
 
@@ -69,7 +70,13 @@ void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
 #define shake256 FIPS202_NAMESPACE(shake256)
 void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
 #define sha3_256 FIPS202_NAMESPACE(sha3_256)
-void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen);
+void sha3_256(uint8_t h[SHA3_256_HASHBYTES], const uint8_t *in, size_t inlen)
+__contract__(
+  requires(memory_no_alias(in, inlen))
+  requires(memory_no_alias(h, SHA3_256_HASHBYTES))
+  assigns(memory_slice(h, SHA3_256_HASHBYTES))
+);
+
 #define sha3_512 FIPS202_NAMESPACE(sha3_512)
 void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen);
 

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -15,6 +15,7 @@
 #define SHA3_512_RATE 72
 #define MLD_KECCAK_LANES 25
 #define SHA3_256_HASHBYTES 32
+#define SHA3_512_HASHBYTES 64
 
 #define FIPS202_NAMESPACE(s) mldsa_fips202_ref_##s
 
@@ -78,6 +79,11 @@ __contract__(
 );
 
 #define sha3_512 FIPS202_NAMESPACE(sha3_512)
-void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen);
+void sha3_512(uint8_t h[SHA3_512_HASHBYTES], const uint8_t *in, size_t inlen)
+__contract__(
+  requires(memory_no_alias(in, inlen))
+  requires(memory_no_alias(h, SHA3_512_HASHBYTES))
+  assigns(memory_slice(h, SHA3_512_HASHBYTES))
+);
 
 #endif /* !MLD_FIPS202_FIPS202_H */

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -13,12 +13,13 @@
 #define SHAKE256_RATE 136
 #define SHA3_256_RATE 136
 #define SHA3_512_RATE 72
+#define MLD_KECCAK_LANES 25
 
 #define FIPS202_NAMESPACE(s) mldsa_fips202_ref_##s
 
 typedef struct
 {
-  uint64_t s[25];
+  uint64_t s[MLD_KECCAK_LANES];
   unsigned int pos;
 } keccak_state;
 

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -54,7 +54,13 @@ void shake256_finalize(keccak_state *state);
 #define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)
 void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
 #define shake256_absorb_once FIPS202_NAMESPACE(shake256_absorb_once)
-void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen)
+__contract__(
+  requires(memory_no_alias(state, sizeof(keccak_state)))
+  requires(memory_no_alias(in, inlen))
+  assigns(memory_slice(state, sizeof(keccak_state)))
+);
+
 #define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
 void shake256_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
 

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -35,7 +35,13 @@ void shake128_finalize(keccak_state *state);
 #define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
 void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
 #define shake128_absorb_once FIPS202_NAMESPACE(shake128_absorb_once)
-void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen)
+__contract__(
+  requires(memory_no_alias(state, sizeof(keccak_state)))
+  requires(memory_no_alias(in, inlen))
+  assigns(memory_slice(state, sizeof(keccak_state)))
+);
+
 #define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
 void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
 

--- a/proofs/cbmc/Makefile_params.common
+++ b/proofs/cbmc/Makefile_params.common
@@ -5,6 +5,7 @@ ifndef MLDSA_MODE
 endif
 
 MLDSA_MODE ?= 3
+FIPS202_NAMESPACE = mldsa_fips202_ref_
 
 ifeq ($(MLDSA_MODE),2)
      MLD_NAMESPACE=MLD_44_ref_

--- a/proofs/cbmc/keccakf1600_absorb_once/Makefile
+++ b/proofs/cbmc/keccakf1600_absorb_once/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccakf1600_absorb_once_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccakf1600_absorb_once
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=keccak_absorb_once
+USE_FUNCTION_CONTRACTS=KeccakF1600_StatePermute load64
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = keccak_absorb_once
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccakf1600_absorb_once/keccakf1600_absorb_once_harness.c
+++ b/proofs/cbmc/keccakf1600_absorb_once/keccakf1600_absorb_once_harness.c
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+extern void keccak_absorb_once(uint64_t s[MLD_KECCAK_LANES],
+                               const unsigned int r, const uint8_t *in,
+                               size_t inlen, uint8_t p);
+
+void harness(void)
+{
+  uint64_t *s;
+  const unsigned int r;
+  const uint8_t *in;
+  size_t inlen;
+  uint8_t p;
+
+  keccak_absorb_once(s, r, in, inlen, p);
+}

--- a/proofs/cbmc/keccakf1600_permute/Makefile
+++ b/proofs/cbmc/keccakf1600_permute/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccakf1600_permute_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccakf1600_permute
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=KeccakF1600_StatePermute
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = KeccakF1600_StatePermute
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccakf1600_permute/keccakf1600_permute_harness.c
+++ b/proofs/cbmc/keccakf1600_permute/keccakf1600_permute_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+extern void KeccakF1600_StatePermute(uint64_t state[25]);
+
+void harness(void)
+{
+  uint64_t *a;
+
+  KeccakF1600_StatePermute(a);
+}

--- a/proofs/cbmc/sha3_256/Makefile
+++ b/proofs/cbmc/sha3_256/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = sha3_256_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = sha3_256
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)sha3_256
+USE_FUNCTION_CONTRACTS=keccak_absorb_once KeccakF1600_StatePermute
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = sha3_256
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/sha3_256/sha3_256_harness.c
+++ b/proofs/cbmc/sha3_256/sha3_256_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  uint8_t *h;
+  const uint8_t *in;
+  size_t inlen;
+  
+  sha3_256(h, in, inlen);
+}

--- a/proofs/cbmc/sha3_512/Makefile
+++ b/proofs/cbmc/sha3_512/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = sha3_512_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = sha3_512
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)sha3_512
+USE_FUNCTION_CONTRACTS=keccak_absorb_once KeccakF1600_StatePermute
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = sha3_512
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/sha3_512/sha3_512_harness.c
+++ b/proofs/cbmc/sha3_512/sha3_512_harness.c
@@ -9,5 +9,5 @@ void harness(void)
   const uint8_t *in;
   size_t inlen;
 
-  sha3_256(h, in, inlen);
+  sha3_512(h, in, inlen);
 }

--- a/proofs/cbmc/shake128_absorb_once/Makefile
+++ b/proofs/cbmc/shake128_absorb_once/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake128_absorb_once_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake128_absorb_once
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake128_absorb_once
+USE_FUNCTION_CONTRACTS=keccak_absorb_once
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = shake128_absorb_once
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake128_absorb_once/shake128_absorb_once_harness.c
+++ b/proofs/cbmc/shake128_absorb_once/shake128_absorb_once_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  keccak_state *s;
+  const uint8_t *in;
+  size_t inlen;
+
+  shake128_absorb_once(s, in, inlen);
+}

--- a/proofs/cbmc/shake256_absorb_once/Makefile
+++ b/proofs/cbmc/shake256_absorb_once/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake256_absorb_once_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake256_absorb_once
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake256_absorb_once
+USE_FUNCTION_CONTRACTS=keccak_absorb_once
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = shake256_absorb_once
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake256_absorb_once/shake256_absorb_once_harness.c
+++ b/proofs/cbmc/shake256_absorb_once/shake256_absorb_once_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  keccak_state *s;
+  const uint8_t *in;
+  size_t inlen;
+
+  shake256_absorb_once(s, in, inlen);
+}


### PR DESCRIPTION
This PR adds the spec and proofs for different Keccak dependent functions including:  

 - `KeccakF1600_StatePermute`
 - `keccak_absorb_once`
 - `shake128_absorb_once`
 - `shake256_absorb_once`
 - `sha3_256`
 - `sha3_512`
