### PR TITLE
Add spec and proofs for all fips202 functions

### DIFF
--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -405,7 +405,7 @@ static unsigned int keccak_absorb(uint64_t s[MLD_KECCAK_LANES],
                                   const uint8_t *in, size_t inlen)
 __contract__(
   requires(r < sizeof(uint64_t) * MLD_KECCAK_LANES)
-  requires(pos < r)
+  requires(pos <= r)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   requires(memory_no_alias(in, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
@@ -418,7 +418,7 @@ __contract__(
     assigns(pos, i, in, inlen,
       memory_slice(s, sizeof(uint64_t) *  MLD_KECCAK_LANES))
     invariant(inlen <= loop_entry(inlen))
-    invariant(pos < r)
+    invariant(pos <= r)
     invariant(in == loop_entry(in) + (loop_entry(inlen) - inlen)))
   {
     for (i = pos; i < r; i++)
@@ -458,7 +458,7 @@ __contract__(
 static void keccak_finalize(uint64_t s[MLD_KECCAK_LANES], unsigned int pos,
                             unsigned int r, uint8_t p)
 __contract__(
-  requires(pos < r && r < sizeof(uint64_t) * MLD_KECCAK_LANES)
+  requires(pos <= r && r < sizeof(uint64_t) * MLD_KECCAK_LANES)
   requires((r / 8) >= 1)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))

--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -488,8 +488,8 @@ static unsigned int keccak_squeeze(uint8_t *out, size_t outlen,
                                    uint64_t s[MLD_KECCAK_LANES],
                                    unsigned int pos, unsigned int r)
 __contract__(
-  requires(r == SHAKE128_RATE || r == SHAKE256_RATE)
-  requires(pos <= r)
+  requires((r == SHAKE128_RATE && pos <= SHAKE128_RATE) ||
+    (r == SHAKE256_RATE && pos <= SHAKE256_RATE))
   requires(outlen <= 8 * r /* somewhat arbitrary bound */)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   requires(memory_no_alias(out, outlen))

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -131,6 +131,7 @@ __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(in, inlen))
   assigns(memory_slice(state, sizeof(keccak_state)))
+  ensures(state->pos == SHAKE256_RATE)
 );
 
 #define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
@@ -139,8 +140,10 @@ __contract__(
   requires(nblocks <= 8 /* somewhat arbitrary bound */)
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(out, nblocks * SHAKE256_RATE))
+  requires(state->pos <= SHAKE256_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
   assigns(memory_slice(out, nblocks * SHAKE256_RATE))
+  ensures(state->pos <= SHAKE256_RATE)
 );
 
 #define shake128 FIPS202_NAMESPACE(shake128)
@@ -153,7 +156,14 @@ __contract__(
 );
 
 #define shake256 FIPS202_NAMESPACE(shake256)
-void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
+__contract__(
+  requires(outlen <= 8 * SHAKE256_RATE /* somewhat arbitrary bound */)
+  requires(memory_no_alias(in, inlen))
+  requires(memory_no_alias(out, outlen))
+  assigns(memory_slice(out, outlen))
+);
+
 #define sha3_256 FIPS202_NAMESPACE(sha3_256)
 void sha3_256(uint8_t h[SHA3_256_HASHBYTES], const uint8_t *in, size_t inlen)
 __contract__(

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -72,6 +72,7 @@ __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(in, inlen))
   assigns(memory_slice(state, sizeof(keccak_state)))
+  ensures(state->pos == SHAKE128_RATE)
 );
 
 #define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
@@ -80,8 +81,10 @@ __contract__(
   requires(nblocks <= 8 /* somewhat arbitrary bound */)
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(out, nblocks * SHAKE128_RATE))
+  requires(state->pos <= SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
   assigns(memory_slice(out, nblocks * SHAKE128_RATE))
+  ensures(state->pos <= SHAKE128_RATE)
 );
 
 #define shake256_init FIPS202_NAMESPACE(shake256_init)
@@ -141,7 +144,14 @@ __contract__(
 );
 
 #define shake128 FIPS202_NAMESPACE(shake128)
-void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
+__contract__(
+  requires(outlen <= 8 * SHAKE128_RATE /* somewhat arbitrary bound */)
+  requires(memory_no_alias(in, inlen))
+  requires(memory_no_alias(out, outlen))
+  assigns(memory_slice(out, outlen))
+);
+
 #define shake256 FIPS202_NAMESPACE(shake256)
 void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
 #define sha3_256 FIPS202_NAMESPACE(sha3_256)

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -41,17 +41,18 @@ void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen)
 __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(in, inlen))
