### PR TITLE
AVX2: Add native implementation of `poly_reduce` and `poly_caddq`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,21 +33,21 @@ jobs:
           name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
           bench_pmu: PMU
           archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
-          cflags: "-flto -DMLD_FORCE_AARCH64"
+          cflags: "-DMLD_FORCE_AARCH64"
           bench_extra_args: ""
           only_no_opt: false
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
-          cflags: "-flto -DMLD_FORCE_AARCH64"
+          cflags: "-DMLD_FORCE_AARCH64"
           bench_extra_args: ""
           only_no_opt: false
         - system: a55
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: "-flto -static -DMLD_FORCE_AARCH64"
+          cflags: "-static -DMLD_FORCE_AARCH64"
           bench_extra_args: -w exec-on-a55
           only_no_opt: false
         - system: bpi
@@ -109,43 +109,43 @@ jobs:
             ec2_instance_type: t4g.small
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -mcpu=cortex-a76 -march=armv8.2-a
-            cflags: "-flto -DMLD_FORCE_AARCH64"
+            cflags: "-DMLD_FORCE_AARCH64"
             perf: PERF
           - name: Graviton3
             ec2_instance_type: c7g.medium
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv8.4-a+sha3
-            cflags: "-flto -DMLD_FORCE_AARCH64"
+            cflags: "-DMLD_FORCE_AARCH64"
             perf: PERF
           - name: Graviton4
             ec2_instance_type: c8g.medium
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv9-a+sha3
-            cflags: "-flto -DMLD_FORCE_AARCH64"
+            cflags: "-DMLD_FORCE_AARCH64"
             perf: PERF
           - name: AMD EPYC 4th gen (c7a)
             ec2_instance_type: c7a.medium
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver4
-            cflags: "-flto -DMLD_FORCE_X86_64"
+            cflags: "-DMLD_FORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 4th gen (c7i)
             ec2_instance_type: c7i.metal-24xl
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=sapphirerapids
-            cflags: "-flto -DMLD_FORCE_X86_64"
+            cflags: "-DMLD_FORCE_X86_64"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
             ec2_instance_type: c6a.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver3
-            cflags: "-flto -DMLD_FORCE_X86_64"
+            cflags: "-DMLD_FORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 3rd gen (c6i)
             ec2_instance_type: c6i.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=icelake-server
-            cflags: "-flto -DMLD_FORCE_X86_64"
+            cflags: "-DMLD_FORCE_X86_64"
             perf: PMU
     uses: ./.github/workflows/bench_ec2_reusable.yml
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')

--- a/mldsa/native/api.h
+++ b/mldsa/native/api.h
@@ -80,23 +80,49 @@ set if there are native implementations for NTT and INTT."
  * Arguments:   - int32_t p[MLDSA_N]: pointer to in/output polynomial
  *
  **************************************************/
-static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t p[MLDSA_N])
+static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t p[MLDSA_N]);
 #endif /* MLD_USE_NATIVE_NTT_CUSTOM_ORDER */
 
 
 #if defined(MLD_USE_NATIVE_INTT)
-    /*************************************************
-     * Name:        mld_intt_native
-     *
-     * Description: Computes inverse of negacyclic number-theoretic transform
-     *(NTT) of a polynomial in place.
-     *
-     *              The input polynomial is in bitreversed order.
-     *              The output polynomial is assumed to be in normal order.
-     *
-     * Arguments:   - uint32_t p[MLDSA_N]: pointer to in/output polynomial
-     **************************************************/
-    static MLD_INLINE void mld_intt_native(int16_t p[MLDSA_N])
+/*************************************************
+ * Name:        mld_intt_native
+ *
+ * Description: Computes inverse of negacyclic number-theoretic transform
+ *(NTT) of a polynomial in place.
+ *
+ *              The input polynomial is in bitreversed order.
+ *              The output polynomial is assumed to be in normal order.
+ *
+ * Arguments:   - uint32_t p[MLDSA_N]: pointer to in/output polynomial
+ **************************************************/
+static MLD_INLINE void mld_intt_native(int32_t p[MLDSA_N]);
 #endif /* MLD_USE_NATIVE_INTT */
