### PR TITLE
Add common.h and sys.h

### DIFF
--- a/mldsa/common.h
+++ b/mldsa/common.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MLD_COMMON_H
+#define MLD_COMMON_H
+
+#include "params.h"
+#include "sys.h"
+
+#endif /* !MLD_COMMON_H */

--- a/mldsa/ntt.c
+++ b/mldsa/ntt.c
@@ -5,7 +5,6 @@
 #include <stdint.h>
 
 #include "ntt.h"
-#include "params.h"
 #include "reduce.h"
 
 static int32_t mld_fqmul(int32_t a, int32_t b)

--- a/mldsa/ntt.h
+++ b/mldsa/ntt.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 #include "cbmc.h"
-#include "params.h"
+#include "common.h"
 
 /* Absolute exclusive upper bound for the output of the forward NTT */
 #define MLD_NTT_BOUND (9 * MLDSA_Q)

--- a/mldsa/packing.c
+++ b/mldsa/packing.c
@@ -4,8 +4,8 @@
  */
 #include <string.h>
 
+#include "common.h"
 #include "packing.h"
-#include "params.h"
 #include "poly.h"
 #include "polyvec.h"
 

--- a/mldsa/packing.h
+++ b/mldsa/packing.h
@@ -6,7 +6,6 @@
 #define MLD_PACKING_H
 
 #include <stdint.h>
-#include "params.h"
 #include "polyvec.h"
 
 #define pack_pk MLD_NAMESPACE(pack_pk)

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -5,7 +5,6 @@
 #include <stdint.h>
 
 #include "ntt.h"
-#include "params.h"
 #include "poly.h"
 #include "reduce.h"
 #include "rounding.h"

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -7,8 +7,8 @@
 
 #include <stdint.h>
 #include "cbmc.h"
+#include "common.h"
 #include "ntt.h"
-#include "params.h"
 #include "reduce.h"
 #include "rounding.h"
 

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -4,7 +4,7 @@
  */
 #include <stdint.h>
 
-#include "params.h"
+#include "common.h"
 #include "poly.h"
 #include "polyvec.h"
 

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 #include "cbmc.h"
-#include "params.h"
+#include "common.h"
 #include "poly.h"
 
 /* Vectors of polynomials of length MLDSA_L */

--- a/mldsa/reduce.c
+++ b/mldsa/reduce.c
@@ -4,7 +4,6 @@
  */
 #include <stdint.h>
 
-#include "params.h"
 #include "reduce.h"
 
 /*************************************************

--- a/mldsa/reduce.h
+++ b/mldsa/reduce.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 #include "cbmc.h"
-#include "params.h"
+#include "common.h"
 
 #define MONT -4186625 /* 2^32 % MLDSA_Q */
 #define REDUCE_DOMAIN_MAX (INT32_MAX - (1 << 22))

--- a/mldsa/rounding.c
+++ b/mldsa/rounding.c
@@ -4,7 +4,6 @@
  */
 #include <stdint.h>
 
-#include "params.h"
 #include "rounding.h"
 
 

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 #include "cbmc.h"
-#include "params.h"
+#include "common.h"
 
 #define MLD_2_POW_D (1 << MLDSA_D)
 

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -8,7 +8,6 @@
 #include "cbmc.h"
 #include "fips202/fips202.h"
 #include "packing.h"
-#include "params.h"
 #include "poly.h"
 #include "polyvec.h"
 #include "randombytes.h"

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -7,7 +7,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "params.h"
+#include "common.h"
 #include "poly.h"
 #include "polyvec.h"
 

--- a/mldsa/symmetric.h
+++ b/mldsa/symmetric.h
@@ -6,7 +6,6 @@
 #define MLD_SYMMETRIC_H
 
 #include <stdint.h>
-#include "params.h"
 
 #include "fips202/fips202.h"
 

