### PR TITLE
Add contracts and proof files for polyveck_chknorm()

### DIFF
--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -370,6 +370,9 @@ int polyveck_chknorm(const polyveck *v, int32_t bound)
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    invariant(i <= MLDSA_K)
+  )
   {
     if (poly_chknorm(&v->vec[i], bound))
     {

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -356,7 +356,15 @@ __contract__(
  * Returns 0 if norm of all polynomials are strictly smaller than B <=
  *(MLDSA_Q-1)/8 and 1 otherwise.
  **************************************************/
-int polyveck_chknorm(const polyveck *v, int32_t B);
+int polyveck_chknorm(const polyveck *v, int32_t B)
+__contract__(
+  requires(memory_no_alias(v, sizeof(polyveck)))
+  requires(0 <= B && B <= (MLDSA_Q - 1) / 8)
+  requires(forall(k0, 0, MLDSA_K,
+                  array_bound(v->vec[k0].coeffs, 0, MLDSA_N,
+                              -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX)))
+  ensures(return_value == 0 || return_value == 1)
+);
 
 #define polyveck_power2round MLD_NAMESPACE(polyveck_power2round)
 /*************************************************

--- a/proofs/cbmc/polyveck_chknorm/Makefile
+++ b/proofs/cbmc/polyveck_chknorm/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyveck_chknorm_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyveck_chknorm
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_chknorm
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)poly_chknorm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyveck_chknorm
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyveck_chknorm/polyveck_chknorm_harness.c
+++ b/proofs/cbmc/polyveck_chknorm/polyveck_chknorm_harness.c
@@ -1,0 +1,12 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "polyvec.h"
+
+void harness(void)
+{
+  int32_t b;
+  polyveck *v;
+  int r;
+  r = polyveck_chknorm(v, b);
+}


### PR DESCRIPTION
Fixes #132 

Adds contracts and proof files for polyveck_chknorm()

Proofs, lint and tests OK.