-  requires(state->pos < SHAKE128_RATE)
+  requires(state->pos <= SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
-  ensures(state->pos < SHAKE128_RATE)
+  ensures(state->pos <= SHAKE128_RATE)
 );
 
 #define shake128_finalize FIPS202_NAMESPACE(shake128_finalize)
 void shake128_finalize(keccak_state *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
-  requires(state->pos < SHAKE128_RATE)
+  requires(state->pos <= SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
+  ensures(state->pos <= SHAKE128_RATE)
 );
 
 #define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
@@ -100,17 +101,18 @@ void shake256_absorb(keccak_state *state, const uint8_t *in, size_t inlen)
 __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(in, inlen))
-  requires(state->pos < SHAKE256_RATE)
+  requires(state->pos <= SHAKE256_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
-  ensures(state->pos < SHAKE256_RATE)
+  ensures(state->pos <= SHAKE256_RATE)
 );
 
 #define shake256_finalize FIPS202_NAMESPACE(shake256_finalize)
 void shake256_finalize(keccak_state *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
-  requires(state->pos < SHAKE256_RATE)
+  requires(state->pos <= SHAKE256_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
+  ensures(state->pos <= SHAKE256_RATE)
 );
 
 #define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -35,6 +35,7 @@ __contract__(
   assigns(memory_slice(state, sizeof(keccak_state)))
   ensures(state->pos == 0)
 );
+
 #define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
 void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen)
 __contract__(
@@ -44,6 +45,7 @@ __contract__(
   assigns(memory_slice(state, sizeof(keccak_state)))
   ensures(state->pos < SHAKE128_RATE)
 );
+
 #define shake128_finalize FIPS202_NAMESPACE(shake128_finalize)
 void shake128_finalize(keccak_state *state)
 __contract__(
@@ -51,8 +53,19 @@ __contract__(
   requires(state->pos < SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(keccak_state)))
 );
+
 #define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
-void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state)
+__contract__(
+  requires(outlen <= 8 * SHAKE128_RATE /* somewhat arbitrary bound */)
+  requires(memory_no_alias(state, sizeof(keccak_state)))
+  requires(memory_no_alias(out, outlen))
+  requires(state->pos <= SHAKE128_RATE)
+  assigns(memory_slice(state, sizeof(keccak_state)))
+  assigns(memory_slice(out, outlen))
+  ensures(state->pos <= SHAKE128_RATE)
+);
+
 #define shake128_absorb_once FIPS202_NAMESPACE(shake128_absorb_once)
 void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen)
 __contract__(

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -111,7 +111,17 @@ __contract__(
 );
 
 #define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)
-void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state)
+__contract__(
+  requires(outlen <= 8 * SHAKE256_RATE /* somewhat arbitrary bound */)
+  requires(memory_no_alias(state, sizeof(keccak_state)))
+  requires(memory_no_alias(out, outlen))
+  requires(state->pos <= SHAKE256_RATE)
+  assigns(memory_slice(state, sizeof(keccak_state)))
+  assigns(memory_slice(out, outlen))
+  ensures(state->pos <= SHAKE256_RATE)
+);
+
 #define shake256_absorb_once FIPS202_NAMESPACE(shake256_absorb_once)
 void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen)
 __contract__(

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -338,6 +338,7 @@ void poly_uniform(poly *a, const uint8_t seed[MLDSA_SEEDBYTES], uint16_t nonce)
   __loop__(
     assigns(ctr, state, memory_slice(a, sizeof(poly)), object_whole(buf))
     invariant(ctr <= MLDSA_N)
+    invariant((&state)->pos <= SHAKE128_RATE)
     invariant(array_bound(a->coeffs, 0, ctr, 0, MLDSA_Q)))
   {
     stream128_squeezeblocks(buf, 1, &state);
@@ -490,12 +491,14 @@ void poly_challenge(poly *c, const uint8_t seed[MLDSA_CTILDEBYTES])
     invariant(i <= MLDSA_N)
     invariant(pos >= 1)
     invariant(pos <= SHAKE256_RATE)
+    invariant((&state)->pos <= SHAKE256_RATE)
     invariant(array_bound(c->coeffs, 0, MLDSA_N, -1, 2))
   )
   {
     do
     __loop__(
       assigns(j, object_whole(buf), state, pos)
+      invariant((&state)->pos <= SHAKE256_RATE)
     )
     {
       if (pos >= SHAKE256_RATE)

--- a/mldsa/symmetric.h
+++ b/mldsa/symmetric.h
@@ -22,6 +22,7 @@ __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(seed, MLDSA_SEEDBYTES))
   assigns(memory_slice(state, sizeof(keccak_state)))
+  ensures(state->pos <= SHAKE128_RATE)
 );
 
 #define mldsa_shake256_stream_init MLD_NAMESPACE(mldsa_shake256_stream_init)
@@ -32,6 +33,7 @@ __contract__(
   requires(memory_no_alias(state, sizeof(keccak_state)))
   requires(memory_no_alias(seed, MLDSA_CRHBYTES))
   assigns(memory_slice(state, sizeof(keccak_state)))
+  ensures(state->pos <= SHAKE256_RATE)
 );
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE

--- a/proofs/cbmc/keccak_squeeze/Makefile
+++ b/proofs/cbmc/keccak_squeeze/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccak_squeeze_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccak_squeeze
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=keccak_squeeze
+USE_FUNCTION_CONTRACTS=KeccakF1600_StatePermute
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = keccak_squeeze
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccak_squeeze/keccak_squeeze_harness.c
+++ b/proofs/cbmc/keccak_squeeze/keccak_squeeze_harness.c
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+static unsigned int keccak_squeeze(uint8_t *out, size_t outlen,
+                                   uint64_t s[MLD_KECCAK_LANES],
+                                   unsigned int pos, unsigned int r);
+
+void harness(void)
+{
+  uint8_t *out;
+  size_t outlen;
+  uint64_t *s;
+  unsigned int pos, r;
+
+  keccak_squeeze(out, outlen, s, pos, r);
+}

--- a/proofs/cbmc/shake128/Makefile
+++ b/proofs/cbmc/shake128/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake128_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake128
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake128
+USE_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake128_absorb_once $(FIPS202_NAMESPACE)shake128_squeezeblocks $(FIPS202_NAMESPACE)shake128_squeeze
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = shake128
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake128/shake128_harness.c
+++ b/proofs/cbmc/shake128/shake128_harness.c
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  uint8_t *out;
+  size_t outlen;
+  const uint8_t *in;
+  size_t inlen;
+
+  shake128(out, outlen, in, inlen);
+}

