### PR TITLE
CBMC: Prove stronger post-condition for `invntt_tomont`

### DIFF
--- a/mldsa/ntt.h
+++ b/mldsa/ntt.h
@@ -11,6 +11,8 @@
 
 /* Absolute exclusive upper bound for the output of the forward NTT */
 #define MLD_NTT_BOUND (9 * MLDSA_Q)
+/* Absolute exclusive upper bound for the output of the inverse NTT*/
+#define MLD_INTT_BOUND 4211139
 
 #define ntt MLD_NAMESPACE(ntt)
 /*************************************************
@@ -45,20 +47,22 @@ __contract__(
 /*************************************************
  * Name:        invntt_tomont
  *
- * Description: Inverse NTT and multiplication by Montgomery factor 2^32.
- *              In-place. No modular reductions after additions or
- *              subtractions; input coefficients need to be smaller than
- *              MLDSA_Q in absolute value. Output coefficient are smaller than
- *              MLDSA_Q in absolute value.
+ * Description: Inverse NTT and multiplication by
+ *              Montgomery factor mont^2 /256. In-place.
+ *              No modular reductions after additions or subtractions;
+ *              input coefficients need to be smaller than MLDSA_Q in
+ *              absolute value.
+ *              Output coefficient are smaller than MLD_INTT_BOUND in
+ *              absolute value.
  *
- * Arguments:   - uint32_t a[MLDSA_N]: input/output coefficient array
+ * Arguments:   - int32_t a[MLDSA_N]: input/output coefficient array
  **************************************************/
 void invntt_tomont(int32_t a[MLDSA_N])
 __contract__(
   requires(memory_no_alias(a, MLDSA_N * sizeof(int32_t)))
   requires(array_abs_bound(a, 0, MLDSA_N, MLDSA_Q))
   assigns(memory_slice(a, MLDSA_N * sizeof(int32_t)))
-  ensures(array_abs_bound(a, 0, MLDSA_N, MLDSA_Q))
+  ensures(array_abs_bound(a, 0, MLDSA_N, MLD_INTT_BOUND))
 );
 
 #endif /* !MLD_NTT_H */

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -120,7 +120,7 @@ void poly_invntt_tomont(poly *a)
 {
   mld_assert_abs_bound(a->coeffs, MLDSA_N, MLDSA_Q);
   invntt_tomont(a->coeffs);
-  mld_assert_abs_bound(a->coeffs, MLDSA_N, MLDSA_Q);
+  mld_assert_abs_bound(a->coeffs, MLDSA_N, MLD_INTT_BOUND);
 }
 #else  /* !MLD_USE_NATIVE_INTT */
 void poly_invntt_tomont(poly *a)

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -141,7 +141,8 @@ __contract__(
  *
  * Description: Inplace inverse NTT and multiplication by 2^{32}.
  *              Input coefficients need to be less than MLDSA_Q in absolute
- *              value and output coefficients are again bounded by MLDSA_Q.
+ *              value and output coefficients are bounded by
+ *              MLD_INTT_BOUND.
  *
  * Arguments:   - poly *a: pointer to input/output polynomial
  **************************************************/
@@ -150,7 +151,7 @@ __contract__(
   requires(memory_no_alias(a, sizeof(poly)))
   requires(array_abs_bound(a->coeffs, 0, MLDSA_N, MLDSA_Q))
   assigns(memory_slice(a, sizeof(poly)))
-  ensures(array_abs_bound(a->coeffs, 0, MLDSA_N, MLDSA_Q))
+  ensures(array_abs_bound(a->coeffs, 0, MLDSA_N, MLD_INTT_BOUND))
 );
 
 #define poly_pointwise_montgomery MLD_NAMESPACE(poly_pointwise_montgomery)

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -234,7 +234,7 @@ void polyvecl_invntt_tomont(polyvecl *v)
   __loop__(
     invariant(i <= MLDSA_L)
     invariant(forall(k0, i, MLDSA_L, forall(k1, 0, MLDSA_N, v->vec[k0].coeffs[k1] == loop_entry(*v).vec[k0].coeffs[k1])))
-    invariant(forall(k1, 0, i, array_abs_bound(v->vec[k1].coeffs, 0, MLDSA_N, MLDSA_Q))))
+    invariant(forall(k1, 0, i, array_abs_bound(v->vec[k1].coeffs, 0, MLDSA_N, MLD_INTT_BOUND))))
   {
     poly t = v->vec[i];
     poly_invntt_tomont(&t);
@@ -428,7 +428,7 @@ void polyveck_invntt_tomont(polyveck *v)
   __loop__(
     invariant(i <= MLDSA_K)
     invariant(forall(k0, i, MLDSA_K, forall(k1, 0, MLDSA_N, v->vec[k0].coeffs[k1] == loop_entry(*v).vec[k0].coeffs[k1])))
-    invariant(forall(k1, 0, i, array_abs_bound(v->vec[k1].coeffs, 0, MLDSA_N, MLDSA_Q))))
+    invariant(forall(k1, 0, i, array_abs_bound(v->vec[k1].coeffs, 0, MLDSA_N, MLD_INTT_BOUND))))
   {
     poly t = v->vec[i];
     poly_invntt_tomont(&t);

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -104,7 +104,8 @@ __contract__(
  *
  * Description: Inplace inverse NTT and multiplication by 2^{32}.
  *              Input coefficients need to be less than MLDSA_Q in absolute
- *              value and output coefficients are again bounded by MLDSA_Q.
+ *              value and output coefficients are bounded by
+ *              MLD_INTT_BOUND.
  *
  * Arguments:   - polyvecl *v: pointer to input/output vector
  **************************************************/
@@ -113,7 +114,7 @@ __contract__(
   requires(memory_no_alias(v, sizeof(polyvecl)))
   requires(forall(k0, 0, MLDSA_L, array_abs_bound(v->vec[k0].coeffs, 0, MLDSA_N, MLDSA_Q)))
   assigns(memory_slice(v, sizeof(polyvecl)))
-  ensures(forall(k1, 0, MLDSA_L, array_abs_bound(v->vec[k1].coeffs, 0 , MLDSA_N, MLDSA_Q)))
+  ensures(forall(k1, 0, MLDSA_L, array_abs_bound(v->vec[k1].coeffs, 0 , MLDSA_N, MLD_INTT_BOUND)))
 );
 
 #define polyvecl_pointwise_poly_montgomery \
@@ -313,9 +314,9 @@ __contract__(
  * Name:        polyveck_invntt_tomont
  *
  * Description: Inverse NTT and multiplication by 2^{32} of polynomials
- *              in vector of length MLDSA_K. Input coefficients need to be less
- *              than 2*MLDSA_Q.
- *
+ *              in vector of length MLDSA_K.
+ *              Input coefficients need to be less than MLDSA_Q, and
+ *              Output coefficients are bounded by MLD_INTT_BOUND.
  * Arguments:   - polyveck *v: pointer to input/output vector
  **************************************************/
 void polyveck_invntt_tomont(polyveck *v)
@@ -323,7 +324,7 @@ __contract__(
   requires(memory_no_alias(v, sizeof(polyveck)))
   requires(forall(k0, 0, MLDSA_K, array_abs_bound(v->vec[k0].coeffs, 0, MLDSA_N, MLDSA_Q)))
   assigns(memory_slice(v, sizeof(polyveck)))
-  ensures(forall(k1, 0, MLDSA_K, array_abs_bound(v->vec[k1].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  ensures(forall(k1, 0, MLDSA_K, array_abs_bound(v->vec[k1].coeffs, 0, MLDSA_N, MLD_INTT_BOUND)))
 );
 
 #define polyveck_pointwise_poly_montgomery \

--- a/proofs/cbmc/fqscale/Makefile
+++ b/proofs/cbmc/fqscale/Makefile
@@ -4,11 +4,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = invntt_tomont_harness
+HARNESS_FILE = fqscale_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = invntt_tomont
+PROOF_UID = fqscale
 
 DEFINES +=
 INCLUDES +=
@@ -17,10 +17,10 @@ REMOVE_FUNCTION_BODY +=
 UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
-PROJECT_SOURCES += $(SRCDIR)/mldsa/ntt.c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/ntt.c $(SRCDIR)/mldsa/reduce.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)invntt_tomont
-USE_FUNCTION_CONTRACTS=mld_invntt_layer mld_fqscale
+CHECK_FUNCTION_CONTRACTS=mld_fqscale
+USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -28,7 +28,7 @@ USE_DYNAMIC_FRAMES=1
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--bitwuzla
 
-FUNCTION_NAME = invntt_tomont
+FUNCTION_NAME = mld_fqscale
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
@@ -37,7 +37,7 @@ FUNCTION_NAME = invntt_tomont
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 9
+CBMC_OBJECT_BITS = 8
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/fqscale/fqscale_harness.c
+++ b/proofs/cbmc/fqscale/fqscale_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "ntt.h"
+
+int32_t mld_fqscale(int32_t a);
+void harness(void)
+{
+  int32_t a, r;
+  r = mld_fqscale(a);
+}


### PR DESCRIPTION
- Resolves #312 
Add the stronger post-condition to following function and rewrite the CBMC proof if necessary:

- [x] `fqscale` that sepreate from `mld_fqmul` with only one input and scale with fix value "41978"
- [x] `invntt_tomont`
- [x] `poly_invntt_tomont`
- [x] `polyvecl_invntt_tomont`: modified the post-condition with stronger bound MLD_INTT_BOUND(4211139)
- [x] `polyveck_invntt_tomont`: modified the post-condition with stronger bound MLD_INTT_BOUND(4211139)
