### PR TITLE
CI: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  


### PR DESCRIPTION
The mldsa-native CI uses quite a few external dependencies (such as nix-community/cache-nix-action, aws-actions/configure-aws-credentials, etc.). We should keep those up to date to avoid problems in the long term. This commit adds a dependabot configuration that will check for new versions once a month and opens PRs in case there are updates.