--- a/proofs/cbmc/shake128_squeeze/Makefile
+++ b/proofs/cbmc/shake128_squeeze/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake128_squeeze_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake128_squeeze
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET += 
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake128_squeeze
+USE_FUNCTION_CONTRACTS=keccak_squeeze
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = shake128_squeeze
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake128_squeeze/shake128_squeeze_harness.c
+++ b/proofs/cbmc/shake128_squeeze/shake128_squeeze_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  uint8_t *out;
+  size_t outlen;
+  keccak_state *state;
+
+  shake128_squeeze(out, outlen, state);
+}

--- a/proofs/cbmc/shake256/Makefile
+++ b/proofs/cbmc/shake256/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake256_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake256
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake256
+USE_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake256_absorb_once $(FIPS202_NAMESPACE)shake256_squeezeblocks $(FIPS202_NAMESPACE)shake256_squeeze
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = shake256
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake256/shake256_harness.c
+++ b/proofs/cbmc/shake256/shake256_harness.c
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  uint8_t *out;
+  size_t outlen;
+  const uint8_t *in;
+  size_t inlen;
+
+  shake256(out, outlen, in, inlen);
+}

--- a/proofs/cbmc/shake256_squeeze/Makefile
+++ b/proofs/cbmc/shake256_squeeze/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = shake256_squeeze_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = shake256_squeeze
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET += 
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)shake256_squeeze
+USE_FUNCTION_CONTRACTS=keccak_squeeze
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = shake256_squeeze
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/shake256_squeeze/shake256_squeeze_harness.c
+++ b/proofs/cbmc/shake256_squeeze/shake256_squeeze_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+void harness(void)
+{
+  uint8_t *out;
+  size_t outlen;
+  keccak_state *state;
+
+  shake256_squeeze(out, outlen, state);
+}


### PR DESCRIPTION
This PR is a continuation of https://github.com/pq-code-package/mldsa-native/pull/187 and adds specs and proofs for the following functions: 

- keccak_squeeze
- shake128_squeeze
- shake256_squeeze
- shake128
- shake256

