### PR TITLE
CBMC: Strengthen various contracts

### DIFF
--- a/proofs/cbmc/poly_add/Makefile
+++ b/proofs/cbmc/poly_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = poly_add
 

--- a/proofs/cbmc/polyvec_matrix_expand/Makefile
+++ b/proofs/cbmc/polyvec_matrix_expand/Makefile
@@ -14,7 +14,7 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += 
+UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = polyvec_matrix_expand
 

--- a/proofs/cbmc/polyvec_matrix_pointwise_montgomery/Makefile
+++ b/proofs/cbmc/polyvec_matrix_pointwise_montgomery/Makefile
@@ -14,7 +14,7 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyvec_matrix_pointwise_montgomery.0:8 # Largest value of MLDSA_K
+UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = polyvec_matrix_pointwise_montgomery
 

--- a/proofs/cbmc/polyveck_add/Makefile
+++ b/proofs/cbmc/polyveck_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --no-array-field-sensitivity --slice-formula
+CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = polyveck_add
 

--- a/proofs/cbmc/polyvecl_add/Makefile
+++ b/proofs/cbmc/polyvecl_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --no-array-field-sensitivity --slice-formula
+CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = polyvecl_add
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 


### PR DESCRIPTION
Fixes #291 

1. Rename `REDUCE_RANGE_MAX` to `REDUCE32_RANGE_MAX` to help differentiate this constant from `MONTGOMERY_REDUCE_RANGE_MAX`.

2. Similarly, and for consistency, `REDUCE_DOMAIN_MAX` is renamed to `REDUCE32_DOMAIN_MAX`

3. Strengthen post-conditions and loop invariants of the following functions
```
montgomery_reduce()
polyvecl_pointwise_acc_montgomery()
polyvec_matrix_pointwise_montgomery()
```

4. Tests, proofs, lint all OK.
