### PR TITLE
Remove year from copyright header

### DIFF
--- a/mldsa/api.h
+++ b/mldsa/api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_API_H

--- a/mldsa/cbmc.h
+++ b/mldsa/cbmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/common.h
+++ b/mldsa/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/config.h
+++ b/mldsa/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_CONFIG_H

--- a/mldsa/debug.c
+++ b/mldsa/debug.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/debug.h
+++ b/mldsa/debug.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_DEBUG_H

--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 /* Based on the public domain implementation in crypto_hash/keccakc512/simple/

--- a/mldsa/fips202/fips202.h
+++ b/mldsa/fips202/fips202.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_FIPS202_FIPS202_H

--- a/mldsa/native/aarch64/meta.h
+++ b/mldsa/native/aarch64/meta.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/native/aarch64/src/aarch64_zetas.c
+++ b/mldsa/native/aarch64/src/aarch64_zetas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/native/aarch64/src/arith_native_aarch64.h
+++ b/mldsa/native/aarch64/src/arith_native_aarch64.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/native/aarch64/src/intt.S
+++ b/mldsa/native/aarch64/src/intt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/mldsa/native/aarch64/src/ntt.S
+++ b/mldsa/native/aarch64/src/ntt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/mldsa/native/api.h
+++ b/mldsa/native/api.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/native/meta.h
+++ b/mldsa/native/meta.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/ntt.c
+++ b/mldsa/ntt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/ntt.h
+++ b/mldsa/ntt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_NTT_H

--- a/mldsa/packing.c
+++ b/mldsa/packing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>

--- a/mldsa/packing.h
+++ b/mldsa/packing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_PACKING_H

--- a/mldsa/params.h
+++ b/mldsa/params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_PARAMS_H

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_POLY_H

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_POLYVEC_H

--- a/mldsa/randombytes.h
+++ b/mldsa/randombytes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_RANDOMBYTES_H

--- a/mldsa/reduce.c
+++ b/mldsa/reduce.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/reduce.h
+++ b/mldsa/reduce.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_REDUCE_H

--- a/mldsa/rounding.c
+++ b/mldsa/rounding.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_ROUNDING_H

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_SIGN_H

--- a/mldsa/symmetric-shake.c
+++ b/mldsa/symmetric-shake.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>

--- a/mldsa/symmetric.h
+++ b/mldsa/symmetric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef MLD_SYMMETRIC_H

--- a/mldsa/sys.h
+++ b/mldsa/sys.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/mldsa/zetas.inc
+++ b/mldsa/zetas.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/proofs/cbmc/caddq/caddq_harness.c
+++ b/proofs/cbmc/caddq/caddq_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce.h"

--- a/proofs/cbmc/decompose/decompose_harness.c
+++ b/proofs/cbmc/decompose/decompose_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rounding.h"

--- a/proofs/cbmc/fqmul/fqmul_harness.c
+++ b/proofs/cbmc/fqmul/fqmul_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ntt.h"

--- a/proofs/cbmc/invntt_layer/invntt_layer_harness.c
+++ b/proofs/cbmc/invntt_layer/invntt_layer_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/invntt_tomont/invntt_tomont_harness.c
+++ b/proofs/cbmc/invntt_tomont/invntt_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/keccak_absorb/keccak_absorb_harness.c
+++ b/proofs/cbmc/keccak_absorb/keccak_absorb_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccak_absorb_once/keccak_absorb_once_harness.c
+++ b/proofs/cbmc/keccak_absorb_once/keccak_absorb_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccak_finalize/keccak_finalize_harness.c
+++ b/proofs/cbmc/keccak_finalize/keccak_finalize_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccak_init/keccak_init_harness.c
+++ b/proofs/cbmc/keccak_init/keccak_init_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccak_squeeze/keccak_squeeze_harness.c
+++ b/proofs/cbmc/keccak_squeeze/keccak_squeeze_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccak_squeezeblocks/keccak_squeezeblocks_harness.c
+++ b/proofs/cbmc/keccak_squeezeblocks/keccak_squeezeblocks_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/keccakf1600_permute/keccakf1600_permute_harness.c
+++ b/proofs/cbmc/keccakf1600_permute/keccakf1600_permute_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/list_proofs.sh
+++ b/proofs/cbmc/list_proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025 The mldsa-native project authors
+# Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # This tiny script just lists the proof directories in proof/cbmc,

--- a/proofs/cbmc/load64/load64_harness.c
+++ b/proofs/cbmc/load64/load64_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/make_hint/make_hint_harness.c
+++ b/proofs/cbmc/make_hint/make_hint_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rounding.h"

--- a/proofs/cbmc/mldsa_shake128_stream_init/mldsa_shake128_stream_init_harness.c
+++ b/proofs/cbmc/mldsa_shake128_stream_init/mldsa_shake128_stream_init_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "params.h"

--- a/proofs/cbmc/mldsa_shake256_stream_init/mldsa_shake256_stream_init_harness.c
+++ b/proofs/cbmc/mldsa_shake256_stream_init/mldsa_shake256_stream_init_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "params.h"

--- a/proofs/cbmc/montgomery_reduce/montgomery_reduce_harness.c
+++ b/proofs/cbmc/montgomery_reduce/montgomery_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce.h"

--- a/proofs/cbmc/ntt/ntt_harness.c
+++ b/proofs/cbmc/ntt/ntt_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
+++ b/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/ntt_layer/ntt_layer_harness.c
+++ b/proofs/cbmc/ntt_layer/ntt_layer_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/pack_pk/pack_pk_harness.c
+++ b/proofs/cbmc/pack_pk/pack_pk_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/pack_sig/pack_sig_harness.c
+++ b/proofs/cbmc/pack_sig/pack_sig_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/pack_sk/pack_sk_harness.c
+++ b/proofs/cbmc/pack_sk/pack_sk_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/poly_add/poly_add_harness.c
+++ b/proofs/cbmc/poly_add/poly_add_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_caddq/poly_caddq_harness.c
+++ b/proofs/cbmc/poly_caddq/poly_caddq_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_challenge/poly_challenge_harness.c
+++ b/proofs/cbmc/poly_challenge/poly_challenge_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_chknorm/poly_chknorm_harness.c
+++ b/proofs/cbmc/poly_chknorm/poly_chknorm_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_decompose/poly_decompose_harness.c
+++ b/proofs/cbmc/poly_decompose/poly_decompose_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_invntt_tomont/poly_invntt_tomont_harness.c
+++ b/proofs/cbmc/poly_invntt_tomont/poly_invntt_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/poly_make_hint/poly_make_hint_harness.c
+++ b/proofs/cbmc/poly_make_hint/poly_make_hint_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_ntt/poly_ntt_harness.c
+++ b/proofs/cbmc/poly_ntt/poly_ntt_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_pointwise_montgomery/poly_pointwise_montgomery_harness.c
+++ b/proofs/cbmc/poly_pointwise_montgomery/poly_pointwise_montgomery_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_power2round/poly_power2round_harness.c
+++ b/proofs/cbmc/poly_power2round/poly_power2round_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_reduce/poly_reduce_harness.c
+++ b/proofs/cbmc/poly_reduce/poly_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_shiftl/poly_shiftl_harness.c
+++ b/proofs/cbmc/poly_shiftl/poly_shiftl_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_sub/poly_sub_harness.c
+++ b/proofs/cbmc/poly_sub/poly_sub_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_uniform/poly_uniform_harness.c
+++ b/proofs/cbmc/poly_uniform/poly_uniform_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/poly_uniform_eta/poly_uniform_eta_harness.c
+++ b/proofs/cbmc/poly_uniform_eta/poly_uniform_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/poly_uniform_gamma1/poly_uniform_gamma1_harness.c
+++ b/proofs/cbmc/poly_uniform_gamma1/poly_uniform_gamma1_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/poly_use_hint/poly_use_hint_harness.c
+++ b/proofs/cbmc/poly_use_hint/poly_use_hint_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyeta_pack/polyeta_pack_harness.c
+++ b/proofs/cbmc/polyeta_pack/polyeta_pack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyeta_unpack/polyeta_unpack_harness.c
+++ b/proofs/cbmc/polyeta_unpack/polyeta_unpack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyt0_pack/polyt0_pack_harness.c
+++ b/proofs/cbmc/polyt0_pack/polyt0_pack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyt0_unpack/polyt0_unpack_harness.c
+++ b/proofs/cbmc/polyt0_unpack/polyt0_unpack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyt1_pack/polyt1_pack_harness.c
+++ b/proofs/cbmc/polyt1_pack/polyt1_pack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyt1_unpack/polyt1_unpack_harness.c
+++ b/proofs/cbmc/polyt1_unpack/polyt1_unpack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyveck_add/polyveck_add_harness.c
+++ b/proofs/cbmc/polyveck_add/polyveck_add_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_caddq/polyveck_caddq_harness.c
+++ b/proofs/cbmc/polyveck_caddq/polyveck_caddq_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_decompose/polyveck_decompose_harness.c
+++ b/proofs/cbmc/polyveck_decompose/polyveck_decompose_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_invntt_tomont/polyveck_invntt_tomont_harness.c
+++ b/proofs/cbmc/polyveck_invntt_tomont/polyveck_invntt_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/polyveck_make_hint/polyveck_make_hint_harness.c
+++ b/proofs/cbmc/polyveck_make_hint/polyveck_make_hint_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_ntt/polyveck_ntt_harness.c
+++ b/proofs/cbmc/polyveck_ntt/polyveck_ntt_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_pack_eta/polyveck_pack_eta_harness.c
+++ b/proofs/cbmc/polyveck_pack_eta/polyveck_pack_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_pack_t0/polyveck_pack_t0_harness.c
+++ b/proofs/cbmc/polyveck_pack_t0/polyveck_pack_t0_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_pack_w1/polyveck_pack_w1_harness.c
+++ b/proofs/cbmc/polyveck_pack_w1/polyveck_pack_w1_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_pointwise_poly_montgomery/polyveck_pointwise_poly_montgomery_harness.c
+++ b/proofs/cbmc/polyveck_pointwise_poly_montgomery/polyveck_pointwise_poly_montgomery_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_power2round/polyveck_power2round_harness.c
+++ b/proofs/cbmc/polyveck_power2round/polyveck_power2round_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_reduce/polyveck_reduce_harness.c
+++ b/proofs/cbmc/polyveck_reduce/polyveck_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_shiftl/polyveck_shiftl_harness.c
+++ b/proofs/cbmc/polyveck_shiftl/polyveck_shiftl_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_sub/polyveck_sub_harness.c
+++ b/proofs/cbmc/polyveck_sub/polyveck_sub_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_uniform_eta/polyveck_uniform_eta_harness.c
+++ b/proofs/cbmc/polyveck_uniform_eta/polyveck_uniform_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/polyveck_unpack_eta/polyveck_unpack_eta_harness.c
+++ b/proofs/cbmc/polyveck_unpack_eta/polyveck_unpack_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_unpack_t0/polyveck_unpack_t0_harness.c
+++ b/proofs/cbmc/polyveck_unpack_t0/polyveck_unpack_t0_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyveck_use_hint/polyveck_use_hint_harness.c
+++ b/proofs/cbmc/polyveck_use_hint/polyveck_use_hint_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_add/polyvecl_add_harness.c
+++ b/proofs/cbmc/polyvecl_add/polyvecl_add_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_invntt_tomont/polyvecl_invntt_tomont_harness.c
+++ b/proofs/cbmc/polyvecl_invntt_tomont/polyvecl_invntt_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/proofs/cbmc/polyvecl_ntt/polyvecl_ntt_harness.c
+++ b/proofs/cbmc/polyvecl_ntt/polyvecl_ntt_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_pack_eta/polyvecl_pack_eta_harness.c
+++ b/proofs/cbmc/polyvecl_pack_eta/polyvecl_pack_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_pack_z/polyvecl_pack_z_harness.c
+++ b/proofs/cbmc/polyvecl_pack_z/polyvecl_pack_z_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_pointwise_poly_montgomery/polyvecl_pointwise_poly_montgomery_harness.c
+++ b/proofs/cbmc/polyvecl_pointwise_poly_montgomery/polyvecl_pointwise_poly_montgomery_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_reduce/polyvecl_reduce_harness.c
+++ b/proofs/cbmc/polyvecl_reduce/polyvecl_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_uniform_eta/polyvecl_uniform_eta_harness.c
+++ b/proofs/cbmc/polyvecl_uniform_eta/polyvecl_uniform_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/polyvecl_unpack_eta/polyvecl_unpack_eta_harness.c
+++ b/proofs/cbmc/polyvecl_unpack_eta/polyvecl_unpack_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyvecl_unpack_z/polyvecl_unpack_z_harness.c
+++ b/proofs/cbmc/polyvecl_unpack_z/polyvecl_unpack_z_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "polyvec.h"

--- a/proofs/cbmc/polyw1_pack/polyw1_pack_harness.c
+++ b/proofs/cbmc/polyw1_pack/polyw1_pack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyz_pack/polyz_pack_harness.c
+++ b/proofs/cbmc/polyz_pack/polyz_pack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/polyz_unpack/polyz_unpack_harness.c
+++ b/proofs/cbmc/polyz_unpack/polyz_unpack_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/power2round/power2round_harness.c
+++ b/proofs/cbmc/power2round/power2round_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rounding.h"

--- a/proofs/cbmc/reduce32/reduce32_harness.c
+++ b/proofs/cbmc/reduce32/reduce32_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce.h"

--- a/proofs/cbmc/rej_eta/rej_eta_harness.c
+++ b/proofs/cbmc/rej_eta/rej_eta_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/rej_uniform/rej_uniform_harness.c
+++ b/proofs/cbmc/rej_uniform/rej_uniform_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "poly.h"

--- a/proofs/cbmc/sha3_256/sha3_256_harness.c
+++ b/proofs/cbmc/sha3_256/sha3_256_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/sha3_512/sha3_512_harness.c
+++ b/proofs/cbmc/sha3_512/sha3_512_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128/shake128_harness.c
+++ b/proofs/cbmc/shake128/shake128_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128_absorb/shake128_absorb_harness.c
+++ b/proofs/cbmc/shake128_absorb/shake128_absorb_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128_absorb_once/shake128_absorb_once_harness.c
+++ b/proofs/cbmc/shake128_absorb_once/shake128_absorb_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128_finalize/shake128_finalize_harness.c
+++ b/proofs/cbmc/shake128_finalize/shake128_finalize_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128_init/shake128_init_harness.c
+++ b/proofs/cbmc/shake128_init/shake128_init_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128_squeeze/shake128_squeeze_harness.c
+++ b/proofs/cbmc/shake128_squeeze/shake128_squeeze_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake128_squeezeblocks/shake128_squeezeblocks_harness.c
+++ b/proofs/cbmc/shake128_squeezeblocks/shake128_squeezeblocks_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256/shake256_harness.c
+++ b/proofs/cbmc/shake256/shake256_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256_absorb/shake256_absorb_harness.c
+++ b/proofs/cbmc/shake256_absorb/shake256_absorb_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256_absorb_once/shake256_absorb_once_harness.c
+++ b/proofs/cbmc/shake256_absorb_once/shake256_absorb_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256_finalize/shake256_finalize_harness.c
+++ b/proofs/cbmc/shake256_finalize/shake256_finalize_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256_init/shake256_init_harness.c
+++ b/proofs/cbmc/shake256_init/shake256_init_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256_squeeze/shake256_squeeze_harness.c
+++ b/proofs/cbmc/shake256_squeeze/shake256_squeeze_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/shake256_squeezeblocks/shake256_squeezeblocks_harness.c
+++ b/proofs/cbmc/shake256_squeezeblocks/shake256_squeezeblocks_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/store64/store64_harness.c
+++ b/proofs/cbmc/store64/store64_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fips202/fips202.h"

--- a/proofs/cbmc/unpack_hints/unpack_hints_harness.c
+++ b/proofs/cbmc/unpack_hints/unpack_hints_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/unpack_pk/unpack_pk_harness.c
+++ b/proofs/cbmc/unpack_pk/unpack_pk_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/unpack_sig/unpack_sig_harness.c
+++ b/proofs/cbmc/unpack_sig/unpack_sig_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/unpack_sk/unpack_sk_harness.c
+++ b/proofs/cbmc/unpack_sk/unpack_sk_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "packing.h"

--- a/proofs/cbmc/use_hint/use_hint_harness.c
+++ b/proofs/cbmc/use_hint/use_hint_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The mldsa-native project authors
+// Copyright (c) The mldsa-native project authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rounding.h"

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
-# Copyright (c) 2025      The mldsa-native project authors
+# Copyright (c) The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess
@@ -33,7 +33,7 @@ def status_update(task, msg):
 
 def gen_header():
     yield "/*"
-    yield " * Copyright (c) 2025 The mldsa-native project authors"
+    yield " * Copyright (c) The mldsa-native project authors"
     yield " * SPDX-License-Identifier: Apache-2.0"
     yield " */"
     yield ""
