### PR TITLE
Update to nixpkgs 25.05

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: CI
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [ "opened", "synchronize" ]
+
+jobs:
+  base:
+    name: Base
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/base.yml
+    secrets: inherit
+  nix:
+    name: Nix
+    permissions:
+      actions: 'write'
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/nix.yml
+    secrets: inherit
+  ci:
+    name: Extended
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base, nix ]
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+  cbmc:
+    name: CBMC
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base, nix ]
+    uses: ./.github/workflows/cbmc.yml
+    secrets: inherit

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,173 @@
+# Copyright (c) The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: Base
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        system: [ubuntu-latest, pqcp-arm64]
+    name: Linting
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/lint
+        with:
+          nix-shell: ci-linter
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          cross-prefix: "aarch64-unknown-linux-gnu-"
+  lint-markdown-link:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
+  quickcheck:
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: ubuntu-latest
+           name: 'x86_64'
+         - runner: macos-latest
+           name: 'macos (aarch64)'
+         - runner: macos-13
+           name: 'macos (x86_64)'
+        exclude:
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'aarch64'
+             }}
+    name: Quickcheck (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: make quickcheck
+        run: |
+          OPT=0 make quickcheck
+          make clean >/dev/null
+          OPT=1 make quickcheck
+      - uses: ./.github/actions/setup-os
+      - name: tests func
+        run: |
+          ./scripts/tests func
+  quickcheck_bench:
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: ubuntu-latest
+           name: 'x86_64'
+         - runner: macos-latest
+           name: 'macos (aarch64)'
+         - runner: macos-13
+           name: 'macos (x86_64)'
+        exclude:
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'aarch64'
+             }}
+    name: Quickcheck bench (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: "tests bench (cycles: NO)"
+        run: |
+          ./scripts/tests bench -c NO
+      - name: "tests bench (build only, cycles: PMU)"
+        if: ${{ matrix.target.name != 'macos (aarch64)' && matrix.target.name != 'macos (x86_64)' }}
+        run: |
+          make clean
+          ./scripts/tests bench -c PMU --no-run
+      - name: "tests bench (build only, cycles: PERF)"
+        if: ${{ matrix.target.name != 'macos (aarch64)' && matrix.target.name != 'macos (x86_64)' }}
+        run: |
+          make clean
+          ./scripts/tests bench -c PERF --no-run
+      - name: "tests bench (build only, cycles: MAC)"
+        if: ${{ matrix.target.name == 'macos (aarch64)' || matrix.target.name == 'macos (x86_64)' }}
+        run: |
+          make clean
+          ./scripts/tests bench -c MAC --no-run
+      - name: tests bench components
+        run: |
+          make clean
+          ./scripts/tests bench --components -c NO
+  quickcheck-c90:
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: ubuntu-latest
+           name: 'x86_64'
+        exclude:
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'aarch64'
+             }}
+    name: Quickcheck C90 (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: make quickcheck
+        run: |
+          OPT=0 CFLAGS=-std=c90 make quickcheck
+          make clean >/dev/null
+          OPT=1 CFLAGS=-std=c90 make quickcheck
+      - uses: ./.github/actions/setup-apt
+      - name: tests func
+        run: |
+          ./scripts/tests func --cflags="-std=c90"
+      - name: tests bench
+        run: |
+          ./scripts/tests bench -c NO --cflags="-std=c90"
+      - name: tests bench components
+        run: |
+          ./scripts/tests bench --components -c NO --cflags="-std=c90"
+  scan-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: ubuntu-latest
+           name: 'x86_64'
+    name: scan-build (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-apt
+        with:
+          packages: clang-tools clang
+      - name: make quickcheck
+        run: |
+          scan-build --status-bugs make quickcheck OPT=0
+          make clean >/dev/null
+          scan-build --status-bugs make quickcheck OPT=1

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: CBMC
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  cbmc_44:
+    name: CBMC (ML-DSA-44)
+    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/ci_ec2_reusable.yml
+    with:
+      name: CBMC (ML-DSA-44)
+      ec2_instance_type: c7g.8xlarge
+      ec2_ami: ubuntu-latest (custom AMI)
+      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
+      compile_mode: native
+      opt: no_opt
+      lint: false
+      verbose: true
+      functest: true
+      kattest: false
+      nistkattest: false
+      acvptest: false
+      cbmc: true
+      cbmc_mldsa_mode: 2
+    secrets: inherit
+  cbmc_65:
+    name: CBMC (ML-DSA-65)
+    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/ci_ec2_reusable.yml
+    with:
+      name: CBMC (ML-DSA-65)
+      ec2_instance_type: c7g.8xlarge
+      ec2_ami: ubuntu-latest (custom AMI)
+      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
+      compile_mode: native
+      opt: no_opt
+      lint: false
+      verbose: true
+      functest: true
+      kattest: false
+      nistkattest: false
+      acvptest: false
+      cbmc: true
+      cbmc_mldsa_mode: 3
+    secrets: inherit
+  cbmc_87:
+    name: CBMC (ML-DSA-87)
+    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/ci_ec2_reusable.yml
+    with:
+      name: CBMC (ML-DSA-87)
+      ec2_instance_type: c7g.8xlarge
+      ec2_ami: ubuntu-latest (custom AMI)
+      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
+      compile_mode: native
+      opt: no_opt
+      lint: false
+      verbose: true
+      functest: true
+      kattest: false
+      nistkattest: false
+      acvptest: false
+      cbmc: true
+      cbmc_mldsa_mode: 5
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,186 +2,15 @@
 # Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-name: CI
+name: Extended
 permissions:
   contents: read
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
-    types: ["opened", "synchronize"]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
-  lint:
-    strategy:
-      fail-fast: false
-      matrix:
-        system: [ubuntu-latest, pqcp-arm64]
-    name: Linting
-    runs-on: ${{ matrix.system }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/lint
-        with:
-          nix-shell: ci-linter
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          cross-prefix: "aarch64-unknown-linux-gnu-"
-  lint-markdown-link:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
-  quickcheck:
-    strategy:
-      fail-fast: false
-      matrix:
-        external:
-         - ${{ github.repository_owner != 'pq-code-package' }}
-        target:
-         - runner: pqcp-arm64
-           name: 'aarch64'
-         - runner: ubuntu-latest
-           name: 'x86_64'
-         - runner: macos-latest
-           name: 'macos (aarch64)'
-         - runner: macos-13
-           name: 'macos (x86_64)'
-        exclude:
-          - {external: true,
-             target: {
-               runner: pqcp-arm64,
-               name: 'aarch64'
-             }}
-    name: Quickcheck (${{ matrix.target.name }})
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: make quickcheck
-        run: |
-          OPT=0 make quickcheck
-          make clean >/dev/null
-          OPT=1 make quickcheck
-      - uses: ./.github/actions/setup-os
-      - name: tests func
-        run: |
-          ./scripts/tests func
-  quickcheck_bench:
-    strategy:
-      fail-fast: false
-      matrix:
-        external:
-         - ${{ github.repository_owner != 'pq-code-package' }}
-        target:
-         - runner: pqcp-arm64
-           name: 'aarch64'
-         - runner: pqcp-arm64
-           name: 'aarch64'
-         - runner: ubuntu-latest
-           name: 'x86_64'
-         - runner: macos-latest
-           name: 'macos (aarch64)'
-         - runner: macos-13
-           name: 'macos (x86_64)'
-        exclude:
-          - {external: true,
-             target: {
-               runner: pqcp-arm64,
-               name: 'aarch64'
-             }}
-    name: Quickcheck bench (${{ matrix.target.name }})
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: "tests bench (cycles: NO)"
-        run: |
-          ./scripts/tests bench -c NO
-      - name: "tests bench (build only, cycles: PMU)"
-        if: ${{ matrix.target.name != 'macos (aarch64)' && matrix.target.name != 'macos (x86_64)' }}
-        run: |
-          make clean
-          ./scripts/tests bench -c PMU --no-run
-      - name: "tests bench (build only, cycles: PERF)"
-        if: ${{ matrix.target.name != 'macos (aarch64)' && matrix.target.name != 'macos (x86_64)' }}
-        run: |
-          make clean
-          ./scripts/tests bench -c PERF --no-run
-      - name: "tests bench (build only, cycles: MAC)"
-        if: ${{ matrix.target.name == 'macos (aarch64)' || matrix.target.name == 'macos (x86_64)' }}
-        run: |
-          make clean
-          ./scripts/tests bench -c MAC --no-run
-      - name: tests bench components
-        run: |
-          make clean
-          ./scripts/tests bench --components -c NO
-  quickcheck-c90:
-    strategy:
-      fail-fast: false
-      matrix:
-        external:
-         - ${{ github.repository_owner != 'pq-code-package' }}
-        target:
-         - runner: pqcp-arm64
-           name: 'aarch64'
-         - runner: ubuntu-latest
-           name: 'x86_64'
-        exclude:
-          - {external: true,
-             target: {
-               runner: pqcp-arm64,
-               name: 'aarch64'
-             }}
-    name: Quickcheck C90 (${{ matrix.target.name }})
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: make quickcheck
-        run: |
-          OPT=0 CFLAGS=-std=c90 make quickcheck
-          make clean >/dev/null
-          OPT=1 CFLAGS=-std=c90 make quickcheck
-      - uses: ./.github/actions/setup-apt
-      - name: tests func
-        run: |
-          ./scripts/tests func --cflags="-std=c90"
-      - name: tests bench
-        run: |
-          ./scripts/tests bench -c NO --cflags="-std=c90"
-      - name: tests bench components
-        run: |
-          ./scripts/tests bench --components -c NO --cflags="-std=c90"
-  scan-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        external:
-         - ${{ github.repository_owner != 'pq-code-package' }}
-        target:
-         - runner: pqcp-arm64
-           name: 'aarch64'
-         - runner: ubuntu-latest
-           name: 'x86_64'
-    name: scan-build (${{ matrix.target.name }})
-    runs-on: ${{ matrix.target.runner }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/setup-apt
-        with:
-          packages: clang-tools clang
-      - name: make quickcheck
-        run: |
-          scan-build --status-bugs make quickcheck OPT=0
-          make clean >/dev/null
-          scan-build --status-bugs make quickcheck OPT=1
-
   build_kat:
-    needs: [quickcheck, quickcheck-c90, quickcheck_bench, lint]
     strategy:
       fail-fast: false
       matrix:
@@ -295,7 +124,6 @@ jobs:
           compile_mode: native
           cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
   compiler_tests:
-    needs: [quickcheck, quickcheck-c90, quickcheck_bench, lint]
     name: Compiler tests  (${{ matrix.compiler.name }}, ${{ matrix.target.name }})
     strategy:
       fail-fast: false
@@ -500,79 +328,6 @@ jobs:
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
           cflags: "-std=c23"
-
-  cbmc_44:
-    needs: [quickcheck, quickcheck-c90, quickcheck_bench, lint]
-    name: CBMC (ML-DSA-44)
-    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    uses: ./.github/workflows/ci_ec2_reusable.yml
-    with:
-      name: CBMC (ML-DSA-44)
-      ec2_instance_type: c7g.8xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
-      compile_mode: native
-      opt: no_opt
-      lint: false
-      verbose: true
-      functest: true
-      kattest: false
-      nistkattest: false
-      acvptest: false
-      cbmc: true
-      cbmc_mldsa_mode: 2
-    secrets: inherit
-  cbmc_65:
-    needs: [quickcheck, quickcheck-c90, quickcheck_bench, lint]
-    name: CBMC (ML-DSA-65)
-    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    uses: ./.github/workflows/ci_ec2_reusable.yml
-    with:
-      name: CBMC (ML-DSA-65)
-      ec2_instance_type: c7g.8xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
-      compile_mode: native
-      opt: no_opt
-      lint: false
-      verbose: true
-      functest: true
-      kattest: false
-      nistkattest: false
-      acvptest: false
-      cbmc: true
-      cbmc_mldsa_mode: 3
-    secrets: inherit
-  cbmc_87:
-    needs: [quickcheck, quickcheck-c90, quickcheck_bench, lint]
-    name: CBMC (ML-DSA-87)
-    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    uses: ./.github/workflows/ci_ec2_reusable.yml
-    with:
-      name: CBMC (ML-DSA-87)
-      ec2_instance_type: c7g.8xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
-      compile_mode: native
-      opt: no_opt
-      lint: false
-      verbose: true
-      functest: true
-      kattest: false
-      nistkattest: false
-      acvptest: false
-      cbmc: true
-      cbmc_mldsa_mode: 5
-    secrets: inherit
 
   check_autogenerated_files:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,13 @@ jobs:
            c23: False
            examples: False
            opt: no_opt
+         - name: zig-0.14
+           shell: ci_zig0_14
+           darwin: True
+           c17: True
+           c23: True
+           examples: False
+           opt: no_opt
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738435198,
-        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
+        "lastModified": 1747953325,
+        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
+        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
 
   inputs = {
     nixpkgs-2405.url = "github:NixOS/nixpkgs/nixos-24.05";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     flake-parts = {
@@ -25,9 +25,10 @@
           pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
           pkgs-2405 = inputs.nixpkgs-2405.legacyPackages.${system};
           util = pkgs.callPackage ./nix/util.nix {
+            # Keep those around in case we want to switch to unstable versions
             cbmc = pkgs.cbmc;
-            bitwuzla = pkgs-unstable.bitwuzla;
-            z3 = pkgs-unstable.z3_4_14;
+            bitwuzla = pkgs.bitwuzla;
+            z3 = pkgs.z3;
           };
           zigWrapCC = zig: pkgs.symlinkJoin {
             name = "zig-wrappers";
@@ -50,8 +51,9 @@
               (_:_: {
                 gcc48 = pkgs-2405.gcc48;
                 gcc49 = pkgs-2405.gcc49;
-                qemu = pkgs-unstable.qemu; # 9.2.2
-                clang_20 = pkgs-unstable.clang_20;
+                gcc7 = pkgs-2405.gcc7;
+                zig_0_10 = pkgs-2405.zig_0_10;
+                zig_0_11 = pkgs-2405.zig_0_11;
               })
             ];
           };
@@ -111,6 +113,7 @@
           devShells.ci_zig0_11 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_11);
           devShells.ci_zig0_12 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_12);
           devShells.ci_zig0_13 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_13);
+          devShells.ci_zig0_14 = util.mkShellWithCC' (zigWrapCC pkgs.zig);
 
           devShells.ci_gcc48 = util.mkShellWithCC' pkgs.gcc48;
           devShells.ci_gcc49 = util.mkShellWithCC' pkgs.gcc49;
@@ -144,8 +147,8 @@
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
               cbmc = pkgs.cbmc;
-              bitwuzla = pkgs-unstable.bitwuzla;
-              z3 = pkgs-unstable.z3_4_14;
+              bitwuzla = pkgs.bitwuzla;
+              z3 = pkgs.z3;
             };
           in
           util.mkShell {

--- a/nix/cbmc/0001-Do-not-download-sources-in-cmake.patch
+++ b/nix/cbmc/0001-Do-not-download-sources-in-cmake.patch
@@ -1,7 +1,27 @@
-# Copyright (c) The mlkem-native project authors
-# Copyright (c) The mldsa-native project authors
-# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
-diff --git a/src/solvers/CMakeLists.txt b/src/solvers/CMakeLists.txt
-index 003a0d957b..79751ef8b2 100644
---- a/src/solvers/CMakeLists.txt
-+++ b/src/solvers/CMakeLists.txt
+# SPDX-License-Identifier: MIT
+From 7b49a436bd5cc903b86b01f1a0f046ab8ec99fdb Mon Sep 17 00:00:00 2001
+From: wxt <3264117476@qq.com>
+Date: Mon, 11 Nov 2024 11:07:37 +0800
+Subject: [PATCH] Do not download sources in cmake
+
+---
+ CMakeLists.txt | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2c1289a..8128362 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -116,8 +116,7 @@ if(DEFINED CMAKE_USE_CUDD)
+     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadProject.cmake")
+     message(STATUS "Downloading Cudd-3.0.0")
+     download_project(PROJ cudd
+-            URL https://sourceforge.net/projects/cudd-mirror/files/cudd-3.0.0.tar.gz/download
+-            URL_MD5 4fdafe4924b81648b908881c81fe6c30
++            SOURCE_DIR @cudd@
+             )
+ 
+     if(NOT EXISTS ${cudd_SOURCE_DIR}/Makefile)
+-- 
+2.47.0
+

--- a/nix/cbmc/0002-Do-not-download-sources-in-cmake.patch
+++ b/nix/cbmc/0002-Do-not-download-sources-in-cmake.patch
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+From c6b6438d3c87ce000b4e80b2eda2389e9473d24c Mon Sep 17 00:00:00 2001
+From: wxt <3264117476@qq.com>
+Date: Mon, 11 Nov 2024 11:35:03 +0800
+Subject: [PATCH] Do not download sources in cmake
+
+---
+ src/solvers/CMakeLists.txt | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/src/solvers/CMakeLists.txt b/src/solvers/CMakeLists.txt
+index ab8d111..d7165e2 100644
+--- a/src/solvers/CMakeLists.txt
++++ b/src/solvers/CMakeLists.txt
+@@ -102,10 +102,9 @@ foreach(SOLVER ${sat_impl})
+         message(STATUS "Building solvers with glucose")
+ 
+         download_project(PROJ glucose
+-            URL https://github.com/BrunoDutertre/glucose-syrup/archive/0bb2afd3b9baace6981cbb8b4a1c7683c44968b7.tar.gz
++            SOURCE_DIR @srcglucose@
+             PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/scripts/glucose-syrup-patch
+             COMMAND cmake -E copy ${CBMC_SOURCE_DIR}/scripts/glucose_CMakeLists.txt CMakeLists.txt
+-            URL_MD5 7c539c62c248b74210aef7414787323a
+         )
+ 
+         add_subdirectory(${glucose_SOURCE_DIR} ${glucose_BINARY_DIR})
+@@ -121,11 +120,10 @@ foreach(SOLVER ${sat_impl})
+         message(STATUS "Building solvers with cadical")
+ 
+         download_project(PROJ cadical
+-            URL https://github.com/arminbiere/cadical/archive/rel-2.0.0.tar.gz
++            SOURCE_DIR @srccadical@
+             PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/scripts/cadical-2.0.0-patch
+             COMMAND cmake -E copy ${CBMC_SOURCE_DIR}/scripts/cadical_CMakeLists.txt CMakeLists.txt
+             COMMAND ./configure
+-            URL_MD5 9fc2a66196b86adceb822a583318cc35
+         )
+ 
+         add_subdirectory(${cadical_SOURCE_DIR} ${cadical_BINARY_DIR})
+@@ -144,10 +142,9 @@ foreach(SOLVER ${sat_impl})
+         message(STATUS "Building with IPASIR solver linking against: CaDiCaL")
+ 
+         download_project(PROJ cadical
+-            URL https://github.com/arminbiere/cadical/archive/rel-2.0.0.tar.gz
++            SOURCE_DIR @srccadical@
+             PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/scripts/cadical-2.0.0-patch
+             COMMAND ./configure
+-            URL_MD5 9fc2a66196b86adceb822a583318cc35
+         )
+ 
+         message(STATUS "Building CaDiCaL")
+-- 
+2.47.0
+

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -9,6 +9,8 @@
 , ninja
 , cadical
 , z3
+, cudd
+, replaceVars
 }:
 
 buildEnv {
@@ -20,17 +22,24 @@ buildEnv {
         src = fetchFromGitHub {
           owner = "diffblue";
           repo = "cbmc";
-          rev = "3c915ebe35448a20555c1ef55d51540b52c5c34a";
           hash = "sha256-ot0vVBgiSVru/RE7KeyTsXzDfs0CSa5vaFsON+PCZZo=";
+          tag = "cbmc-6.6.0";
         };
+        # TODO: Remove those once upstream has removed the third patch
+        patches = [
+          (replaceVars ./0001-Do-not-download-sources-in-cmake.patch {
+            cudd = cudd.src;
+          })
+          ./0002-Do-not-download-sources-in-cmake.patch
+        ];
       });
       litani = callPackage ./litani.nix { }; # 1.29.0
       cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.11
 
       inherit
-        cadical#1.9.5
+        cadical#2.1.3
         bitwuzla# 0.7.0
-        z3# 4.14.1
-        ninja; # 1.11.1
+        z3# 4.15.0
+        ninja; # 1.12.1
     };
 }

