### PR TITLE
Add contracts and proofs for top-level signature functions

### DIFF
--- a/proofs/cbmc/Makefile_params.common
+++ b/proofs/cbmc/Makefile_params.common
@@ -9,10 +9,13 @@ MLDSA_MODE ?= 3
 FIPS202_NAMESPACE = mldsa_fips202_ref_
 
 ifeq ($(MLDSA_MODE),2)
+     MLD_NAMESPACETOP=MLD_44_ref
      MLD_NAMESPACE=MLD_44_ref_
 else ifeq ($(MLDSA_MODE),3)
+     MLD_NAMESPACETOP=MLD_65_ref
      MLD_NAMESPACE=MLD_65_ref_
 else ifeq ($(MLDSA_MODE),5)
+     MLD_NAMESPACETOP=MLD_87_ref
      MLD_NAMESPACE=MLD_87_ref_
 else
      $(error Invalid value of MLDSA_MODE)

--- a/proofs/cbmc/crypto_sign/Makefile
+++ b/proofs/cbmc/crypto_sign/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_sign_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_sign
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACETOP)
+USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)signature
+
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+
+FUNCTION_NAME = crypto_sign
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/crypto_sign/crypto_sign_harness.c
+++ b/proofs/cbmc/crypto_sign/crypto_sign_harness.c
@@ -1,0 +1,18 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void harness(void)
+{
+  uint8_t *sm;
+  size_t *smlen;
+  uint8_t *m;
+  size_t mlen;
+  uint8_t *ctx;
+  size_t ctxlen;
+  uint8_t *sk;
+  int r;
+
+  r = crypto_sign(sm, smlen, m, mlen, ctx, ctxlen, sk);
+}

--- a/proofs/cbmc/crypto_sign_signature/Makefile
+++ b/proofs/cbmc/crypto_sign_signature/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_sign_signature_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_sign_signature
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)signature
+USE_FUNCTION_CONTRACTS=mld_randombytes \
+                       $(MLD_NAMESPACE)signature_internal
+
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+
+FUNCTION_NAME = crypto_sign_signature
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/crypto_sign_signature/crypto_sign_signature_harness.c
+++ b/proofs/cbmc/crypto_sign_signature/crypto_sign_signature_harness.c
@@ -1,0 +1,18 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void harness(void)
+{
+  uint8_t *sig;
+  size_t *siglen;
+  uint8_t *m;
+  size_t mlen;
+  uint8_t *ctx;
+  size_t ctxlen;
+  uint8_t *sk;
+  int r;
+
+  r = crypto_sign_signature(sig, siglen, m, mlen, ctx, ctxlen, sk);
+}

--- a/proofs/cbmc/crypto_sign_signature_extmu/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_extmu/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_sign_signature_extmu_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_sign_signature_extmu
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mldsa/sign.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)signature_extmu
+USE_FUNCTION_CONTRACTS=mld_randombytes \
+                       $(MLD_NAMESPACE)signature_internal
+
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+CBMCFLAGS += --slice-formula
+
+FUNCTION_NAME = crypto_sign_signature_extmu
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mldsa/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mldsa/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/crypto_sign_signature_extmu/crypto_sign_signature_extmu_harness.c
+++ b/proofs/cbmc/crypto_sign_signature_extmu/crypto_sign_signature_extmu_harness.c
@@ -1,0 +1,15 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void harness(void)
+{
+  uint8_t *sig;
+  size_t *siglen;
+  uint8_t *mu;
+  uint8_t *sk;
+  int r;
+
+  r = crypto_sign_signature_extmu(sig, siglen, mu, sk);
+}


### PR DESCRIPTION
Fixes #273
Fixes #274
Fixes #275 

Add contracts and proofs for top-level signature functions:
  crypto_sign_signature()
  crypto_sign_signature_extmu()
  crypto_sign()

Also adjust the Makefile_params.common file for CBMC to define the MLD_NAMESPACETOP macro for crypto_sign()