### PR TITLE
CBMC: Refactored rej_eta and poly_uniform_eta

### DIFF
--- a/proofs/cbmc/rej_eta/Makefile
+++ b/proofs/cbmc/rej_eta/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = rej_eta
 

--- a/proofs/cbmc/rej_eta/rej_eta_harness.c
+++ b/proofs/cbmc/rej_eta/rej_eta_harness.c
@@ -3,15 +3,17 @@
 
 #include "poly.h"
 
-unsigned rej_eta(int32_t *a, unsigned int len, const uint8_t *buf,
-                 unsigned int buflen);
+static unsigned int rej_eta(int32_t *a, unsigned int target,
+                            unsigned int offset, const uint8_t *buf,
+                            unsigned int buflen);
 
 void harness(void)
 {
   int32_t *a;
-  unsigned int len;
+  unsigned int target;
+  unsigned int offset;
   const uint8_t *buf;
   unsigned int buflen;
 
-  rej_eta(a, len, buf, buflen);
+  rej_eta(a, target, offset, buf, buflen);
 }


### PR DESCRIPTION
Preparation for the CBMC proof of `poly_uniform_eta`. Similarly to https://github.com/pq-code-package/mldsa-native/pull/218 we need to refactor `rej_eta` to remove pointer arithmetic within the argument. The function `poly_uniform_eta` has been modified to accept the changes to `rej_eta`.