--- a/mldsa/sys.h
+++ b/mldsa/sys.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) 2025 The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MLD_SYS_H
+#define MLD_SYS_H
+
+/* Check if we're running on an AArch64 little endian system. _M_ARM64 is set by
+ * MSVC. */
+#if defined(__AARCH64EL__) || defined(_M_ARM64)
+#define MLD_SYS_AARCH64
+#endif
+
+/* Check if we're running on an AArch64 big endian system. */
+#if defined(__AARCH64EB__)
+#define MLD_SYS_AARCH64_EB
+#endif
+
+#if defined(__x86_64__)
+#define MLD_SYS_X86_64
+#if defined(__AVX2__)
+#define MLD_SYS_X86_64_AVX2
+#endif
+#endif /* __x86_64__ */
+
+#if defined(_WIN32)
+#define MLD_SYS_WINDOWS
+#endif
+
+#if !defined(MLD_CONFIG_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
+#define MLD_HAVE_INLINE_ASM
+#endif
+
+/* Try to find endianness, if not forced through CFLAGS already */
+#if !defined(MLD_SYS_LITTLE_ENDIAN) && !defined(MLD_SYS_BIG_ENDIAN)
+#if defined(__BYTE_ORDER__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define MLD_SYS_LITTLE_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define MLD_SYS_BIG_ENDIAN
+#else
+#error "__BYTE_ORDER__ defined, but don't recognize value."
+#endif
+#endif /* __BYTE_ORDER__ */
+#endif /* !MLD_SYS_LITTLE_ENDIAN && !MLD_SYS_BIG_ENDIAN */
+
+/* If MLD_FORCE_AARCH64 is set, assert that we're indeed on an AArch64 system.
+ */
+#if defined(MLD_FORCE_AARCH64) && !defined(MLD_SYS_AARCH64)
+#error "MLD_FORCE_AARCH64 is set, but we don't seem to be on an AArch64 system."
+#endif
+
+/* If MLD_FORCE_AARCH64_EB is set, assert that we're indeed on a big endian
+ * AArch64 system. */
+#if defined(MLD_FORCE_AARCH64_EB) && !defined(MLD_SYS_AARCH64_EB)
+#error \
+    "MLD_FORCE_AARCH64_EB is set, but we don't seem to be on an AArch64 system."
+#endif
+
+/* If MLD_FORCE_X86_64 is set, assert that we're indeed on an X86_64 system. */
+#if defined(MLD_FORCE_X86_64) && !defined(MLD_SYS_X86_64)
+#error "MLD_FORCE_X86_64 is set, but we don't seem to be on an X86_64 system."
+#endif
+
+/*
+ * C90 does not have the inline compiler directive yet.
+ * We don't use it in C90 builds.
+ * However, in that case the compiler warns about some inline functions in
+ * header files not being used in every compilation unit that includes that
+ * header. To work around it we silence that warning in that case using
+ * __attribute__((unused)).
+ */
+
+/* Do not use inline for C90 builds*/
+#if !defined(MLD_INLINE)
+#if !defined(inline)
+#if defined(_MSC_VER)
+#define MLD_INLINE __inline
+/* Don't combine __inline and __forceinline */
+#define MLD_ALWAYS_INLINE __forceinline
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define MLD_INLINE inline
+#define MLD_ALWAYS_INLINE MLD_INLINE __attribute__((always_inline))
+#else
+#define MLD_INLINE __attribute__((unused))
+#define MLD_ALWAYS_INLINE MLD_INLINE
+#endif
+
+#else /* !inline */
+#define MLD_INLINE inline
+#define MLD_ALWAYS_INLINE MLD_INLINE __attribute__((always_inline))
+#endif /* inline */
+#endif /* !MLD_INLINE */
+
+/*
+ * C90 does not have the restrict compiler directive yet.
+ * We don't use it in C90 builds.
+ */
+#if !defined(restrict)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define MLD_RESTRICT restrict
+#else
+#define MLD_RESTRICT
+#endif
+
+#else /* !restrict */
+
+#define MLD_RESTRICT restrict
+#endif /* restrict */
+
+#define MLD_DEFAULT_ALIGN 32
+#define MLD_ALIGN_UP(N) \
+  ((((N) + (MLD_DEFAULT_ALIGN - 1)) / MLD_DEFAULT_ALIGN) * MLD_DEFAULT_ALIGN)
+#if defined(__GNUC__)
+#define MLD_ALIGN __attribute__((aligned(MLD_DEFAULT_ALIGN)))
+#elif defined(_MSC_VER)
+#define MLD_ALIGN __declspec(align(MLD_DEFAULT_ALIGN))
+#else
+#define MLD_ALIGN /* No known support for alignment constraints */
+#endif
+
+
+/* New X86_64 CPUs support Conflow-flow protection using the CET instructions.
+ * When enabled (through -fcf-protection=), all compilation units (including
+ * empty ones) need to support CET for this to work.
+ * For assembly, this means that source files need to signal support for
+ * CET by setting the appropriate note.gnu.property section.
+ * This can be achieved by including the <cet.h> header in all assembly file.
+ * This file also provides the _CET_ENDBR macro which needs to be placed at
+ * every potential target of an indirect branch.
+ * If CET is enabled _CET_ENDBR maps to the endbr64 instruction, otherwise
+ * it is empty.
+ * In case the compiler does not support CET (e.g., <gcc8, <clang11),
+ * the __CET__ macro is not set and we default to nothing.
+ * Note that we only issue _CET_ENDBR instructions through the MLD_ASM_FN_SYMBOL
+ * macro as the global symbols are the only possible targets of indirect
+ * branches in our code.
+ */
+#if defined(MLD_SYS_X86_64)
+#if defined(__CET__)
+#include <cet.h>
+#define MLD_CET_ENDBR _CET_ENDBR
+#else
+#define MLD_CET_ENDBR
+#endif
+#endif /* MLD_SYS_X86_64 */
+
+#if defined(MLD_CONFIG_CT_TESTING_ENABLED) && !defined(__ASSEMBLER__)
+#include <valgrind/memcheck.h>
+#define MLD_CT_TESTING_SECRET(ptr, len) \
+  VALGRIND_MAKE_MEM_UNDEFINED((ptr), (len))
+#define MLD_CT_TESTING_DECLASSIFY(ptr, len) \
+  VALGRIND_MAKE_MEM_DEFINED((ptr), (len))
+#else /* MLD_CONFIG_CT_TESTING_ENABLED && !__ASSEMBLER__ */
+#define MLD_CT_TESTING_SECRET(ptr, len) \
+  do                                    \
+  {                                     \
+  } while (0)
+#define MLD_CT_TESTING_DECLASSIFY(ptr, len) \
+  do                                        \
+  {                                         \
+  } while (0)
+#endif /* !(MLD_CONFIG_CT_TESTING_ENABLED && !__ASSEMBLER__) */
+
+#if defined(__GNUC__) || defined(clang)
+#define MLD_MUST_CHECK_RETURN_VALUE __attribute__((warn_unused_result))
+#else
+#define MLD_MUST_CHECK_RETURN_VALUE
+#endif
+
+#endif /* !MLD_SYS_H */

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -491,8 +491,10 @@ def adjust_header_guard_for_filename(content, header_file):
     if header_file in exceptions.keys():
         guard_name = exceptions[header_file]
 
