### PR TITLE
Add EC2 benchmarking

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -92,3 +92,67 @@ jobs:
           nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci-bench' }}
           cross_prefix: ${{ matrix.target.cross_prefix }}
           opt: false
+  ec2_all:
+    name: ${{ matrix.target.name }} ${{ matrix.opt.name }}
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: Graviton2
+            ec2_instance_type: t4g.small
+            ec2_ami: ubuntu-latest (aarch64)
+            archflags: -mcpu=cortex-a76 -march=armv8.2-a
+            cflags: "-flto"
+            perf: PERF
+          - name: Graviton3
+            ec2_instance_type: c7g.medium
+            ec2_ami: ubuntu-latest (aarch64)
+            archflags: -march=armv8.4-a+sha3
+            cflags: "-flto"
+            perf: PERF
+          - name: Graviton4
+            ec2_instance_type: c8g.medium
+            ec2_ami: ubuntu-latest (aarch64)
+            archflags: -march=armv9-a+sha3
+            cflags: "-flto"
+            perf: PERF
+          - name: AMD EPYC 4th gen (c7a)
+            ec2_instance_type: c7a.medium
+            ec2_ami: ubuntu-latest (x86_64)
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver4
+            cflags: "-flto"
+            perf: PMU
+          - name: Intel Xeon 4th gen (c7i)
+            ec2_instance_type: c7i.metal-24xl
+            ec2_ami: ubuntu-latest (x86_64)
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=sapphirerapids
+            cflags: "-flto"
+            perf: PMU
+          - name: AMD EPYC 3rd gen (c6a)
+            ec2_instance_type: c6a.large
+            ec2_ami: ubuntu-latest (x86_64)
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver3
+            cflags: "-flto"
+            perf: PMU
+          - name: Intel Xeon 3rd gen (c6i)
+            ec2_instance_type: c6i.large
+            ec2_ami: ubuntu-latest (x86_64)
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=icelake-server
+            cflags: "-flto"
+            perf: PMU
+    uses: ./.github/workflows/bench_ec2_reusable.yml
+    if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
+    with:
+      ec2_instance_type: ${{ matrix.target.ec2_instance_type }}
+      ec2_ami: ${{ matrix.target.ec2_ami }}
+      archflags: ${{ matrix.target.archflags }}
+      cflags: ${{ matrix.target.cflags }}
+      opt: "all"
+      store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
+      name: ${{ matrix.target.name }}
+      perf: ${{ matrix.target.perf }}
+    secrets: inherit

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: bench-ec2-any
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: Alternative name of instance
+        default: Graviton2
+      ec2_instance_type:
+        description: Type if EC2 instance to benchmark on
+        default: t4g.small
+      ec2_ami:
+        description: AMI ID
+        type: choice
+        options:
+          - ubuntu-latest (x86_64)
+          - ubuntu-latest (aarch64)
+          - ubuntu-latest (custom AMI)
+        default: ubuntu-latest (aarch64)
+      ec2_ami_id:
+        description: AMI ID
+        required: false
+        default: ami-0c4e709339fa8521a
+      cflags:
+        description: Custom CFLAGS for compilation
+        default:
+      archflags:
+        description: Custom ARCH flags for compilation
+        default: ''
+      opt:
+        description: Benchmark optimized, non-optimized, or both
+        type: choice
+        options:
+           - all
+           - opt
+           - no_opt
+      bench_extra_args:
+        description: Additional command line to be appended to `tests bench` script
+        default: ''
+      compiler:
+        description: Compiler to use. When unset, default nix shell is used.
+        default: ''
+      additional_packages:
+        description: Additional packages to install when custom compiler is used.
+        default: ''
+jobs:
+  bench-ec2-any:
+    name: Ad-hoc benchmark on $${{ inputs.ec2_instance_type }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/bench_ec2_reusable.yml
+    with:
+      ec2_instance_type: ${{ inputs.ec2_instance_type }}
+      ec2_ami: ${{ inputs.ec2_ami }}
+      ec2_ami_id: ${{ inputs.ec2_ami_id }}
+      cflags: ${{ inputs.cflags }}
+      archflags: ${{ inputs.archflags }}
+      opt: ${{ inputs.opt }}
+      name: ${{ inputs.name }}
+      store_results: false
+      bench_extra_args: ${{ inputs.bench_extra_args }}
+      compiler: ${{ inputs.compiler }}
+      additional_packages: ${{ inputs.additional_packages }}
+    secrets: inherit

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: bench-ec2-reusable
+on:
+  workflow_call:
+    inputs:
+      name:
+        type: string
+        description: Alternative name of instance
+        default: Graviton2
+      ec2_instance_type:
+        type: string
+        description: Type if EC2 instance to benchmark on
+        default: t4g.small
+      ec2_ami:
+        type: string
+        description: Textual description of AMI
+        default: ubuntu-latest (aarch64)
+      ec2_ami_id:
+        type: string
+        description: AMI ID
+        default: ami-0c4e709339fa8521a
+      cflags:
+        type: string
+        description: Custom CFLAGS for compilation
+        default: ""
+      archflags:
+        type: string
+        description: Custom ARCH flags for compilation
+        default: -mcpu=neoverse-n1 -march=armv8.2-a
+      opt:
+        type: string
+        description: Runs with optimized code if enabled (opt, no_opt, all)
+        default: "opt"
+      perf:
+        type: string
+        description: Method by which clock cycles should be measured (PMU | PERF)
+        default: PERF
+      store_results:
+        type: boolean
+        description: Indicates if results should be pushed to github pages
+        default: false
+      verbose:
+        description: Determine for the log verbosity
+        type: boolean
+        default: false
+      bench_extra_args:
+        type: string
+        description: Additional command line to be appended to `bench` script
+        default: ''
+      compiler:
+        type: string
+        description: Compiler to use. When unset, default nix shell is used.
+        default: ''
+      additional_packages:
+        type: string
+        description: Additional packages to install when custom compiler is used.
+        default: ''
+      aws_region:
+        type: string
+        default: "us-east-1"
+      alert_threshold:
+        type: string
+        description: "Set alert threshold in percentage for benchmark result"
+        default: "103%"
+env:
+  AWS_ROLE: arn:aws:iam::904233116199:role/mldsa-native-ci
+  AMI_UBUNTU_LATEST_X86_64: ami-084568db4383264d4
+  AMI_UBUNTU_LATEST_AARCH64: ami-0c4e709339fa8521a
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  start-ec2-runner:
+    name: Start ${{ inputs.name }} (${{ inputs.ec2_instance_type }})
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # The point is to make this step non-cancellable,
+                        # avoiding race conditions where an instance is started,
+                        # but isn't yet done registering as a runner and reporting back.
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Determine AMI ID
+        id: det_ami_id
+        run: |
+          if [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (x86_64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_LATEST_X86_64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (aarch64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_LATEST_AARCH64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (custom AMI)" ]]; then
+            AMI_ID=${{ inputs.ec2_ami_id }}
+          fi
+          echo "Using AMI ID: $AMI_ID"
+          echo "AMI_ID=$AMI_ID" >> $GITHUB_OUTPUT
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ inputs.aws_region }}
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@a8c20fc0876503410b2b966c124abc2311984ce2 # v2.3.9
+        with:
+          mode: start
+          github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
+          ec2-instance-type: ${{ inputs.ec2_instance_type }}
+          subnet-id: subnet-094d73eb42eb6bf5b
+          security-group-id: sg-0282706dbc92a1579
+  bench_nix:
+    name: Bench (nix)
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ${{ needs.start-ec2-runner.outputs.label }}
+    needs: start-ec2-runner # required to start the main job when the runner is ready
+    if: ${{ inputs.compiler == '' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'opt' }}
+        with:
+          nix-verbose: ${{ inputs.verbose }}
+          name: ${{ inputs.name }}
+          cflags: ${{ inputs.cflags }}
+          archflags: ${{ inputs.archflags }}
+          opt: true
+          perf: ${{ inputs.perf }}
+          store_results: ${{ inputs.store_results }}
+          bench_extra_args: ${{ inputs.bench_extra_args }}
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+      - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'no_opt' }}
+        with:
+          nix-verbose: ${{ inputs.verbose }}
+          name: ${{ inputs.name }} (no-opt)
+          cflags: ${{ inputs.cflags }}
+          archflags: ${{ inputs.archflags }}
+          opt: false
+          perf: ${{ inputs.perf }}
+          store_results: ${{ inputs.store_results }}
+          bench_extra_args: ${{ inputs.bench_extra_args }}
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          alert_threshold: ${{ inputs.alert_threshold }}
+  bench_custom:
+    name: Bench (custom compiler)
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ${{ needs.start-ec2-runner.outputs.label }}
+    needs: start-ec2-runner # required to start the main job when the runner is ready
+    if: ${{ inputs.compiler != '' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-apt
+        with:
+          packages: ${{ inputs.additional_packages }}
+      - name: Set compiler
+        run: |
+          echo "CC=${{ inputs.compiler }}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'opt' }}
+        with:
+          nix-shell: 'ci-bench'
+          custom-shell: 'bash'
+          nix-cache: false
+          nix-verbose: ${{ inputs.verbose }}
+          name: ${{ inputs.name }} (${{ inputs.compiler }})
+          cflags: ${{ inputs.cflags }}
+          archflags: ${{ inputs.archflags }}
+          opt: true
+          perf: ${{ inputs.perf }}
+          store_results: ${{ inputs.store_results }}
+          bench_extra_args: ${{ inputs.bench_extra_args }}
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+      - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'no_opt' }}
+        with:
+          nix-shell: 'ci-bench'
+          custom-shell: 'bash'
+          nix-cache: false
+          nix-verbose: ${{ inputs.verbose }}
+          name: ${{ inputs.name }} (${{ inputs.compiler }}) (no-opt)
+          cflags: ${{ inputs.cflags }}
+          archflags: ${{ inputs.archflags }}
+          opt: false
+          perf: ${{ inputs.perf }}
+          store_results: ${{ inputs.store_results }}
+          bench_extra_args: ${{ inputs.bench_extra_args }}
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          alert_threshold: ${{ inputs.alert_threshold }}
+  stop-ec2-runner:
+    name: Stop ${{ inputs.name }} (${{ inputs.ec2_instance_type }})
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs:
+      - start-ec2-runner
+      - bench_nix # required to wait when the main job is done
+      - bench_custom # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ inputs.aws_region }}
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@a8c20fc0876503410b2b966c124abc2311984ce2 # v2.3.9
+        with:
+          mode: stop
+          github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          label: ${{ needs.start-ec2-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: gaurav-nelson/github-action-markdown-link-check@1b916f2cf6c36510a6059943104e3c42ce6c16bc # v1.0.16
+    - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
   quickcheck:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -68,8 +68,8 @@ on:
 env:
   AWS_ROLE: arn:aws:iam::904233116199:role/mldsa-native-ci
   AWS_REGION: us-east-1
-  AMI_UBUNTU_LATEST_X86_64: ami-0e86e20dae9224db8
-  AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
+  AMI_UBUNTU_LATEST_X86_64: ami-084568db4383264d4
+  AMI_UBUNTU_LATEST_AARCH64: ami-0c4e709339fa8521a
 jobs:
   start-ec2-runner:
     name: Start instance (${{ inputs.ec2_instance_type }})


### PR DESCRIPTION
This commit adds benchmarking on
 - Graviton 2 (t4g.small)
 - Graviton 3 (c7g.medium)
 - Graviton 4 (c8g.medium)
 - AMD EPYC 4th gen (c7a.medium)
 - Intel Xeon 4th gen (c7i.metal-24xl)
 - AMD EPYC 3rd gen (c6a.large)
 - Intel Xeon 3rd gen (c6i.large)

With that we have all the platforms that are covered in mlkem-native.