--- a/nix/slothy/default.nix
+++ b/nix/slothy/default.nix
@@ -17,35 +17,10 @@
 
 
 let
-  # TODO: switch to protobuf from nixpkgs
-  # ortools 9.12 requires protobuf >= 5.29.3 - currently nixpkgs 24.11 has
-  # protobuf 5.28.3
-  protobuf_6_30_1 = python312Packages.buildPythonPackage rec {
-    pname = "protobuf";
-    version = "5.29.3";
 
-    propagatedBuildInputs = [
-      python312Packages.setuptools
-    ];
-
-    build-system = with python312Packages; [
-      setuptools
-    ];
-
-    dontConfigure = true;
-    nativeBuildInputs =
-      [
-        cmake
-        pkg-config
-      ];
-
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-XaD0HtrxF73jFkBLrRpIbLTt7fjkpUiRKW9kjo4HZiA=";
-    };
-  };
-
-
+  # I have experimented with the ortools (9.12) that is packaged in nixpkgs.
+  # However, it results in _much_ poorer SLOTHY performance and, we hence,
+  # instead stick to the pre-built ones from pypi.
   ortools912 = python312Packages.buildPythonPackage rec {
     pname = "ortools";
     version = "9.12.4544";
@@ -80,44 +55,15 @@ let
     propagatedBuildInputs = with python312Packages; [
       numpy
       pandas
-      protobuf_6_30_1
+      protobuf
     ];
 
-  };
-
-  # TODO: switch to unicorn from nixpkgs
-  # nixpkgs 24.11 currently has 2.1.1 - we are experiencing some issues with
-  # that version on MacOS. 2.1.2/2.1.3 (and also some older versions) don't
-  # have that problem
-  unicorn_2_1_3 = python312Packages.buildPythonPackage rec {
-    pname = "unicorn";
-    version = "2.1.3";
-
-    propagatedBuildInputs = [
-      python312Packages.setuptools
-    ];
-
-    build-system = with python312Packages; [
-      setuptools
-    ];
-
-    dontConfigure = true;
-    nativeBuildInputs =
-      [
-        cmake
-        pkg-config
-      ];
-
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-DAZFbPVQwijyADzHA2avpK7OLm5+TDLY9LIscXumtyk=";
-    };
   };
 
   pythonEnv = python312.withPackages (ps: with ps; [
     ortools912
     sympy
-    unicorn_2_1_3
+    unicorn
   ]);
 
 in


### PR DESCRIPTION
- Resolves https://github.com/pq-code-package/mldsa-native/issues/285

Similar to https://github.com/pq-code-package/mlkem-native/pull/1041
Additionally, refactoring the CI to align with mlkem-native

[NixOS 25.05 ](https://nixos.org/blog/announcements/2025/nixos-2505/) has been released yesterday bringing various version updates also to nixpkgs.

Notable changes for us are: 
 - Default clang/llvm is now 19; we switch to the default in the core shells
 - Default gcc is now 14; we switch to it in the core shells
 - gcc 7, zig_0_10, zig_0_11 are not longer supported in 25.05; we instead
   take it from nixpkgs 24.05
 - zig_0_14 has been added; we test in CI now as well
 - Unicorn and protobuf versions are now compatible with SLOTHY simpliying the
   build
 - z3 has been updated to 4.15.0; we take it from 25.05
 - clang_20, bitwuzla, qemu now have suitable versions in 25.05; we no longer
   need to take them from unstable.
 - The CBMC build in nixpkgs includes 3 patches now instead of 2. The third patch is not compatible and not needed for cbmc 6.6.0. We, hence, have to copy the first two patches and apply them locally. This makes the patch slightly more complicated.
 - A few dependency updates for which we do not require specific versions