### PR TITLE
Fix benchmark parsing

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -567,7 +567,7 @@ class Tests:
                         {
                             "name": f"{schemeStr} {primitive}",
                             "unit": "cycles",
-                            "value": d[f"{primitive} cycles"],
+                            "value": d[f"{primitive} cycles (avg)"],
                         }
                     )
 


### PR DESCRIPTION
https://github.com/pq-code-package/mldsa-native/pull/307 changes the output format of the benchmarks adding an 'avg'.
This broke the parsing of the benchmarks that is required for the Github benchmark action.
This commit fixes that parsing and restores the benchmarking in CI.