### PR TITLE
Remove workarounds for CBMC issue 8617

### DIFF
--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -221,8 +221,8 @@ __contract__(
   requires(memory_no_alias(a0, sizeof(poly)))
   requires(memory_no_alias(a, sizeof(poly)))
   requires(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
-  assigns(object_whole(a1))
-  assigns(object_whole(a0))
+  assigns(memory_slice(a1, sizeof(poly)))
+  assigns(memory_slice(a0, sizeof(poly)))
   ensures(array_bound(a1->coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)))
   ensures(array_abs_bound(a0->coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1))
 );

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -185,7 +185,7 @@ int polyvecl_chknorm(const polyvecl *v, int32_t B)
 __contract__(
   requires(memory_no_alias(v, sizeof(polyvecl)))
   requires(0 <= B && B <= (MLDSA_Q - 1) / 8)
-  requires(forall(k0, 0, MLDSA_L, 
+  requires(forall(k0, 0, MLDSA_L,
     array_bound(v->vec[k0].coeffs, 0, MLDSA_N, -REDUCE_RANGE_MAX, REDUCE_RANGE_MAX)))
   ensures(return_value == 0 || return_value == 1)
 );
@@ -422,8 +422,8 @@ __contract__(
   requires(memory_no_alias(v, sizeof(polyveck)))
   requires(forall(k0, 0, MLDSA_K,
     array_bound(v->vec[k0].coeffs, 0, MLDSA_N, 0, MLDSA_Q)))
-  assigns(object_whole(v1))
-  assigns(object_whole(v0))
+  assigns(memory_slice(v1, sizeof(polyveck)))
+  assigns(memory_slice(v0, sizeof(polyveck)))
   ensures(forall(k1, 0, MLDSA_K,
                  array_bound(v1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)) &&
                  array_abs_bound(v0->vec[k1].coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1)))


### PR DESCRIPTION
Remove all but one instance of workaround for CBMC issue 8617 now that CBMC 6.7.0 has been rolled out.

The final workaround in polyvec_matrix_expand() requires some additional refactoring of the code, so will be dealt with under a separate PR.
