### PR TITLE
CBMC: Add the spec and proof for crypto_sign_verify, crypto_sign_verify_extmu

### DIFF
--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -456,7 +456,8 @@ int crypto_sign_verify_extmu(const uint8_t *sig, size_t siglen,
                              const uint8_t mu[MLDSA_CRHBYTES],
                              const uint8_t *pk)
 {
-  return crypto_sign_verify_internal(sig, siglen, mu, 0, NULL, 0, pk, 1);
+  return crypto_sign_verify_internal(sig, siglen, mu, MLDSA_CRHBYTES, NULL, 0,
+                                     pk, 1);
 }
 
 int crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen,

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -441,6 +441,9 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
   pre[0] = 0;
   pre[1] = ctxlen;
   for (i = 0; i < ctxlen; i++)
+  __loop__(
+    invariant(i <= ctxlen)
+  )
   {
     pre[2 + i] = ctx[i];
   }

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -197,7 +197,14 @@ __contract__(
  **************************************************/
 int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
                        size_t mlen, const uint8_t *ctx, size_t ctxlen,
-                       const uint8_t *pk);
+                       const uint8_t *pk)
+__contract__(
+  requires(memory_no_alias(sig, siglen))
+  requires(memory_no_alias(m, mlen))
+  requires(memory_no_alias(ctx, ctxlen))
+  requires(memory_no_alias(pk, CRYPTO_PUBLICKEYBYTES))
+  ensures(return_value == 0 || return_value == -1)
+);
 
 #define crypto_sign_verify_extmu MLD_NAMESPACE(verify_extmu)
 /*************************************************

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -173,7 +173,7 @@ __contract__(
   requires(memory_no_alias(sig, siglen))
   requires(memory_no_alias(m, mlen))
   requires(externalmu == 0 || (externalmu == 1 && mlen == MLDSA_CRHBYTES))
-  requires(memory_no_alias(pre, prelen))
+  requires(externalmu == 1 || memory_no_alias(pre, prelen))
   requires(memory_no_alias(pk, CRYPTO_PUBLICKEYBYTES))
   ensures(return_value == 0 || return_value == -1)
 );
@@ -222,7 +222,13 @@ __contract__(
  **************************************************/
 int crypto_sign_verify_extmu(const uint8_t *sig, size_t siglen,
                              const uint8_t mu[MLDSA_CRHBYTES],
-                             const uint8_t *pk);
+                             const uint8_t *pk)
+__contract__(
+  requires(memory_no_alias(sig, siglen))
+  requires(memory_no_alias(mu, MLDSA_CRHBYTES))
+  requires(memory_no_alias(pk, CRYPTO_PUBLICKEYBYTES))
+  ensures(return_value == 0 || return_value == -1)
+);
 
 #define crypto_sign_open MLD_NAMESPACE(open)
 /*************************************************

--- a/proofs/cbmc/crypto_sign_verify/Makefile
+++ b/proofs/cbmc/crypto_sign_verify/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_sign_verify_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_sign_verify
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)verify
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)verify_internal
+
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+
+FUNCTION_NAME = crypto_sign_verify
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/crypto_sign_verify/crypto_sign_verify_harness.c
+++ b/proofs/cbmc/crypto_sign_verify/crypto_sign_verify_harness.c
@@ -1,0 +1,19 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void harness(void)
+{
+  const uint8_t sig;
+  size_t siglen;
+  const uint8_t *m;
+  size_t mlen;
+  const uint8_t *ctx;
+  size_t ctxlen;
+  const uint8_t *pk;
+
+  int r;
+
+  r = crypto_sign_verify(sig, siglen, m, mlen, ctx, ctxlen, pk);
+}

--- a/proofs/cbmc/crypto_sign_verify_extmu/Makefile
+++ b/proofs/cbmc/crypto_sign_verify_extmu/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_sign_verify_extmu_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_sign_verify_extmu
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)verify_extmu
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)verify_internal
+
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+
+FUNCTION_NAME = crypto_sign_verify_extmu
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/crypto_sign_verify_extmu/crypto_sign_verify_extmu_harness.c
+++ b/proofs/cbmc/crypto_sign_verify_extmu/crypto_sign_verify_extmu_harness.c
@@ -1,0 +1,18 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+
+
+void harness(void)
+{
+  uint8_t *sig;
+  size_t siglen;
+  uint8_t *mu;
+  uint8_t *pk;
+
+  int r;
+
+  r = crypto_sign_verify_extmu(sig, siglen, mu, pk);
+}


### PR DESCRIPTION
- Resolves #277 
- Resolves #278
- [x] This PR is based on PR #288. 
Please review that first.

This PR add the spec and proof for `crypto_sign_verify`, `crypto_sign_verify_extmu`
for `crypto_sign_verify_extmu`, the following has been changed:
- Add cbmc proof for crypto_sign_verify_extmu
- Strengthen crypto_sign_verify_internal's contract
- Add the mu's length in crypto_sign_verify_extmu