### PR TITLE
Optimize proof for `keccak_squeezeblocks`

### DIFF
--- a/proofs/cbmc/keccakf1600_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes/Makefile
@@ -3,11 +3,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = keccak_squeezeblocks_harness
+HARNESS_FILE = keccakf1600_extract_bytes_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = keccak_squeezeblocks
+PROOF_UID = keccakf1600_extract_bytes
 
 DEFINES +=
 INCLUDES +=
@@ -18,16 +18,16 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
 
-CHECK_FUNCTION_CONTRACTS=keccak_squeezeblocks
-USE_FUNCTION_CONTRACTS=KeccakF1600_StatePermute keccakf1600_extract_bytes
+CHECK_FUNCTION_CONTRACTS=keccakf1600_extract_bytes
+USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--smt2
 
-FUNCTION_NAME = keccak_squeezeblocks
+FUNCTION_NAME = keccakf1600_extract_bytes
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+extern void keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
+                                      unsigned offset, unsigned length);
+
+void harness(void)
+{
+  uint64_t *state;
+  unsigned char *data;
+  unsigned offset;
+  unsigned length;
+
+  keccakf1600_extract_bytes(state, data, offset, length);
+}


### PR DESCRIPTION
This PR introduces the function `keccakf1600_extract_bytes` which optimizes the CBMC proof latency for `keccak_squeezeblocks` to 48s (previously ~150s).

Notes:
- Introduce `keccakf1600_extract_bytes` function as it is defined in mlkem-native - https://github.com/pq-code-package/mlkem-native/blob/ae2afe58380797f6b6789060b3ff8be2b2917fb5/mlkem/fips202/keccakf1600.c#L38 
- The main speedup was observed after adding support for both little- and big-endian.