### PR TITLE
Downgrade to z3 4.12.6 and adjust CBMC proofs

### DIFF
--- a/mldsa/packing.c
+++ b/mldsa/packing.c
@@ -18,6 +18,10 @@ void mld_pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
   pk += MLDSA_SEEDBYTES;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    assigns(i, object_whole(pk))
+    invariant(i <= MLDSA_K)
+  )
   {
     mld_polyt1_pack(pk + i * MLDSA_POLYT1_PACKEDBYTES, &t1->vec[i]);
   }

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -1106,13 +1106,13 @@ void mld_polyz_unpack(mld_poly *r, const uint8_t *a)
   mld_assert_bound(r->coeffs, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1);
 }
 
-void mld_polyw1_pack(uint8_t *r, const mld_poly *a)
+void mld_polyw1_pack(uint8_t r[MLDSA_POLYW1_PACKEDBYTES], const mld_poly *a)
 {
   unsigned int i;
 
-#if MLDSA_MODE == 2
-  mld_assert_bound(a->coeffs, MLDSA_N, 0, 44);
+  mld_assert_bound(a->coeffs, MLDSA_N, 0, (MLDSA_Q - 1) / (2 * MLDSA_GAMMA2));
 
+#if MLDSA_MODE == 2
   for (i = 0; i < MLDSA_N / 4; ++i)
   __loop__(
     invariant(i <= MLDSA_N/4))
@@ -1125,8 +1125,6 @@ void mld_polyw1_pack(uint8_t *r, const mld_poly *a)
     r[3 * i + 2] |= (a->coeffs[4 * i + 3] << 2) & 0xFF;
   }
 #else  /* MLDSA_MODE == 2 */