+
+#if defined(MLD_USE_NATIVE_POLY_REDUCE)
+/*************************************************
+ * Name:        mld_poly_reduce_native
+ *
+ * Description: Inplace reduction of all coefficients of polynomial to
+ *              representative in [-6283009,6283008]. Assumes input
+ *              coefficients to be at most 2^31 - 2^22 - 1 in absolute
+ *value.
+ *
+ * Arguments:   - int32_t *a: pointer to input/output polynomial
+ **************************************************/
+static MLD_INLINE void mld_poly_reduce_native(int32_t a[MLDSA_N]);
+#endif /* MLD_USE_NATIVE_POLY_REDUCE */
+
+#if defined(MLD_USE_NATIVE_POLY_CADDQ)
+/*************************************************
+ * Name:        mld_poly_caddq_native
+ *
+ * Description: For all coefficients of in/out polynomial add Q if
+ *              coefficient is negative.
+ *
+ * Arguments:   - int32_t *a: pointer to input/output polynomial
+ **************************************************/
+static MLD_INLINE void mld_poly_caddq_native(int32_t a[MLDSA_N]);
+#endif /* MLD_USE_NATIVE_POLY_CADDQ */
 
 #endif /* !MLD_NATIVE_API_H */

--- a/mldsa/native/x86_64/meta.h
+++ b/mldsa/native/x86_64/meta.h
@@ -14,6 +14,8 @@
 #define MLD_USE_NATIVE_NTT_CUSTOM_ORDER
 #define MLD_USE_NATIVE_NTT
 #define MLD_USE_NATIVE_INTT
+#define MLD_USE_NATIVE_POLY_REDUCE
+#define MLD_USE_NATIVE_POLY_CADDQ
 
 #if !defined(__ASSEMBLER__)
 #include <string.h>
@@ -32,6 +34,16 @@ static MLD_INLINE void mld_ntt_native(int32_t data[MLDSA_N])
 static MLD_INLINE void mld_intt_native(int32_t data[MLDSA_N])
 {
   mld_invntt_avx2((__m256i *)data, mld_qdata.vec);
+}
+
+static MLD_INLINE void mld_poly_reduce_native(int32_t a[MLDSA_N])
+{
+  mld_poly_reduce_avx2(a);
+}
+
+static MLD_INLINE void mld_poly_caddq_native(int32_t a[MLDSA_N])
+{
+  mld_poly_caddq_avx2(a);
 }
 
 #endif /* !__ASSEMBLER__ */

--- a/mldsa/native/x86_64/src/arith_native_x86_64.h
+++ b/mldsa/native/x86_64/src/arith_native_x86_64.h
@@ -19,4 +19,10 @@ void mld_invntt_avx2(__m256i *r, const __m256i *mld_qdata);
 #define mld_nttunpack_avx2 MLD_NAMESPACE(nttunpack_avx2)
 void mld_nttunpack_avx2(__m256i *r);
 
+#define mld_poly_reduce_avx2 MLD_NAMESPACE(poly_reduce_avx2)
+void mld_poly_reduce_avx2(int32_t *r);
+
+#define mld_poly_caddq_avx2 MLD_NAMESPACE(poly_caddq_avx2)
+void mld_poly_caddq_avx2(int32_t *r);
+
 #endif /* !MLD_NATIVE_X86_64_SRC_ARITH_NATIVE_X86_64_H */

