### PR TITLE
CBMC: Add proof and contract for shake128_squeezeblocks

### DIFF
--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -580,7 +580,7 @@ static void keccak_squeezeblocks(uint8_t *out, size_t nblocks,
                                  uint64_t s[MLD_KECCAK_LANES], unsigned int r)
 __contract__(
   requires(r == SHAKE128_RATE || r == SHAKE256_RATE)
-  requires(nblocks < (UINT32_MAX / r))
+  requires(nblocks <= 8 /* somewhat arbitrary bound */)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   requires(memory_no_alias(out, nblocks * r))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -45,7 +45,14 @@ __contract__(
 );
 
 #define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
-void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
+void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state)
+__contract__(
+  requires(nblocks < (UINT32_MAX / SHAKE128_RATE))
+  requires(memory_no_alias(state, sizeof(keccak_state)))
+  requires(memory_no_alias(out, nblocks * SHAKE128_RATE))
+  assigns(memory_slice(state, sizeof(keccak_state)))
+  assigns(memory_slice(out, nblocks * SHAKE128_RATE))
+);
 
 #define shake256_init FIPS202_NAMESPACE(shake256_init)
 void shake256_init(keccak_state *state)

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -47,7 +47,7 @@ __contract__(
 #define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
 void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state)
 __contract__(
-  requires(nblocks < (UINT32_MAX / SHAKE128_RATE))
+  requires(nblocks <= 8 /* somewhat arbitrary bound */)
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(out, nblocks * SHAKE128_RATE))
   assigns(memory_slice(state, sizeof(keccak_state)))
@@ -90,7 +90,7 @@ __contract__(
 #define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
 void shake256_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state)
 __contract__(
-  requires(nblocks < (UINT32_MAX / SHAKE256_RATE))
+  requires(nblocks <= 8 /* somewhat arbitrary bound */)
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(out, nblocks * SHAKE256_RATE))
   assigns(memory_slice(state, sizeof(keccak_state)))

--- a/proofs/cbmc/shake128_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake128_squeezeblocks/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake128_squeezeblocks_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake128_squeezeblocks
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake128_squeezeblocks
+USE_FUNCTION_CONTRACTS=keccak_squeezeblocks
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = shake128_squeezeblocks
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake128_squeezeblocks/shake128_squeezeblocks_harness.c
+++ b/proofs/cbmc/shake128_squeezeblocks/shake128_squeezeblocks_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  uint8_t *out;
+  size_t nblocks;
+  keccak_state *state;
+
+  shake128_squeezeblocks(out, nblocks, state);
+}


### PR DESCRIPTION
Resolves https://github.com/pq-code-package/mldsa-native/issues/142

Was reviewing Mila's current PR and was testing functionality of the `keccak_squeezeblocks` contract by thinking through possible values of `r`. I wrote this test code to test it for the case of `shake128_squeezeblocks` and thought I may as well complete the proof (as the remaining poly/polyvec functions now rely on the fips202 ones for sampling).

Depends on https://github.com/pq-code-package/mldsa-native/pull/187