@@ -693,8 +693,8 @@ def adjust_header_guard_for_filename(content, header_file):
     def gen_copyright(include_mlkem=False):
         yield "/*"
         if include_mlkem is True:
-            yield " * Copyright (c) 2024-2025 The mlkem-native project authors"
-        yield " * Copyright (c) 2025 The mldsa-native project authors"
+            yield " * Copyright (c) The mlkem-native project authors"
+        yield " * Copyright (c) The mldsa-native project authors"
         yield " * SPDX-License-Identifier: Apache-2.0"
         yield " */"
 

--- a/scripts/copy_nix_from_upstream
+++ b/scripts/copy_nix_from_upstream
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025 The mldsa-native project authors
+# Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
 ROOT="$(realpath "$(dirname "$0")"/../)"

--- a/scripts/format
+++ b/scripts/format
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025 The mldsa-native project authors
+# Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
 set -o errexit

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025 The mldsa-native project authors
+# Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
 set -o errexit
@@ -87,7 +87,7 @@ check-spdx()
   done
   for file in $(git ls-files -- "*.[chsS]" "*.py" ":/!proofs/cbmc/*.py"); do
     # Ignore symlinks
-    if [[ ! -L $file && $(grep "Copyright (c) 2025 The mldsa-native project authors" $file | wc -l) == 0 ]]; then
+    if [[ ! -L $file && $(grep "Copyright (c) The mldsa-native project authors" $file | wc -l) == 0 ]]; then
       echo "::error file=$file,line=${line:-1},title=Missing copyright header error::$file is missing copyright header"
       success=false
     fi

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025 The mldsa-native project authors
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Convenience CLI script wrapping various `make` invocations for

