### PR TITLE
Strengthen post-condition of `polyveck_add` and `polyvecl_add`

### DIFF
--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -172,8 +172,9 @@ void polyvecl_add(polyvecl *u, const polyvecl *v)
   __loop__(
     assigns(i, memory_slice(u, sizeof(polyvecl)))
     invariant(i <= MLDSA_L)
-    invariant(forall(k0, i, MLDSA_L,
-              forall(k1, 0, MLDSA_N, u->vec[k0].coeffs[k1] == loop_entry(*u).vec[k0].coeffs[k1]))))
+    invariant(forall(k0, i, MLDSA_L, 
+              forall(k1, 0, MLDSA_N, u->vec[k0].coeffs[k1] == loop_entry(*u).vec[k0].coeffs[k1])))
+    invariant(forall(k4, 0, i, forall(k5, 0, MLDSA_N, u->vec[k4].coeffs[k5] == loop_entry(*u).vec[k4].coeffs[k5] + v->vec[k4].coeffs[k5]))))
   {
     poly_add(&u->vec[i], &v->vec[i]);
   }
@@ -317,8 +318,9 @@ void polyveck_add(polyveck *u, const polyveck *v)
   __loop__(
     assigns(i, memory_slice(u, sizeof(polyveck)))
     invariant(i <= MLDSA_K)
-    invariant(forall(k0, i, MLDSA_K,
-             forall(k1, 0, MLDSA_N, u->vec[k0].coeffs[k1] == loop_entry(*u).vec[k0].coeffs[k1]))))
+    invariant(forall(k0, i, MLDSA_K, 
+              forall(k1, 0, MLDSA_N, u->vec[k0].coeffs[k1] == loop_entry(*u).vec[k0].coeffs[k1])))
+    invariant(forall(k4, 0, i, forall(k5, 0, MLDSA_N, u->vec[k4].coeffs[k5] == loop_entry(*u).vec[k4].coeffs[k5] + v->vec[k4].coeffs[k5]))))
   {
     poly_add(&u->vec[i], &v->vec[i]);
   }

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -79,6 +79,7 @@ __contract__(
   requires(forall(k0, 0, MLDSA_L, forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] + v->vec[k0].coeffs[k1] <= INT32_MAX)))
   requires(forall(k2, 0, MLDSA_L, forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] + v->vec[k2].coeffs[k3] >= INT32_MIN)))
   assigns(object_whole(u))
+  ensures(forall(k4, 0, MLDSA_L, forall(k5, 0, MLDSA_N, u->vec[k4].coeffs[k5] == old(*u).vec[k4].coeffs[k5] + v->vec[k4].coeffs[k5])))
 );
 
 #define polyvecl_ntt MLD_NAMESPACE(polyvecl_ntt)
@@ -253,6 +254,7 @@ __contract__(
   requires(forall(k0, 0, MLDSA_K, forall(k1, 0, MLDSA_N, (int64_t) u->vec[k0].coeffs[k1] + v->vec[k0].coeffs[k1] <= INT32_MAX)))
   requires(forall(k2, 0, MLDSA_K, forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] + v->vec[k2].coeffs[k3] >= INT32_MIN)))
   assigns(object_whole(u))
+  ensures(forall(k4, 0, MLDSA_K, forall(k5, 0, MLDSA_N, u->vec[k4].coeffs[k5] == old(*u).vec[k4].coeffs[k5] + v->vec[k4].coeffs[k5])))
 );
 
 #define polyveck_sub MLD_NAMESPACE(polyveck_sub)

--- a/proofs/cbmc/polyveck_add/Makefile
+++ b/proofs/cbmc/polyveck_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --no-array-field-sensitivity --slice-formula
 
 FUNCTION_NAME = polyveck_add
 

--- a/proofs/cbmc/polyvecl_add/Makefile
+++ b/proofs/cbmc/polyvecl_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --no-array-field-sensitivity --slice-formula
 
 FUNCTION_NAME = polyvecl_add
 


### PR DESCRIPTION
- Resolves #311 

In https://github.com/pq-code-package/mldsa-native/issues/311, it was
identified that the current post-conditions are insufficent to complete
the higher level proofs.

There are 3 different places where polynomial additions are required
and they come with different input/output bounds:
Case 1: polyvecl_add in Signing
Inputs (-q, q) -- actual bound is tigher, but this suffices
Outputs (-2q, 2q)

Case 2: polyveck_add in Signing
Inputs (-q, q)
Outputs (-2q, 2q) -- no output bound required

Case 3: polyveck_add in Key Generation
Inputs (-4211139, 4211139) and (-4, 4) -- can relax to something like (-3q/4, 3q/4) and (-q/4, q/4)
Outputs (-q, q) -- this is a strict bound for the following to work.

It appears best to prove correctness of the addition itself, then the bound
reasoning can happen in the higher level functions.

This commit adds that functional correctness proof for polyvecl_add
and polyveck_add.
It only becomes feasible with a recent update to CBMC which also
allows removal of the workaround using whole-struct assignments.