### PR TITLE
Fix: conditional in nix-post-check step in setup-nix action

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -92,7 +92,7 @@ runs:
 
         echo "cache_prefix=$cache_prefix" >> $GITHUB_OUTPUT
 
-        if [[ ${{ steps.nix-pre-check.outputs.installed }} == 'false' ]]; then
+        if [[ "${{ steps.nix-pre-check.outputs.installed }}" == 'false' ]]; then
           sudo chown -R $USER:nixbld /nix
         fi
 


### PR DESCRIPTION
The nix-post-check step in the setup-nix action used a conditional that is incorrectly using ${{ steps.nix-pre-check.outputs.installed }} as a raw value instead of a string causing a error in case the value is undefined. This commit wraps it quotes fixing the issue.

Related to https://github.com/pq-code-package/mlkem-native/issues/1033