### PR TITLE
Fix reporting of total proof count in cbmc-starter-kit

### DIFF
--- a/proofs/cbmc/lib/summarize.py
+++ b/proofs/cbmc/lib/summarize.py
@@ -88,13 +88,13 @@ def _get_status_and_proof_summaries(run_dict):
     count_statuses = {}
     proofs = [["Proof", "Status", "Duration (in s)"]]
     for proof_pipeline in run_dict["pipelines"]:
+        if proof_pipeline["name"] == "print_tool_versions":
+            continue
         status_pretty_name = proof_pipeline["status"].title().replace("_", " ")
         try:
             count_statuses[status_pretty_name] += 1
         except KeyError:
             count_statuses[status_pretty_name] = 1
-        if proof_pipeline["name"] == "print_tool_versions":
-            continue
         duration = 0
         for stage in proof_pipeline["ci_stages"]:
             for job in stage["jobs"]:


### PR DESCRIPTION
CBMC-Starter_Kit PR#207 (https://github.com/model-checking/cbmc-starter-kit/pull/207)
fixed a defect where the total number of proofs reported is one too big when
cbmc-run-proofs.py --summarize is run.

This PR imports that fix into the mldsa-native repo.
