### PR TITLE
Refactor poly_sub, polyveck_sub to two argument (first = in + out)

### DIFF
--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -65,19 +65,21 @@ void poly_add(poly *r, const poly *b)
     r->coeffs[i] = r->coeffs[i] + b->coeffs[i];
   }
 }
-
-void poly_sub(poly *c, const poly *a, const poly *b)
+/* Reference: We use destructive version (output=first input) to avoid
+ *            reasoning about aliasing in the CBMC specification */
+void poly_sub(poly *r, const poly *b)
 {
   unsigned int i;
 
   for (i = 0; i < MLDSA_N; ++i)
   __loop__(
-    invariant(i <= MLDSA_N)
-    invariant(forall(k1, 0, i, c->coeffs[k1] == a->coeffs[k1] - b->coeffs[k1])))
+      invariant(i <= MLDSA_N)
+      invariant(forall(k0, i, MLDSA_N, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
+      invariant(forall(k1, 0, i, r->coeffs[k1] == loop_entry(*r).coeffs[k1] - b->coeffs[k1]))
+    )
   {
-    c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+    r->coeffs[i] = r->coeffs[i] - b->coeffs[i];
   }
-  cassert(forall(k, 0, MLDSA_N, c->coeffs[k] == a->coeffs[k] - b->coeffs[k]));
 }
 
 void poly_shiftl(poly *a)

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -372,21 +372,22 @@ void polyveck_add(polyveck *u, const polyveck *v)
   }
 }
 
-void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v)
+void polyveck_sub(polyveck *u, const polyveck *v)
 {
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
   __loop__(
-    assigns(i, object_whole(w))
-    invariant(i <= MLDSA_K))
+    invariant(i <= MLDSA_K)
+    invariant(forall(k0, i, MLDSA_K, 
+             forall(k1, 0, MLDSA_N, u->vec[k0].coeffs[k1] == loop_entry(*u).vec[k0].coeffs[k1]))))
   {
-    poly t;
-    poly_sub(&t, &u->vec[i], &v->vec[i]);
+    poly tmp = u->vec[i];
+    poly_sub(&tmp, &v->vec[i]);
     /* Full struct assignment from local variables to simplify proof */
     /* TODO: eliminate once CBMC resolves
      * https://github.com/diffblue/cbmc/issues/8617 */
-    w->vec[i] = t;
+    u->vec[i] = tmp;
   }
 }
 

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -261,21 +261,17 @@ __contract__(
  * Description: Subtract vectors of polynomials of length MLDSA_K.
  *              No modular reduction is performed.
  *
- * Arguments:   - polyveck *w: pointer to output vector
- *              - const polyveck *u: pointer to first input vector
+ * Arguments:   - polyveck *u: pointer to first input vector
  *              - const polyveck *v: pointer to second input vector to be
  *                                   subtracted from first input vector
  **************************************************/
-void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v)
+void polyveck_sub(polyveck *u, const polyveck *v)
 __contract__(
-  requires(memory_no_alias(w, sizeof(polyveck)))
   requires(memory_no_alias(u, sizeof(polyveck)))
   requires(memory_no_alias(v, sizeof(polyveck)))
-  requires(forall(k0, 0, MLDSA_K,
-    forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] - v->vec[k0].coeffs[k1] <= INT32_MAX)))
-  requires(forall(k2, 0, MLDSA_K,
-    forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] - v->vec[k2].coeffs[k3] >= INT32_MIN)))
-  assigns(memory_slice(w, sizeof(polyveck)))
+  requires(forall(k0, 0, MLDSA_K, forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] - v->vec[k0].coeffs[k1] <= INT32_MAX)))
+  requires(forall(k2, 0, MLDSA_K, forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] - v->vec[k2].coeffs[k3] >= INT32_MIN)))
+  assigns(object_whole(u))
 );
 
 #define polyveck_shiftl MLD_NAMESPACE(polyveck_shiftl)

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -191,7 +191,7 @@ int crypto_sign_signature_internal(uint8_t *sig, size_t *siglen,
      * do not reveal secret information */
     polyveck_pointwise_poly_montgomery(&h, &cp, &s2);
     polyveck_invntt_tomont(&h);
-    polyveck_sub(&w0, &w0, &h);
+    polyveck_sub(&w0, &h);
     polyveck_reduce(&w0);
     if (polyveck_chknorm(&w0, MLDSA_GAMMA2 - MLDSA_BETA))
     {
@@ -355,7 +355,7 @@ int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
   polyveck_ntt(&t1);
   polyveck_pointwise_poly_montgomery(&t1, &cp, &t1);
 
-  polyveck_sub(&w1, &w1, &t1);
+  polyveck_sub(&w1, &t1);
   polyveck_reduce(&w1);
   polyveck_invntt_tomont(&w1);
 

--- a/proofs/cbmc/poly_sub/poly_sub_harness.c
+++ b/proofs/cbmc/poly_sub/poly_sub_harness.c
@@ -5,6 +5,6 @@
 
 void harness(void)
 {
-  poly *c, *a, *b;
-  poly_sub(c, a, b);
+  poly *r, *b;
+  poly_sub(r, b);
 }

--- a/proofs/cbmc/polyveck_sub/polyveck_sub_harness.c
+++ b/proofs/cbmc/polyveck_sub/polyveck_sub_harness.c
@@ -5,6 +5,6 @@
 
 void harness(void)
 {
-  polyveck *a, *b, *c;
-  polyveck_sub(a, b, c);
+  polyveck *u, *v;
+  polyveck_sub(u, v);
 }


### PR DESCRIPTION
- Resolves #289 

This commit changes the signature of poly_sub to take only 2 arguments.

polyveck_sub and all call sites are adjusted accordingly.

CBMC proofs are adjusted.