-  mld_assert_bound(a->coeffs, MLDSA_N, 0, 16);
-
   for (i = 0; i < MLDSA_N / 2; ++i)
   __loop__(
     invariant(i <= MLDSA_N/2))

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -653,20 +653,12 @@ __contract__(
  *                            MLDSA_POLYW1_PACKEDBYTES bytes
  *              - const mld_poly *a: pointer to input polynomial
  **************************************************/
-void mld_polyw1_pack(uint8_t *r, const mld_poly *a)
-#if MLDSA_MODE == 2
+void mld_polyw1_pack(uint8_t r[MLDSA_POLYW1_PACKEDBYTES], const mld_poly *a)
 __contract__(
   requires(memory_no_alias(r, MLDSA_POLYW1_PACKEDBYTES))
   requires(memory_no_alias(a, sizeof(mld_poly)))
-  requires(array_bound(a->coeffs, 0, MLDSA_N, 0, 44))
-  assigns(object_whole(r)));
-#else  /* MLDSA_MODE == 2 */
-__contract__(
-  requires(memory_no_alias(r, MLDSA_POLYW1_PACKEDBYTES))
-  requires(memory_no_alias(a, sizeof(mld_poly)))
-  requires(array_bound(a->coeffs, 0, MLDSA_N, 0, 16))
-  assigns(object_whole(r)));
-#endif /* MLDSA_MODE != 2 */
-
+  requires(array_bound(a->coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)))
+  assigns(object_whole(r))
+);
 
 #endif /* !MLD_POLY_H */

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -489,8 +489,9 @@ void mld_polyveck_decompose(mld_polyveck *v1, mld_polyveck *v0,
     assigns(i, memory_slice(v0, sizeof(mld_polyveck)), memory_slice(v1, sizeof(mld_polyveck)))
     invariant(i <= MLDSA_K)
     invariant(forall(k1, 0, i,
-                     array_bound(v1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)) &&
-                     array_abs_bound(v0->vec[k1].coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1)))
+                     array_bound(v1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2))))
+    invariant(forall(k2, 0, i,
+                     array_abs_bound(v0->vec[k2].coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1)))
   )
   {
     mld_poly_decompose(&v1->vec[i], &v0->vec[i], &v->vec[i]);
@@ -539,6 +540,10 @@ void mld_polyveck_pack_w1(uint8_t r[MLDSA_K * MLDSA_POLYW1_PACKEDBYTES],
   unsigned int i;
 
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    assigns(i, object_whole(r))
+    invariant(i <= MLDSA_K)
+  )
   {
     mld_polyw1_pack(&r[i * MLDSA_POLYW1_PACKEDBYTES], &w1->vec[i]);
   }
@@ -549,8 +554,12 @@ void mld_polyveck_pack_eta(uint8_t r[MLDSA_K * MLDSA_POLYETA_PACKEDBYTES],
 {
   unsigned int i;
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    assigns(i, object_whole(r))
+    invariant(i <= MLDSA_K)
+  )
   {
-    mld_polyeta_pack(r + i * MLDSA_POLYETA_PACKEDBYTES, &p->vec[i]);
+    mld_polyeta_pack(&r[i * MLDSA_POLYETA_PACKEDBYTES], &p->vec[i]);
   }
 }
 
@@ -559,8 +568,12 @@ void mld_polyvecl_pack_eta(uint8_t r[MLDSA_L * MLDSA_POLYETA_PACKEDBYTES],
 {
   unsigned int i;
   for (i = 0; i < MLDSA_L; ++i)
+  __loop__(
+    assigns(i, object_whole(r))
+    invariant(i <= MLDSA_L)
+  )
   {
-    mld_polyeta_pack(r + i * MLDSA_POLYETA_PACKEDBYTES, &p->vec[i]);
+    mld_polyeta_pack(&r[i * MLDSA_POLYETA_PACKEDBYTES], &p->vec[i]);
   }
 }
 
@@ -569,8 +582,12 @@ void mld_polyvecl_pack_z(uint8_t r[MLDSA_L * MLDSA_POLYZ_PACKEDBYTES],
 {
   unsigned int i;
   for (i = 0; i < MLDSA_L; ++i)
+  __loop__(
+    assigns(i, object_whole(r))
+    invariant(i <= MLDSA_L)
+  )
   {
-    mld_polyz_pack(r + i * MLDSA_POLYZ_PACKEDBYTES, &p->vec[i]);
+    mld_polyz_pack(&r[i * MLDSA_POLYZ_PACKEDBYTES], &p->vec[i]);
   }
 }
 
@@ -580,8 +597,12 @@ void mld_polyveck_pack_t0(uint8_t r[MLDSA_K * MLDSA_POLYT0_PACKEDBYTES],
 {
   unsigned int i;
   for (i = 0; i < MLDSA_K; ++i)
+  __loop__(
+    assigns(i, object_whole(r))
+    invariant(i <= MLDSA_K)
+  )
   {
-    mld_polyt0_pack(r + i * MLDSA_POLYT0_PACKEDBYTES, &p->vec[i]);
+    mld_polyt0_pack(&r[i * MLDSA_POLYT0_PACKEDBYTES], &p->vec[i]);
   }
 }
 

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -428,10 +428,10 @@ __contract__(
  * Name:        mld_polyveck_decompose
  *
  * Description: For all coefficients a of polynomials in vector of length
- *MLDSA_K, compute high and low bits a0, a1 such a mod^+ MLDSA_Q = a1*ALPHA
- *+ a0 with -ALPHA/2 < a0 <= ALPHA/2 except a1 = (MLDSA_Q-1)/ALPHA where we set
- *a1 = 0 and -ALPHA/2 <= a0 = a mod MLDSA_Q - MLDSA_Q < 0. Assumes coefficients
- *to be standard representatives.
+ * MLDSA_K, compute high and low bits a0, a1 such a mod^+ MLDSA_Q = a1*ALPHA
+ * + a0 with -ALPHA/2 < a0 <= ALPHA/2 except a1 = (MLDSA_Q-1)/ALPHA where we set
+ * a1 = 0 and -ALPHA/2 <= a0 = a mod MLDSA_Q - MLDSA_Q < 0. Assumes coefficients
+ * to be standard representatives.
  *
  * Arguments:   - mld_polyveck *v1: pointer to output vector of polynomials with
  *                              coefficients a1
@@ -450,8 +450,9 @@ __contract__(
   assigns(memory_slice(v1, sizeof(mld_polyveck)))
   assigns(memory_slice(v0, sizeof(mld_polyveck)))
   ensures(forall(k1, 0, MLDSA_K,
-                 array_bound(v1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)) &&
-                 array_abs_bound(v0->vec[k1].coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1)))
+                 array_bound(v1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2))))
+  ensures(forall(k2, 0, MLDSA_K,
+                 array_abs_bound(v0->vec[k2].coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1)))
 );
 
 #define mld_polyveck_make_hint MLD_NAMESPACE(polyveck_make_hint)
@@ -516,22 +517,13 @@ __contract__(
  **************************************************/
 void mld_polyveck_pack_w1(uint8_t r[MLDSA_K * MLDSA_POLYW1_PACKEDBYTES],
                           const mld_polyveck *w1)
-#if MLDSA_MODE == 2
 __contract__(
   requires(memory_no_alias(r, MLDSA_K * MLDSA_POLYW1_PACKEDBYTES))
   requires(memory_no_alias(w1, sizeof(mld_polyveck)))
   requires(forall(k1, 0, MLDSA_K,
     array_bound(w1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2))))
-  assigns(object_whole(r)));
-#else  /* MLDSA_MODE == 2 */
-__contract__(
-  requires(memory_no_alias(r, MLDSA_K * MLDSA_POLYW1_PACKEDBYTES))
-  requires(memory_no_alias(w1, sizeof(mld_polyveck)))
-  requires(forall(k1, 0, MLDSA_K,
-    array_bound(w1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2))))
-  assigns(object_whole(r)));
-#endif /* MLDSA_MODE != 2 */
-
+  assigns(object_whole(r))
+);
 
 #define mld_polyveck_pack_eta MLD_NAMESPACE(polyveck_pack_eta)
 void mld_polyveck_pack_eta(uint8_t r[MLDSA_K * MLDSA_POLYETA_PACKEDBYTES],

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -11,6 +11,7 @@
 , z3
 , cudd
 , replaceVars
+, fetchpatch
 }:
 
 buildEnv {
@@ -28,11 +29,40 @@ buildEnv {
       });
       litani = callPackage ./litani.nix { }; # 1.29.0
       cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.11
