### PR TITLE
Adjust KAT test to work with PCT

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -8,16 +8,16 @@ implementations:
     length-public-key: 1312
     length-secret-key: 2560
     length-signature: 2420
-    kat-sha256: 9d4ae4ea0c1b56f96650838c7425cc2167a0754643b79a93bee28cb039ac2fc2
+    kat-sha256: 33e7eb7e3b4965fc8b8274ebf8a222c519008ec242b3f753d1bc240f1ee3cb1f
   - name: ML-DSA-65
     claimed-nist-level: 3
     length-public-key: 1952
     length-secret-key: 4032
     length-signature: 3309
-    kat-sha256: b66d7de88a3bec2d7cf171a7a1198f6de47384e2a1dd3bf7d07432316a9a40f8
+    kat-sha256: 2ff0ddcd0dc08b746aa04853d6f84c82c6c8ac38783c9061aed78e29c1698ae5
   - name: ML-DSA-87
     claimed-nist-level: 5
     length-public-key: 2592
     length-secret-key: 4896
     length-signature: 4627
-    kat-sha256: 93029142bf62f67ae3df0d31c2fccf8c9fa1e61ab388048e1b3faeb9451a61ce
+    kat-sha256: 1bfb25b29f6f2bc89057e3bddee055a8f7df563b0e747004b2968159f7739afa


### PR DESCRIPTION
Currently our KAT tests do not work in case the pairwise-consistency test (PCT) is enabled through MLD_CONFIG_KEYGEN_PCT. The reason for this is that when PCT is enabled, a signature is generated at the end of key generation which requires randomness to be sampled from randombytes() messing with the state of the deterministic random number generator used for KAT tests.

To work around this, this commit changes the KAT tests to follow the same approach that is also used by mlkem-native: Only use the de-randomized APIs and derive all random coins deterministically using SHAKE instead of randombytes().

This enabled KAT tests even when PCT is enabled.
Unfortunately, it requires changing the KAT hashes once.

CI to test this will be added in https://github.com/pq-code-package/mldsa-native/pull/393 (I rebased already to make sure it works).