### PR TITLE
CBMC Proof of crypto_sign_keypair()

### DIFF
--- a/mldsa/randombytes.h
+++ b/mldsa/randombytes.h
@@ -8,6 +8,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void randombytes(uint8_t *out, size_t outlen);
+#include "cbmc.h"
+#include "common.h"
+
+void randombytes(uint8_t *out, size_t outlen)
+__contract__(
+  requires(memory_no_alias(out, outlen))
+  assigns(memory_slice(out, outlen))
+);
 
 #endif /* !MLD_RANDOMBYTES_H */

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -24,7 +24,7 @@
  *              - uint8_t *sk:   pointer to output private key (allocated
  *                               array of CRYPTO_SECRETKEYBYTES bytes)
  *              - uint8_t *seed: pointer to input random seed (MLDSA_SEEDBYTES
- *bytes)
+ *                               bytes)
  *
  * Returns 0 (success)
  **************************************************/
@@ -52,7 +52,13 @@ __contract__(
  *
  * Returns 0 (success)
  **************************************************/
-int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+int crypto_sign_keypair(uint8_t *pk, uint8_t *sk)
+__contract__(
+  requires(memory_no_alias(pk, CRYPTO_PUBLICKEYBYTES))
+  requires(memory_no_alias(sk, CRYPTO_SECRETKEYBYTES))
+  assigns(object_whole(pk))
+  assigns(object_whole(sk))
+);
 
 #define crypto_sign_signature_internal MLD_NAMESPACE(signature_internal)
 /*************************************************

--- a/proofs/cbmc/crypto_sign_keypair/Makefile
+++ b/proofs/cbmc/crypto_sign_keypair/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_sign_keypair_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_sign_keypair
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)keypair
+USE_FUNCTION_CONTRACTS=randombytes
+USE_FUNCTION_CONTRACTS+=$(MLD_NAMESPACE)crypto_sign_keypair_internal
+
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+
+FUNCTION_NAME = crypto_sign_keypair
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/crypto_sign_keypair/crypto_sign_keypair_harness.c
+++ b/proofs/cbmc/crypto_sign_keypair/crypto_sign_keypair_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void harness(void)
+{
+  uint8_t *pk, *sk;
+  int r;
+  r = crypto_sign_keypair(pk, sk);
+}


### PR DESCRIPTION
Fixes #268 

CBMC Proof of crypto_sign_keypair()

1. Add minimal contract for randombytes.h randombytes() function.
2. Add contracts and proof support files for crypto_sign_keypair().

Tests OK. Lint OK. All proofs OK.