+      z3 = z3.overrideAttrs (old: rec {
+        version = "4.12.6";
+        src = fetchFromGitHub {
+          owner = "Z3Prover";
+          repo = "z3";
+          rev = "z3-4.12.6";
+          hash = "sha256-X4wfPWVSswENV0zXJp/5u9SQwGJWocLKJ/CNv57Bt+E=";
+        };
+
+        static-matrix-patch = fetchpatch {
+          name = "gcc-15-fixes.patch";
+          url = "https://github.com/Z3Prover/z3/commit/2ce89e5f491fa817d02d8fdce8c62798beab258b.patch";
+          hash = "sha256-UvrUL27o/w1/sH/hO7bmvVupg3vbSjEqoIpoZh2BOhg=";
+          includes = [ "src/math/lp/static_matrix.h" ];
+        };
+
+        static-matrix-def-patch = fetchpatch {
+          # clang / gcc fixes. fixes typos in some member names
+          name = "gcc-15-fixes.patch";
+          url = "https://github.com/Z3Prover/z3/commit/2ce89e5f491fa817d02d8fdce8c62798beab258b.patch";
+          includes = [ "src/math/lp/static_matrix_def.h" ];
+          hash = "sha256-rEH+UzylzyhBdtx65uf8QYj5xwuXOyG6bV/4jgKkXGo=";
+        };
+
+        patches = [
+          ./z3-lower-bound-typo.patch
+          static-matrix-def-patch
+          static-matrix-patch
+        ];
+      });
 
       inherit
         cadical#2.1.3
         bitwuzla# 0.7.0
-        z3# 4.15.0
         ninja; # 1.12.1
     };
 }

--- a/nix/cbmc/z3-lower-bound-typo.patch
+++ b/nix/cbmc/z3-lower-bound-typo.patch
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+diff --git a/src/math/lp/column_info.h b/src/math/lp/column_info.h
+index 1dc0c60..9cbeea6 100644
+--- a/src/math/lp/column_info.h
++++ b/src/math/lp/column_info.h
+@@ -47,7 +47,7 @@ public:
+             m_lower_bound_is_strict == c.m_lower_bound_is_strict &&
+             m_upper_bound_is_set == c.m_upper_bound_is_set&&
+             m_upper_bound_is_strict == c.m_upper_bound_is_strict&&
+-            (!m_lower_bound_is_set || m_lower_bound == c.m_low_bound) &&
++            (!m_lower_bound_is_set || m_lower_bound == c.m_lower_bound) &&
+             (!m_upper_bound_is_set || m_upper_bound == c.m_upper_bound) &&
+             m_cost == c.m_cost &&
+             m_is_fixed == c.m_is_fixed &&

--- a/proofs/cbmc/pack_pk/Makefile
+++ b/proofs/cbmc/pack_pk/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)pack_pk.0:8 # Largest value of MLDSA_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/packing.c
@@ -27,6 +26,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = pack_pk
 

--- a/proofs/cbmc/polyveck_decompose/Makefile
+++ b/proofs/cbmc/polyveck_decompose/Makefile
@@ -27,6 +27,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_decompose
 

--- a/proofs/cbmc/polyveck_pack_eta/Makefile
+++ b/proofs/cbmc/polyveck_pack_eta/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_eta.0:8 # Largest value of MLDSA_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -27,6 +26,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_pack_eta
 

--- a/proofs/cbmc/polyveck_pack_t0/Makefile
+++ b/proofs/cbmc/polyveck_pack_t0/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_t0.0:8 # Largest value of MLDSA_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -27,6 +26,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_pack_t0
 

--- a/proofs/cbmc/polyveck_pack_w1/Makefile
+++ b/proofs/cbmc/polyveck_pack_w1/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyveck_pack_w1.0:8 # Largest value of MLDSA_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -27,6 +26,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --no-array-field-sensitivity
 
 FUNCTION_NAME = polyveck_pack_w1
 

--- a/proofs/cbmc/polyvecl_pack_eta/Makefile
+++ b/proofs/cbmc/polyvecl_pack_eta/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyvecl_pack_eta.0:7 # Largest value of MLDSA_L
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -27,6 +26,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvecl_pack_eta
 

--- a/proofs/cbmc/polyvecl_pack_z/Makefile
+++ b/proofs/cbmc/polyvecl_pack_z/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLD_NAMESPACE)polyvecl_pack_z.0:7 # Largest value of MLDSA_L
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
@@ -27,6 +26,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvecl_pack_z
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2 --no-array-field-sensitivity
 
 FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 


### PR DESCRIPTION
We have noticed a severe performance degradation of some CBMC proofs when moving from z3 4.12 to 4.13/4.14/4.15. This is currently blocking the proof of the signing functions.
This PR downgrades back to z3 4.12.6 - the last release prior to the performance regression. A few minor changes to the other CBMC proofs are required which are applied as part of this PR.