### PR TITLE
Switch these proofs to use Z3 rather than Bitwuzla

### DIFF
--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = mld_invntt_layer
 

--- a/proofs/cbmc/poly_invntt_tomont/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = poly_invntt_tomont
 

--- a/proofs/cbmc/polyvecl_unpack_z/Makefile
+++ b/proofs/cbmc/polyvecl_unpack_z/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = polyvecl_unpack_z
 


### PR DESCRIPTION
I have found 3 functions whose proof is slow with Bitwuzla, but much faster with Z3.

Results on Mac M1:

polyvecl_unpack_z() - from 90s to 5s
poly_invntt_tomont() - from 75s to 5s
mld_invntt_layer() - from 65s to 30s

These were some of the most expensive proofs in the library, so reduce wall-clock time for the full proof run, even on large multi-core machines.