### PR TITLE
Contributor's agreement to relicensing mldsa-native under Apache-2.0 OR ISC OR MIT

### DIFF
--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -17,3 +17,4 @@ in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
 - Jake Massimo <jakemas@amazon.com>
 - Pravek Sharma <sharmapravek@gmail.com>
 - Mila Anastasova <manastasova2017@fau.edu>
+- Thing Han, Lim potsrevenmil@gmail.com

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -12,3 +12,4 @@ By adding my name to the list below, I agree to relicense all my contributions
 in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
 
 - Hanno Becker <beckphan@amazon.co.uk>
+- Matthias Kannwischer <matthias@kannwischer.eu>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -13,3 +13,5 @@ in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
 
 - Hanno Becker <beckphan@amazon.co.uk>
 - Matthias Kannwischer <matthias@kannwischer.eu>
+- Rod Chapman <rodchap@amazon.co.uk>
+

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -1,0 +1,12 @@
+# Relicensing mldsa-native
+
+This document gathers consent by mldsa-native contributors to relicense
+mldsa-native from `Apache-2.0` to `Apache-2.0 OR ISC OR MIT`.
+
+The relicensing itself is intended to be carried out once all contributors
+have given consent to the relicensing.
+
+## Contributors agreeing to relicensing
+
+By adding my name to the list below, I agree to relicense all my contributions
+in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -14,4 +14,4 @@ in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
 - Hanno Becker <beckphan@amazon.co.uk>
 - Matthias Kannwischer <matthias@kannwischer.eu>
 - Rod Chapman <rodchap@amazon.co.uk>
-
+- Pravek Sharma <sharmapravek@gmail.com>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -14,5 +14,6 @@ in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
 - Hanno Becker <beckphan@amazon.co.uk>
 - Matthias Kannwischer <matthias@kannwischer.eu>
 - Rod Chapman <rodchap@amazon.co.uk>
+- Jake Massimo <jakemas@amazon.com>
 - Pravek Sharma <sharmapravek@gmail.com>
 - Mila Anastasova <manastasova2017@fau.edu>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -10,3 +10,5 @@ have given consent to the relicensing.
 
 By adding my name to the list below, I agree to relicense all my contributions
 in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
+
+- Hanno Becker <beckphan@amazon.co.uk>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -15,3 +15,4 @@ in the mldsa-native project under `Apache-2.0 OR ISC OR MIT`.
 - Matthias Kannwischer <matthias@kannwischer.eu>
 - Rod Chapman <rodchap@amazon.co.uk>
 - Pravek Sharma <sharmapravek@gmail.com>
+- Mila Anastasova <manastasova2017@fau.edu>


### PR DESCRIPTION
This PR adds a RELICENSE file. The purpose of this file is to gather consent from mldsa-native contributors that their contributions may be relicensed as Apache-2.0 OR MIT OR ISC.

The relicensing itself is planned to be carried out once all contributors have added their names to that file.

Contributors agreeing to the relicensing should push a separate commit adding their name to RELICENSE.