--- a/mldsa/native/x86_64/src/reduce_avx2.c
+++ b/mldsa/native/x86_64/src/reduce_avx2.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/*
+ * This file is derived from the public domain
+ * AVX2 Dilithium implementation @[REF_AVX2].
+ */
+
+#include "../../../common.h"
+
+#if defined(MLD_ARITH_BACKEND_X86_64_DEFAULT) && \
+    !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
+
+#include <immintrin.h>
+#include <stdint.h>
+#include "../../../reduce.h"
+#include "arith_native_x86_64.h"
+#include "consts.h"
+
+/*************************************************
+ * Name:        mld_poly_reduce_avx2
+ *
+ * Description: Inplace reduction of all coefficients of polynomial to
+ *              representative in [-6283009,6283008]. Assumes input
+ *              coefficients to be at most 2^31 - 2^22 - 1 in absolute value.
+ *
+ * Arguments:   - int32_t *r: pointer to input/output polynomial
+ **************************************************/
+void mld_poly_reduce_avx2(int32_t *r)
+{
+  unsigned int i;
+  __m256i f, g;
+  const __m256i q = _mm256_set1_epi32(MLDSA_Q);
+  const __m256i off = _mm256_set1_epi32(1 << 22);
+  __m256i *rr = (__m256i *)r;
+
+  for (i = 0; i < MLDSA_N / 8; i++)
+  {
+    f = _mm256_load_si256(&rr[i]);
+    g = _mm256_add_epi32(f, off);
+    g = _mm256_srai_epi32(g, 23);
+    g = _mm256_mullo_epi32(g, q);
+    f = _mm256_sub_epi32(f, g);
+    _mm256_store_si256(&rr[i], f);
+  }
+}
+
+/*************************************************
+ * Name:        mld_poly_caddq_avx2
+ *
+ * Description: For all coefficients of in/out polynomial add Q if
+ *              coefficient is negative.
+ *
+ * Arguments:   - int32_t *r: pointer to input/output polynomial
+ **************************************************/
+void mld_poly_caddq_avx2(int32_t *r)
+{
+  unsigned int i;
+  __m256i f, g;
+  const __m256i q = _mm256_set1_epi32(MLDSA_Q);
+  const __m256i zero = _mm256_setzero_si256();
+  __m256i *rr = (__m256i *)r;
+
+  for (i = 0; i < MLDSA_N / 8; i++)
+  {
+    f = _mm256_load_si256(&rr[i]);
+    g = _mm256_cmpgt_epi32(zero, f);
+    g = _mm256_and_si256(g, q);
+    f = _mm256_add_epi32(f, g);
+    _mm256_store_si256(&rr[i], f);
+  }
+}
+
+#else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
+       */
+
+MLD_EMPTY_CU(avx2_reduce)
+
+#endif /* !(MLD_ARITH_BACKEND_X86_64_DEFAULT && \
+          !MLD_CONFIG_MULTILEVEL_NO_SHARED) */

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -16,11 +16,16 @@
 
 void poly_reduce(poly *a)
 {
+#if !defined(MLD_USE_NATIVE_POLY_REDUCE)
   unsigned int i;
+#endif
   /* TODO: Introduce the following after using inclusive lower bounds in
    * the underlying debug function mld_debug_check_bounds(). */
   /* mld_assert_bound(a->coeffs, MLDSA_N, INT32_MIN, REDUCE_DOMAIN_MAX); */
 
+#if defined(MLD_USE_NATIVE_POLY_REDUCE)
+  mld_poly_reduce_native(a->coeffs);
+#else
   for (i = 0; i < MLDSA_N; ++i)
   __loop__(
     invariant(i <= MLDSA_N)
@@ -29,15 +34,21 @@ void poly_reduce(poly *a)
   {
     a->coeffs[i] = reduce32(a->coeffs[i]);
   }
+#endif /* !MLD_USE_NATIVE_POLY_REDUCE */
 
   mld_assert_bound(a->coeffs, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX);
 }
 
 void poly_caddq(poly *a)
 {
+#if !defined(MLD_USE_NATIVE_POLY_CADDQ)
   unsigned int i;
+#endif
   mld_assert_abs_bound(a->coeffs, MLDSA_N, MLDSA_Q);
 
+#if defined(MLD_USE_NATIVE_POLY_CADDQ)
+  mld_poly_caddq_native(a->coeffs);
+#else
   for (i = 0; i < MLDSA_N; ++i)
   __loop__(
     invariant(i <= MLDSA_N)
@@ -47,6 +58,7 @@ void poly_caddq(poly *a)
   {
     a->coeffs[i] = caddq(a->coeffs[i]);
   }
+#endif /* !MLD_USE_NATIVE_POLY_CADDQ */
 
   mld_assert_bound(a->coeffs, MLDSA_N, 0, MLDSA_Q);
 }

--- a/test/bench_components_mldsa.c
+++ b/test/bench_components_mldsa.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "../mldsa/ntt.h"
 #include "../mldsa/poly.h"
+#include "../mldsa/polyvec.h"
 #include "../mldsa/randombytes.h"
 #include "hal.h"
 
@@ -26,6 +27,9 @@ static int cmp_uint64_t(const void *a, const void *b)
   for (i = 0; i < NTESTS; i++)                          \
   {                                                     \
     randombytes((uint8_t *)data0, sizeof(data0));       \
+    randombytes((uint8_t *)data1, sizeof(data1));       \
+    randombytes((uint8_t *)data2, sizeof(data2));       \
+    randombytes((uint8_t *)data3, sizeof(data3));       \
     for (j = 0; j < NWARMUP; j++)                       \
     {                                                   \
       code;                                             \
@@ -44,14 +48,46 @@ static int cmp_uint64_t(const void *a, const void *b)
 
 static int bench(void)
 {
-  MLD_ALIGN int32_t data0[256];
+  MLD_ALIGN int32_t data0[MLDSA_N * MLDSA_K];
+  MLD_ALIGN int32_t data1[MLDSA_N * MLDSA_K];
+  MLD_ALIGN int32_t data2[MLDSA_N * MLDSA_K];
+  MLD_ALIGN int32_t data3[MLDSA_N * MLDSA_K];
   uint64_t cyc[NTESTS];
   unsigned i, j;
   uint64_t t0, t1;
 
-  /* ntt */
   BENCH("poly_ntt", poly_ntt((poly *)data0))
   BENCH("poly_invntt_tomont", poly_invntt_tomont((poly *)data0))
+
+  BENCH("poly_pointwise_montgomery",
+        poly_pointwise_montgomery((poly *)data0, (poly *)data1, (poly *)data2))
+  BENCH("poly_reduce", poly_reduce((poly *)data0))
+  BENCH("poly_caddq", poly_caddq((poly *)data0))
+  BENCH("poly_add", poly_add((poly *)data0, (poly *)data1))
+  BENCH("poly_sub", poly_sub((poly *)data0, (poly *)data1))
+  BENCH("poly_shiftl", poly_shiftl((poly *)data0))
+  BENCH("poly_power2round",
+        poly_power2round((poly *)data0, (poly *)data1, (poly *)data2))
+  BENCH("poly_decompose",
+        poly_decompose((poly *)data0, (poly *)data1, (poly *)data2))
+  BENCH("poly_make_hint",
+        poly_make_hint((poly *)data0, (poly *)data1, (poly *)data2))
+  BENCH("poly_use_hint",
+        poly_use_hint((poly *)data0, (poly *)data1, (poly *)data2))
+  BENCH("poly_chknorm", poly_chknorm((poly *)data0, INT32_MAX))
+  BENCH("polyz_unpack", polyz_unpack((poly *)data0, (uint8_t *)data1))
+  BENCH("polyw1_pack", polyw1_pack((uint8_t *)data0, (poly *)data1))
+  BENCH("polyt1_unpack", polyt1_unpack((poly *)data0, (uint8_t *)data1))
+  BENCH("polyt1_unpack", polyt1_unpack((poly *)data0, (uint8_t *)data1))
+  BENCH("poly_uniform", poly_uniform((poly *)data0, (uint8_t *)data1))
+  BENCH("poly_uniform_4x", poly_uniform((poly *)data0, (uint8_t *)data1))
+  BENCH("poly_uniform_eta_4x",
+        poly_uniform_eta_4x((poly *)data0, (poly *)data1, (poly *)data2,
+                            (poly *)data3, (uint8_t *)data1, 0, 1, 2, 3))
+
+  BENCH("polyvecl_pointwise_acc_montgomery",
+        polyvecl_pointwise_acc_montgomery((poly *)data0, (polyvecl *)data1,
+                                          (polyvecl *)data2))
 
   return 0;
 }


### PR DESCRIPTION
TESTING CI

- Resolves https://github.com/pq-code-package/mldsa-native/issues/327
- Resolves https://github.com/pq-code-package/mldsa-native/issues/326

Following the flow of https://github.com/pq-code-package/mldsa-native/pull/317:
- First add axv2 native implementation for `poly_reduce` and `poly_caddq`
- Then build x86 asmb implementation as in mlkem-native https://github.com/pq-code-package/mlkem-native/blob/main/mlkem/src/native/x86_64/src/reduce.S