--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 The mldsa-native project authors
+# Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
 # ACVP client for ML-DSA

--- a/test/acvp_mldsa.c
+++ b/test/acvp_mldsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stddef.h>

--- a/test/bench_components_mldsa.c
+++ b/test/bench_components_mldsa.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <inttypes.h>

--- a/test/bench_mldsa.c
+++ b/test/bench_mldsa.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <inttypes.h>

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2022 Arm Limited
  * Copyright (c) 2020 Dougall Johnson
  * SPDX-License-Identifier: MIT

--- a/test/hal/hal.h
+++ b/test/hal/hal.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2022 Arm Limited
  * SPDX-License-Identifier: MIT
  *

--- a/test/nistrng/aes.c
+++ b/test/nistrng/aes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: MIT
  */
 

--- a/test/nistrng/aes.h
+++ b/test/nistrng/aes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: MIT
  */
 

--- a/test/nistrng/nistrng.h
+++ b/test/nistrng/nistrng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/nistrng/rng.c
+++ b/test/nistrng/rng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/notrandombytes/notrandombytes.c
+++ b/test/notrandombytes/notrandombytes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MI
  * Based on https://cr.yp.to/papers.html#surf by Daniel. J. Bernstein
  */

--- a/test/notrandombytes/notrandombytes.h
+++ b/test/notrandombytes/notrandombytes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MI
  * Based on https://cr.yp.to/papers.html#surf by Daniel. J. Bernstein
  */

--- a/test/test_mldsa.c
+++ b/test/test_mldsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The mldsa-native project authors
+ * Copyright (c) The mldsa-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Following https://github.com/pq-code-package/mlkem-native/pull/982/commits/c2bae1bef32385a160e37ecad5af3e3a2840f466 this commit removes the year from the copyright to save us the trouble of updating it every year.