### PR TITLE
Consistently use mld_assert instead of cassert

### DIFF
--- a/mldsa/fips202/fips202.c
+++ b/mldsa/fips202/fips202.c
@@ -29,7 +29,6 @@ __contract__(
 )
 {
   mld_memset(s, 0, sizeof(uint64_t) * MLD_KECCAK_LANES);
-  cassert(forall(k, 0, MLD_KECCAK_LANES, s[k] == 0));
 }
 
 /*************************************************
@@ -187,7 +186,6 @@ __contract__(
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES)))
 {
   mld_memset(s, 0, sizeof(uint64_t) * MLD_KECCAK_LANES);
-  cassert(forall(k, 0, MLD_KECCAK_LANES, s[k] == 0));
 
   while (inlen >= r)
   __loop__(

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -296,21 +296,7 @@ void mld_polyvecl_pointwise_acc_montgomery(mld_poly *w, const mld_polyvecl *u,
       t += (int64_t)u->vec[j].coeffs[i] * v->vec[j].coeffs[i];
     }
 
-    /* Substitute j == MLSDA_L into the loop invariant to get... */
-    cassert(j == MLDSA_L);
-    cassert(t >= -(int64_t)MLDSA_L * (MLDSA_Q - 1) * (MLD_NTT_BOUND - 1));
-    cassert(t <= (int64_t)MLDSA_L * (MLDSA_Q - 1) * (MLD_NTT_BOUND - 1));
-
-    /* ...and therefore... */
-    cassert(t >= -MONTGOMERY_REDUCE_STRONG_DOMAIN_MAX);
-    cassert(t < MONTGOMERY_REDUCE_STRONG_DOMAIN_MAX);
-
-    /* ...which meets the "strong" case of mld_montgomery_reduce() */
     r = mld_montgomery_reduce(t);
-
-    /* ...and therefore we can assert a stronger bound on r */
-    cassert(r > -MLDSA_Q);
-    cassert(r < MLDSA_Q);
     w->coeffs[i] = r;
   }
 

--- a/mldsa/reduce.h
+++ b/mldsa/reduce.h
@@ -9,6 +9,7 @@
 #include "cbmc.h"
 #include "common.h"
 #include "ct.h"
+#include "debug.h"
 
 #define MONT -4186625 /* 2^32 % MLDSA_Q */
 
@@ -130,7 +131,7 @@ __contract__(
 
   t = (a + (1 << 22)) >> 23;
   t = a - t * MLDSA_Q;
-  cassert((t - a) % MLDSA_Q == 0);
+  mld_assert((t - a) % MLDSA_Q == 0);
   return t;
 }
 

--- a/mldsa/rounding.h
+++ b/mldsa/rounding.h
@@ -9,6 +9,7 @@
 #include "cbmc.h"
 #include "common.h"
 #include "ct.h"
+#include "debug.h"
 
 #define MLD_2_POW_D (1 << MLDSA_D)
 
@@ -74,20 +75,20 @@ __contract__(
 {
   *a1 = (a + 127) >> 7;
   /* We know a >= 0 and a < MLDSA_Q, so... */
-  cassert(*a1 >= 0 && *a1 <= 65472);
+  mld_assert(*a1 >= 0 && *a1 <= 65472);
 
 #if MLDSA_MODE == 2
   *a1 = (*a1 * 11275 + (1 << 23)) >> 24;
-  cassert(*a1 >= 0 && *a1 <= 44);
+  mld_assert(*a1 >= 0 && *a1 <= 44);
 
   *a1 = mld_ct_sel_int32(0, *a1, mld_ct_cmask_neg_i32(43 - *a1));
-  cassert(*a1 >= 0 && *a1 <= 43);
+  mld_assert(*a1 >= 0 && *a1 <= 43);
 #else /* MLDSA_MODE == 2 */
   *a1 = (*a1 * 1025 + (1 << 21)) >> 22;
-  cassert(*a1 >= 0 && *a1 <= 16);
+  mld_assert(*a1 >= 0 && *a1 <= 16);
 
   *a1 &= 15;
-  cassert(*a1 >= 0 && *a1 <= 15);
+  mld_assert(*a1 >= 0 && *a1 <= 15);
 
 #endif /* MLDSA_MODE != 2 */
 

--- a/mldsa/sign.c
+++ b/mldsa/sign.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "cbmc.h"
+#include "debug.h"
 #include "fips202/fips202.h"
 #include "packing.h"
 #include "poly.h"
@@ -371,9 +372,7 @@ __contract__(
   /* If z is valid, then its coefficients are bounded by  */
   /* MLDSA_GAMMA1 - MLDSA_BETA. This will be needed below */
   /* to prove the pre-condition of pack_sig()             */
-  cassert(forall(k1, 0, MLDSA_L,
-                 array_abs_bound(z.vec[k1].coeffs, 0, MLDSA_N,
-                                 (MLDSA_GAMMA1 - MLDSA_BETA))));
+  mld_assert_abs_bound_2d(z.vec, MLDSA_L, MLDSA_N, (MLDSA_GAMMA1 - MLDSA_BETA));
 
   /* Check that subtracting cs2 does not change high bits of w and low bits
    * do not reveal secret information */

--- a/proofs/cbmc/polyvec_matrix_expand/Makefile
+++ b/proofs/cbmc/polyvec_matrix_expand/Makefile
@@ -37,7 +37,7 @@ FUNCTION_NAME = polyvec_matrix_expand
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 10
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyveck_pack_eta/Makefile
+++ b/proofs/cbmc/polyveck_pack_eta/Makefile
@@ -37,7 +37,7 @@ FUNCTION_NAME = polyveck_pack_eta
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 9
+CBMC_OBJECT_BITS = 10
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
cassert turns into a CBMC proof assertion inside of CBMC proofs, but it turns into a no-op otherwise.
mld_assert behaves the save inside of CBMC proofs, but also turns into a run-time assertion in debug builds.