### PR TITLE
Add proof for big-endian version of keccakf1600_extract_bytes()

### DIFF
--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccakf1600_extract_bytes_be_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccakf1600_extract_bytes (big endian)
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/fips202/fips202.c
+
+CHECK_FUNCTION_CONTRACTS=keccakf1600_extract_bytes
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2 --big-endian
+DEFINES += -DMLD_SYS_BIG_ENDIAN=1
+
+FUNCTION_NAME = keccakf1600_extract_bytes
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fips202/fips202.h"
+
+extern void keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
+                                      unsigned offset, unsigned length);
+
+void harness(void)
+{
+  uint64_t *state;
+  unsigned char *data;
+  unsigned offset;
+  unsigned length;
+
+  keccakf1600_extract_bytes(state, data, offset, length);
+}


### PR DESCRIPTION
Fixes #226 

Adds proof for the big-endian version of keccakf1600_extract_bytes() function.

Changes to the proof Makefile are based on similar version in mlkem-native.