-    def gen_copyright():
+    def gen_copyright(include_mlkem=False):
         yield "/*"
+        if include_mlkem is True:
+            yield " * Copyright (c) 2024-2025 The mlkem-native project authors"
         yield " * Copyright (c) 2025 The mldsa-native project authors"
         yield " * SPDX-License-Identifier: Apache-2.0"
         yield " */"
@@ -506,14 +508,18 @@ def adjust_header_guard_for_filename(content, header_file):
         yield ""
 
     cr = list(gen_copyright())
+    cr_alt = list(gen_copyright(include_mlkem=True))
     guard = list(gen_guard())
     footer = list(gen_footer())
 
-    # Check if header file begins with copyright notice; otherwise, add it.
-    if content[: len(cr)] != cr:
+    # Check if header file begins with copyright notice
+    if content[: len(cr)] == cr:
+        i = len(cr)
+    elif content[: len(cr_alt)] == cr_alt:
+        i = len(cr_alt)
+    else:
         assert False
-        content = cr + content
-    i = len(cr)
+
     while content[i].strip() == "":
         i += 1
     # Check if header file has some guard -- if so, drop it


### PR DESCRIPTION
* Resolves #156 

Following mlkem-native, this commit adds two new header files, common.h and sys.h.

sys.h conducts system detection and sets various helper macros such as MLD_ALIGN accordingly. It is identical to the sys.h header in mlkem-native, modulo the MLK_ -> MLD_ renaming.

The common header file common.h should be included by all compilation units, including assembly files. It so far pulls in params.h and sys.h, but will be extended in the future.

All includes of params.h are replaced by includes of common.h.