### PR TITLE
Remove CRYPTO_ALGNAME (NISTKAT test artifact)

### DIFF
--- a/mldsa/config.h
+++ b/mldsa/config.h
@@ -12,15 +12,12 @@
 #endif
 
 #if MLDSA_MODE == 2
-#define CRYPTO_ALGNAME "Dilithium2"
 #define MLD_NAMESPACETOP MLD_44_ref
 #define MLD_NAMESPACE(s) MLD_44_ref_##s
 #elif MLDSA_MODE == 3
-#define CRYPTO_ALGNAME "Dilithium3"
 #define MLD_NAMESPACETOP MLD_65_ref
 #define MLD_NAMESPACE(s) MLD_65_ref_##s
 #elif MLDSA_MODE == 5
-#define CRYPTO_ALGNAME "Dilithium5"
 #define MLD_NAMESPACETOP MLD_87_ref
 #define MLD_NAMESPACE(s) MLD_87_ref_##s
 #endif


### PR DESCRIPTION
- Resolves #11 

CRYPTO_ALGNAME is an artifact of the old NISTKAT testvectors that were removed in https://github.com/pq-code-package/mldsa-native/pull/323. It can be safely removed.

This is the last macro that was not properly namespaced, this hence resolves https://github.com/pq-code-package/mldsa-native/issues/11.