### PR TITLE
Refactor polyvecl_pointwise_acc_montgomery in preparation of native code

### DIFF
--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -146,8 +146,12 @@ __contract__(
  * Name:        polyvecl_pointwise_acc_montgomery
  *
  * Description: Pointwise multiply vectors of polynomials of length MLDSA_L,
- *multiply resulting vector by 2^{-32} and add (accumulate) polynomials in it.
- *Input/output vectors are in NTT domain representation.
+ *              multiply resulting vector by 2^{-32} and add (accumulate)
+ *              polynomials in it.
+ *              Input/output vectors are in NTT domain representation.
+ *              The second input is assumed to be output of an NTT, and
+ *              hence must have coefficients bounded by (-9q, +9q).
+ *
  *
  * Arguments:   - poly *w: output polynomial
  *              - const polyvecl *u: pointer to first input vector


### PR DESCRIPTION
This commit refactors polyvecl_pointwise_acc_montgomery in preparation of pulling in native code for this function.

For the optimized backends, this function will perform the accumulation of the products on 64-bit words prior to reducing it back to 32-bit, e.g., using Montgomery reduction.

This requires a pre-condition that this accumulation cannot overflow an int64_t. This is the case as in all call sites the second input is the output of an NTT which is bounded by 9q.

As a side-effect this commit allows proving the bounds using CBMC. Before the function was simply calling poly_pointwise_montgomery which does not provide any bounds on the inputs/outputs. Consequently the proof of the accumulation of those outputs to not overflow would be impossible.