### PR TITLE
Refactor and add proof files for crypto_sign_signature_internal()

### DIFF
--- a/mldsa/packing.h
+++ b/mldsa/packing.h
@@ -98,7 +98,7 @@ __contract__(
   requires(forall(k1, 0, MLDSA_K,
     array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
   requires(number_of_hints <= MLDSA_OMEGA)
-  assigns(object_whole(sig))
+  assigns(memory_slice(sig, CRYPTO_BYTES))
 );
 
 #define mld_unpack_pk MLD_NAMESPACE(unpack_pk)

--- a/mldsa/poly.c
+++ b/mldsa/poly.c
@@ -200,6 +200,7 @@ unsigned int mld_poly_make_hint(mld_poly *h, const mld_poly *a0,
   __loop__(
     invariant(i <= MLDSA_N)
     invariant(s <= i)
+    invariant(array_bound(h->coeffs, 0, i, 0, 2))
   )
   {
     const unsigned int hint_bit = mld_make_hint(a0->coeffs[i], a1->coeffs[i]);

--- a/mldsa/poly.h
+++ b/mldsa/poly.h
@@ -260,6 +260,7 @@ __contract__(
   requires(memory_no_alias(a1, sizeof(mld_poly)))
   assigns(memory_slice(h, sizeof(mld_poly)))
   ensures(return_value <= MLDSA_N)
+  ensures(array_bound(h->coeffs, 0, MLDSA_N, 0, 2))
 );
 
 #define mld_poly_use_hint MLD_NAMESPACE(poly_use_hint)

--- a/mldsa/polyvec.c
+++ b/mldsa/polyvec.c
@@ -183,6 +183,7 @@ void mld_polyvecl_add(mld_polyvecl *u, const mld_polyvecl *v)
     invariant(forall(k0, i, MLDSA_L,
               forall(k1, 0, MLDSA_N, u->vec[k0].coeffs[k1] == loop_entry(*u).vec[k0].coeffs[k1])))
     invariant(forall(k4, 0, i, forall(k5, 0, MLDSA_N, u->vec[k4].coeffs[k5] == loop_entry(*u).vec[k4].coeffs[k5] + v->vec[k4].coeffs[k5])))
+    invariant(forall(k6, 0, i, array_bound(u->vec[k6].coeffs, 0, MLDSA_N, INT32_MIN, REDUCE32_DOMAIN_MAX)))
   )
   {
     mld_poly_add(&u->vec[i], &v->vec[i]);
@@ -508,6 +509,7 @@ unsigned int mld_polyveck_make_hint(mld_polyveck *h, const mld_polyveck *v0,
     assigns(i, s, object_whole(h))
     invariant(i <= MLDSA_K)
     invariant(s <= i * MLDSA_N)
+    invariant(forall(k1, 0, i, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
   )
   {
     s += mld_poly_make_hint(&h->vec[i], &v0->vec[i], &v1->vec[i]);

--- a/mldsa/polyvec.h
+++ b/mldsa/polyvec.h
@@ -81,6 +81,8 @@ __contract__(
   requires(forall(k2, 0, MLDSA_L, forall(k3, 0, MLDSA_N, (int64_t) u->vec[k2].coeffs[k3] + v->vec[k2].coeffs[k3] >= INT32_MIN)))
   assigns(object_whole(u))
   ensures(forall(k4, 0, MLDSA_L, forall(k5, 0, MLDSA_N, u->vec[k4].coeffs[k5] == old(*u).vec[k4].coeffs[k5] + v->vec[k4].coeffs[k5])))
+  ensures(forall(k6, 0, MLDSA_L,
+                 array_bound(u->vec[k6].coeffs, 0, MLDSA_N, INT32_MIN, REDUCE32_DOMAIN_MAX)))
 );
 
 #define mld_polyvecl_ntt MLD_NAMESPACE(polyvecl_ntt)
@@ -475,6 +477,7 @@ __contract__(
   requires(memory_no_alias(v1, sizeof(mld_polyveck)))
   assigns(object_whole(h))
   ensures(return_value <= MLDSA_N * MLDSA_K)
+  ensures(forall(k1, 0, MLDSA_K, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
 );
 
 #define mld_polyveck_use_hint MLD_NAMESPACE(polyveck_use_hint)

--- a/mldsa/sign.h
+++ b/mldsa/sign.h
@@ -67,7 +67,7 @@ __contract__(
  * Description: Computes signature. Internal API.
  *
  * Arguments:   - uint8_t *sig:   pointer to output signature (of length
- *CRYPTO_BYTES)
+ *                                CRYPTO_BYTES)
  *              - size_t *siglen: pointer to output length of signature
  *              - uint8_t *m:     pointer to message to be signed
  *              - size_t mlen:    length of message
@@ -77,13 +77,33 @@ __contract__(
  *              - uint8_t *sk:    pointer to bit-packed secret key
  *              - int externalmu: indicates input message m is processed as mu
  *
- * Returns 0 (success)
+ * Returns 0 (success) or -1 (indicating nonce exhaustion)
+ *
+ * If the returned value is -1, then the values of *sig and
+ * *siglen should not be referenced.
+ *
+ * Reference: This code differs from the reference implementation
+ *            in that it adds an explicit check for nonce exhaustion
+ *            and can return -1 in that case.
  **************************************************/
 int crypto_sign_signature_internal(uint8_t *sig, size_t *siglen,
                                    const uint8_t *m, size_t mlen,
                                    const uint8_t *pre, size_t prelen,
                                    const uint8_t rnd[MLDSA_RNDBYTES],
-                                   const uint8_t *sk, int externalmu);
+                                   const uint8_t *sk, int externalmu)
+__contract__(
+  requires(memory_no_alias(sig, CRYPTO_BYTES))
+  requires(memory_no_alias(siglen, sizeof(size_t)))
+  requires(memory_no_alias(m, mlen))
+  requires(memory_no_alias(pre, prelen))
+  requires(memory_no_alias(rnd, MLDSA_RNDBYTES))
+  requires(memory_no_alias(sk, CRYPTO_SECRETKEYBYTES))
+  requires(externalmu == 0 || (externalmu == 1 && mlen == MLDSA_CRHBYTES))
+  assigns(memory_slice(sig, CRYPTO_BYTES))
+  assigns(object_whole(siglen))
+  ensures((return_value == 0 && *siglen == CRYPTO_BYTES) ||
+          (return_value == -1 && *siglen == 0))
+);
 
 #define crypto_sign_signature MLD_NAMESPACE(signature)
 /*************************************************

--- a/proofs/cbmc/crypto_sign_signature_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_internal/Makefile
@@ -4,22 +4,29 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = polyveck_pack_t0_harness
+HARNESS_FILE = crypto_sign_signature_internal_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = polyveck_pack_t0
+PROOF_UID = crypto_sign_signature_internal
 
 DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
-PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_pack_t0
-USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyt0_pack
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)signature_internal
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)unpack_sk \
+                       mld_H \
+                       $(MLD_NAMESPACE)polyvec_matrix_expand \
+                       $(MLD_NAMESPACE)polyvecl_ntt \
+                       $(MLD_NAMESPACE)polyveck_ntt \
+                       mld_attempt_signature_generation
+
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -29,7 +36,7 @@ CBMCFLAGS=--smt2
 CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 
-FUNCTION_NAME = polyveck_pack_t0
+FUNCTION_NAME = crypto_sign_signature_internal
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
@@ -38,7 +45,7 @@ FUNCTION_NAME = polyveck_pack_t0
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 9
+CBMC_OBJECT_BITS = 8
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/crypto_sign_signature_internal/crypto_sign_signature_internal_harness.c
+++ b/proofs/cbmc/crypto_sign_signature_internal/crypto_sign_signature_internal_harness.c
@@ -1,0 +1,20 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void harness(void)
+{
+  uint8_t *sig;
+  size_t *siglen;
+  uint8_t *m;
+  size_t mlen;
+  uint8_t *pre;
+  size_t prelen;
+  uint8_t *rnd;
+  uint8_t *sk;
+  int externalmu;
+  int r;
+  r = crypto_sign_signature_internal(sig, siglen, m, mlen, pre, prelen, rnd, sk,
+                                     externalmu);
+}

--- a/proofs/cbmc/mld_attempt_signature_generation/Makefile
+++ b/proofs/cbmc/mld_attempt_signature_generation/Makefile
@@ -4,22 +4,46 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = polyveck_pack_t0_harness
+HARNESS_FILE = mld_attempt_signature_generation_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = polyveck_pack_t0
+PROOF_UID = mld_attempt_signature_generation
 
 DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
-PROJECT_SOURCES += $(SRCDIR)/mldsa/polyvec.c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyveck_pack_t0
-USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyt0_pack
+CHECK_FUNCTION_CONTRACTS=mld_attempt_signature_generation
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_uniform_gamma1 \
+                       $(MLD_NAMESPACE)polyvecl_ntt \
+                       $(MLD_NAMESPACE)polyvec_matrix_pointwise_montgomery \
+                       $(MLD_NAMESPACE)polyveck_reduce \
+                       $(MLD_NAMESPACE)polyveck_invntt_tomont \
+                       $(MLD_NAMESPACE)polyveck_caddq \
+                       $(MLD_NAMESPACE)polyveck_decompose \
+                       $(MLD_NAMESPACE)polyveck_pack_w1 \
+                       mld_H \
+                       $(MLD_NAMESPACE)poly_challenge \
+                       $(MLD_NAMESPACE)poly_ntt \
+                       $(MLD_NAMESPACE)polyvecl_pointwise_poly_montgomery \
+                       $(MLD_NAMESPACE)polyvecl_invntt_tomont \
+                       $(MLD_NAMESPACE)polyvecl_add \
+                       $(MLD_NAMESPACE)polyvecl_reduce \
+                       $(MLD_NAMESPACE)polyvecl_chknorm \
+                       $(MLD_NAMESPACE)polyveck_pointwise_poly_montgomery \
+                       $(MLD_NAMESPACE)polyveck_sub \
+                       $(MLD_NAMESPACE)polyveck_reduce \
+                       $(MLD_NAMESPACE)polyveck_chknorm \
+                       $(MLD_NAMESPACE)polyveck_add \
+                       $(MLD_NAMESPACE)polyveck_make_hint \
+                       $(MLD_NAMESPACE)pack_sig
+
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -29,7 +53,7 @@ CBMCFLAGS=--smt2
 CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 
-FUNCTION_NAME = polyveck_pack_t0
+FUNCTION_NAME = mld_attempt_signature_generation
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
@@ -38,7 +62,7 @@ FUNCTION_NAME = polyveck_pack_t0
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 9
+CBMC_OBJECT_BITS = 11
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/mld_attempt_signature_generation/mld_attempt_signature_generation_harness.c
+++ b/proofs/cbmc/mld_attempt_signature_generation/mld_attempt_signature_generation_harness.c
@@ -1,0 +1,25 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+int mld_attempt_signature_generation(
+    uint8_t *sig, const uint8_t *mu, const uint8_t rhoprime[MLDSA_CRHBYTES],
+    uint16_t nonce, const mld_polyvecl mat[MLDSA_K], const mld_polyvecl *s1,
+    const mld_polyveck *s2, const mld_polyveck *t0);
+
+void harness(void)
+{
+  uint8_t *sig;
+  uint8_t *mu;
+  uint8_t *rhoprime;
+  uint16_t nonce;
+  mld_polyvecl *mat;
+  mld_polyvecl *s1;
+  mld_polyveck *s2;
+  mld_polyveck *t0;
+
+  int r;
+  r = mld_attempt_signature_generation(sig, mu, rhoprime, nonce, mat, s1, s2,
+                                       t0);
+}

--- a/proofs/cbmc/polyveck_chknorm/Makefile
+++ b/proofs/cbmc/polyveck_chknorm/Makefile
@@ -27,6 +27,8 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+CBMCFLAGS += --no-array-field-sensitivity
 
 FUNCTION_NAME = polyveck_chknorm
 

--- a/proofs/cbmc/polyvecl_chknorm/Makefile
+++ b/proofs/cbmc/polyvecl_chknorm/Makefile
@@ -27,6 +27,8 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+CBMCFLAGS += --no-array-field-sensitivity
 
 FUNCTION_NAME = polyvecl_chknorm
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --no-array-field-sensitivity
+CBMCFLAGS=--smt2 --slice-formula --no-array-field-sensitivity
 
 FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 


### PR DESCRIPTION
Fixes #272 

Refactor and add proof files for crypto_sign_signature_internal()

Introduce new local function mld_attempt_signature_generation() to simplify and stabilize proofs.

Strengthen contracts for
  mld_poly_make_hint()
  mld_polyveck_make_hint()
  mld_pack_sig()
in support of that goal.

Adjust CBMC flags for proof stability on macOS and Linux