### PR TITLE
Add liboqs integration

### DIFF
--- a/integration/liboqs/ML-DSA-44_META.yml
+++ b/integration/liboqs/ML-DSA-44_META.yml
@@ -1,0 +1,63 @@
+name: ML-DSA-44
+type: signature
+claimed-nist-level: 2
+claimed-security: SUF-CMA
+length-public-key: 1312
+length-secret-key: 2560
+length-signature: 2420
+nistkat-sha256: 9a196e7fb32fbc93757dc2d8dc1924460eab66303c0c08aeb8b798fb8d8f8cf3
+testvectors-sha256: 5f0d135c0f7fd43f3fb9727265fcd6ec3651eb8c67c04ea5f3d8dfa1d99740d2
+principal-submitters:
+  - Vadim Lyubashevsky
+auxiliary-submitters:
+  - Shi Bai
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Peter Schwabe
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+  - name: ref
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=2 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA44_C_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA44_C_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA44_C_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_c.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+  - name: x86_64
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=2 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA44_X86_64_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA44_X86_64_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA44_X86_64_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_x86_64.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/x86_64/ mldsa/native/api.h mldsa/native/meta.h mldsa/native/x86_64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - avx2
+          - bmi2
+          - popcnt
+  - name: aarch64
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=2 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA44_AARCH64_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA44_AARCH64_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA44_AARCH64_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_aarch64.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/aarch64/ mldsa/native/api.h mldsa/native/meta.h mldsa/native/aarch64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+    supported_platforms:
+      - architecture: arm_8
+        operating_systems:
+            - Linux
+            - Darwin
+        required_flags:
+            - asimd

--- a/integration/liboqs/ML-DSA-65_META.yml
+++ b/integration/liboqs/ML-DSA-65_META.yml
@@ -1,0 +1,62 @@
+name: ML-DSA-65
+type: signature
+claimed-nist-level: 3
+claimed-security: SUF-CMA
+length-public-key: 1952
+length-secret-key: 4032
+length-signature: 3309
+nistkat-sha256: 7cb96242eac9907a55b5c84c202f0ebd552419c50b2e986dc2e28f07ecebf072
+testvectors-sha256: 14bf84918ee90e7afbd580191d3eb890d4557e0900b1145e39a8399ef7dd3fba
+principal-submitters:
+  - Vadim Lyubashevsky
+auxiliary-submitters:
+  - Shi Bai
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Peter Schwabe
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+  - name: ref
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=3 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA65_C_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA65_C_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA65_C_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_c.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+  - name: x86_64
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=3 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA65_X86_64_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA65_X86_64_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA65_X86_64_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_x86_64.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/x86_64/ mldsa/native/api.h mldsa/native/meta.h mldsa/native/x86_64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - avx2
+          - popcnt
+  - name: aarch64
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=3 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA65_AARCH64_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA65_AARCH64_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA65_AARCH64_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_aarch64.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/aarch64/ mldsa/native/api.h mldsa/native/meta.h mldsa/native/aarch64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+    supported_platforms:
+      - architecture: arm_8
+        operating_systems:
+            - Linux
+            - Darwin
+        required_flags:
+            - asimd

--- a/integration/liboqs/ML-DSA-87_META.yml
+++ b/integration/liboqs/ML-DSA-87_META.yml
@@ -1,0 +1,62 @@
+name: ML-DSA-87
+type: signature
+claimed-nist-level: 5
+claimed-security: SUF-CMA
+length-public-key: 2592
+length-secret-key: 4896
+length-signature: 4627
+nistkat-sha256: 4537905d2aabcf302fab2f242baed293459ecda7c230e6a67063b02c7e2840ed
+testvectors-sha256: 759a3ba35210c7e27ff90a7ce5e399295533b82ef125e6ec98af158e00268e44
+principal-submitters:
+  - Vadim Lyubashevsky
+auxiliary-submitters:
+  - Shi Bai
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Peter Schwabe
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+  - name: ref
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=5 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA87_C_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA87_C_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA87_C_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_c.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+  - name: x86_64
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=5 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA87_X86_64_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA87_X86_64_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA87_X86_64_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_x86_64.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/x86_64/ mldsa/native/api.h mldsa/native/meta.h mldsa/native/x86_64 mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/aarch64/ mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - avx2
+          - popcnt
+  - name: aarch64
+    version: FIPS204
+    folder_name: .
+    compile_opts: -DMLDSA_MODE=5 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
+    signature_keypair: PQCP_MLSDA_NATIVE_MLDSA87_AARCH64_keypair
+    signature_signature: PQCP_MLSDA_NATIVE_MLDSA87_AARCH64_signature
+    signature_verify: PQCP_MLSDA_NATIVE_MLDSA87_AARCH64_verify
+    api-with-context-string: true
+    sources: integration/liboqs/config_aarch64.h mldsa/api.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/fips202/fips202.c mldsa/fips202/fips202.h mldsa/fips202/fips202x4.c mldsa/fips202/fips202x4.h mldsa/fips202/keccakf1600.c mldsa/fips202/keccakf1600.h mldsa/fips202/native/api.h mldsa/fips202/native/auto.h mldsa/fips202/native/aarch64/ mldsa/native/api.h mldsa/native/meta.h mldsa/native/aarch64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.c mldsa/reduce.h mldsa/rounding.c mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+    supported_platforms:
+      - architecture: arm_8
+        operating_systems:
+            - Linux
+            - Darwin
+        required_flags:
+            - asimd

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#ifndef MLD_INTEGRATION_LIBOQS_CONFIG_AARCH64_H
+#define MLD_INTEGRATION_LIBOQS_CONFIG_AARCH64_H
+
+#define MLD_RANDOMIZED_SIGNING
+
+#ifndef MLDSA_MODE
+#define MLDSA_MODE 2
+#endif
+
+#if MLDSA_MODE == 2
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA44_AARCH64_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA44_AARCH64_##s
+#elif MLDSA_MODE == 3
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA65_AARCH64_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA65_AARCH64_##s
+#elif MLDSA_MODE == 5
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA87_AARCH64_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA87_AARCH64_##s
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FILE
+ *
+ * Description: If defined, this is a header that will be included instead
+ *              of this default configuration file mldsa/config.h.
+ *
+ *              When you need to build mldsa-native in multiple configurations,
+ *              using varying MLD_CONFIG_FILE can be more convenient
+ *              then configuring everything through CFLAGS.
+ *
+ *              To use, MLD_CONFIG_FILE _must_ be defined prior
+ *              to the inclusion of any mldsa-native headers. For example,
+ *              it can be set by passing `-DMLD_CONFIG_FILE="..."`
+ *              on the command line.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_FILE "config.h" */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_ARITH_BACKEND_FILE
+ *
+ * Description: The arithmetic backend to use.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_ARITH is unset, this option
+ *              is ignored.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_ARITH is set, this option must
+ *              either be undefined or the filename of an arithmetic backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
+#define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FIPS202_BACKEND_FILE
+ *
+ * Description: The FIPS-202 backend to use.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 is set, this option
+ *              must either be undefined or the filename of a FIPS202 backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
+#define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
+ *
+ * Description: In compliance with FIPS 204 Section 3.6.3, mldsa-native zeroizes
+ *              intermediate stack buffers before returning from function calls.
+ *
+ *              Set this option and define `mld_zeroize_native` if you want to
+ *              use a custom method to zeroize intermediate stack buffers.
+ *              The default implementation uses SecureZeroMemory on Windows
+ *              and a memset + compiler barrier otherwise. If neither of those
+ *              is available on the target platform, compilation will fail,
+ *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mld_zeroize_native()`.
+ *
+ *              WARNING:
+ *              The explicit stack zeroization conducted by mldsa-native
+ *              reduces the likelihood of data leaking on the stack, but
+ *              does not eliminate it! The C standard makes no guarantee about
+ *              where a compiler allocates structures and whether/where it makes
+ *              copies of them. Also, in addition to entire structures, there
+ *              may also be potentially exploitable leakage of individual values
+ *              on the stack.
+ *
+ *              If you need bullet-proof zeroization of the stack, you need to
+ *              consider additional measures instead of what this feature
+ *              provides. In this case, you can set mld_zeroize_native to a
+ *              no-op.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_ZEROIZE
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <oqs/rand.h>
+#include <stdint.h>
+#include "../../mldsa/sys.h"
+static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+{
+  OQS_randombytes(ptr, len);
+}
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_KEYGEN_PCT
+ *
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
+ *              Pairwise Consistency Test (PCT) to be carried out on a freshly
+ *              generated keypair before it can be exported.
+ *
+ *              Set this option if such a check should be implemented.
+ *              In this case, crypto_sign_keypair_internal and
+ *              crypto_sign_keypair will return a non-zero error code if the
+ *              PCT failed.
+ *
+ *              NOTE: This feature will drastically lower the performance of
+ *              key generation.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+ *
+ * Description: If this option is set, the user must provide a runtime
+ *              function `static inline int mld_break_pct() { ... }` to
+ *              indicate whether the PCT should be made fail.
+ *
+ *              This option only has an effect if MLD_CONFIG_KEYGEN_PCT is set.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+   #if !defined(__ASSEMBLER__)
+   #include "sys.h"
+   static MLD_INLINE int mld_break_pct(void)
+   {
+       ... return 0/1 depending on whether PCT should be broken ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly.
+ *
+ *              By default, inline assembly is used to implement value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *              Inline assembly is also used to implement a secure zeroization
+ *              function on non-Windows platforms. If this option is set and
+ *              the target platform is not Windows, you MUST set
+ *              MLD_CONFIG_CUSTOM_ZEROIZE and provide a custom zeroization
+ *              function.
+ *
+ *              If this option is set, MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 and
+ *              and MLD_CONFIG_USE_NATIVE_BACKEND_ARITH will be ignored, and no
+ *              native backends will be used.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM_VALUE_BARRIER
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly for value barriers.
+ *
+ *              By default, inline assembly (if available) is used to implement
+ *              value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
+/* Enable valgrind-based assertions in mlkem-native through macro
+ * from libOQS. */
+#if !defined(__ASSEMBLER__)
+#include <oqs/common.h>
+#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
+#define MLK_CONFIG_CT_TESTING_ENABLED
+#endif
+#endif /* !__ASSEMBLER__ */
+
+#endif /* !MLD_INTEGRATION_LIBOQS_CONFIG_AARCH64_H */

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#ifndef MLD_INTEGRATION_LIBOQS_CONFIG_C_H
+#define MLD_INTEGRATION_LIBOQS_CONFIG_C_H
+
+#define MLD_RANDOMIZED_SIGNING
+
+#ifndef MLDSA_MODE
+#define MLDSA_MODE 2
+#endif
+
+#if MLDSA_MODE == 2
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA44_C_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA44_C_##s
+#elif MLDSA_MODE == 3
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA65_C_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA65_C_##s
+#elif MLDSA_MODE == 5
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA87_C_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA87_C_##s
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FILE
+ *
+ * Description: If defined, this is a header that will be included instead
+ *              of this default configuration file mldsa/config.h.
+ *
+ *              When you need to build mldsa-native in multiple configurations,
+ *              using varying MLD_CONFIG_FILE can be more convenient
+ *              then configuring everything through CFLAGS.
+ *
+ *              To use, MLD_CONFIG_FILE _must_ be defined prior
+ *              to the inclusion of any mldsa-native headers. For example,
+ *              it can be set by passing `-DMLD_CONFIG_FILE="..."`
+ *              on the command line.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_FILE "config.h" */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_ARITH_BACKEND_FILE
+ *
+ * Description: The arithmetic backend to use.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_ARITH is unset, this option
+ *              is ignored.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_ARITH is set, this option must
+ *              either be undefined or the filename of an arithmetic backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #if defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH) && \
+       !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
+   #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FIPS202_BACKEND_FILE
+ *
+ * Description: The FIPS-202 backend to use.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 is set, this option
+ *              must either be undefined or the filename of a FIPS202 backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #if defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202) && \
+       !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
+   #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
+ *
+ * Description: In compliance with FIPS 204 Section 3.6.3, mldsa-native zeroizes
+ *              intermediate stack buffers before returning from function calls.
+ *
+ *              Set this option and define `mld_zeroize_native` if you want to
+ *              use a custom method to zeroize intermediate stack buffers.
+ *              The default implementation uses SecureZeroMemory on Windows
+ *              and a memset + compiler barrier otherwise. If neither of those
+ *              is available on the target platform, compilation will fail,
+ *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mld_zeroize_native()`.
+ *
+ *              WARNING:
+ *              The explicit stack zeroization conducted by mldsa-native
+ *              reduces the likelihood of data leaking on the stack, but
+ *              does not eliminate it! The C standard makes no guarantee about
+ *              where a compiler allocates structures and whether/where it makes
+ *              copies of them. Also, in addition to entire structures, there
+ *              may also be potentially exploitable leakage of individual values
+ *              on the stack.
+ *
+ *              If you need bullet-proof zeroization of the stack, you need to
+ *              consider additional measures instead of what this feature
+ *              provides. In this case, you can set mld_zeroize_native to a
+ *              no-op.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_ZEROIZE
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <oqs/rand.h>
+#include <stdint.h>
+#include "../../mldsa/sys.h"
+static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+{
+  OQS_randombytes(ptr, len);
+}
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_KEYGEN_PCT
+ *
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
+ *              Pairwise Consistency Test (PCT) to be carried out on a freshly
+ *              generated keypair before it can be exported.
+ *
+ *              Set this option if such a check should be implemented.
+ *              In this case, crypto_sign_keypair_internal and
+ *              crypto_sign_keypair will return a non-zero error code if the
+ *              PCT failed.
+ *
+ *              NOTE: This feature will drastically lower the performance of
+ *              key generation.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+ *
+ * Description: If this option is set, the user must provide a runtime
+ *              function `static inline int mld_break_pct() { ... }` to
+ *              indicate whether the PCT should be made fail.
+ *
+ *              This option only has an effect if MLD_CONFIG_KEYGEN_PCT is set.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+   #if !defined(__ASSEMBLER__)
+   #include "sys.h"
+   static MLD_INLINE int mld_break_pct(void)
+   {
+       ... return 0/1 depending on whether PCT should be broken ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly.
+ *
+ *              By default, inline assembly is used to implement value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *              Inline assembly is also used to implement a secure zeroization
+ *              function on non-Windows platforms. If this option is set and
+ *              the target platform is not Windows, you MUST set
+ *              MLD_CONFIG_CUSTOM_ZEROIZE and provide a custom zeroization
+ *              function.
+ *
+ *              If this option is set, MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 and
+ *              and MLD_CONFIG_USE_NATIVE_BACKEND_ARITH will be ignored, and no
+ *              native backends will be used.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM_VALUE_BARRIER
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly for value barriers.
+ *
+ *              By default, inline assembly (if available) is used to implement
+ *              value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
+/* Enable valgrind-based assertions in mlkem-native through macro
+ * from libOQS. */
+#if !defined(__ASSEMBLER__)
+#include <oqs/common.h>
+#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
+#define MLK_CONFIG_CT_TESTING_ENABLED
+#endif
+#endif /* !__ASSEMBLER__ */
+
+#endif /* !MLD_INTEGRATION_LIBOQS_CONFIG_C_H */

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#ifndef MLD_INTEGRATION_LIBOQS_CONFIG_X86_64_H
+#define MLD_INTEGRATION_LIBOQS_CONFIG_X86_64_H
+
+#define MLD_RANDOMIZED_SIGNING
+
+#ifndef MLDSA_MODE
+#define MLDSA_MODE 2
+#endif
+
+#if MLDSA_MODE == 2
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA44_X86_64_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA44_X86_64_##s
+#elif MLDSA_MODE == 3
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA65_X86_64_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA65_X86_64_##s
+#elif MLDSA_MODE == 5
+#define MLD_NAMESPACETOP PQCP_MLSDA_NATIVE_MLDSA87_X86_64_
+#define MLD_NAMESPACE(s) PQCP_MLSDA_NATIVE_MLDSA87_X86_64_##s
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FILE
+ *
+ * Description: If defined, this is a header that will be included instead
+ *              of this default configuration file mldsa/config.h.
+ *
+ *              When you need to build mldsa-native in multiple configurations,
+ *              using varying MLD_CONFIG_FILE can be more convenient
+ *              then configuring everything through CFLAGS.
+ *
+ *              To use, MLD_CONFIG_FILE _must_ be defined prior
+ *              to the inclusion of any mldsa-native headers. For example,
+ *              it can be set by passing `-DMLD_CONFIG_FILE="..."`
+ *              on the command line.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_FILE "config.h" */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_ARITH_BACKEND_FILE
+ *
+ * Description: The arithmetic backend to use.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_ARITH is unset, this option
+ *              is ignored.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_ARITH is set, this option must
+ *              either be undefined or the filename of an arithmetic backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
+#define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FIPS202_BACKEND_FILE
+ *
+ * Description: The FIPS-202 backend to use.
+ *
+ *              If MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 is set, this option
+ *              must either be undefined or the filename of a FIPS202 backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
+#define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
+
+
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
+ *
+ * Description: In compliance with FIPS 204 Section 3.6.3, mldsa-native zeroizes
+ *              intermediate stack buffers before returning from function calls.
+ *
+ *              Set this option and define `mld_zeroize_native` if you want to
+ *              use a custom method to zeroize intermediate stack buffers.
+ *              The default implementation uses SecureZeroMemory on Windows
+ *              and a memset + compiler barrier otherwise. If neither of those
+ *              is available on the target platform, compilation will fail,
+ *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mld_zeroize_native()`.
+ *
+ *              WARNING:
+ *              The explicit stack zeroization conducted by mldsa-native
+ *              reduces the likelihood of data leaking on the stack, but
+ *              does not eliminate it! The C standard makes no guarantee about
+ *              where a compiler allocates structures and whether/where it makes
+ *              copies of them. Also, in addition to entire structures, there
+ *              may also be potentially exploitable leakage of individual values
+ *              on the stack.
+ *
+ *              If you need bullet-proof zeroization of the stack, you need to
+ *              consider additional measures instead of what this feature
+ *              provides. In this case, you can set mld_zeroize_native to a
+ *              no-op.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_ZEROIZE
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <oqs/rand.h>
+#include <stdint.h>
+#include "../../mldsa/sys.h"
+static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+{
+  OQS_randombytes(ptr, len);
+}
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_KEYGEN_PCT
+ *
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
+ *              Pairwise Consistency Test (PCT) to be carried out on a freshly
+ *              generated keypair before it can be exported.
+ *
+ *              Set this option if such a check should be implemented.
+ *              In this case, crypto_sign_keypair_internal and
+ *              crypto_sign_keypair will return a non-zero error code if the
+ *              PCT failed.
+ *
+ *              NOTE: This feature will drastically lower the performance of
+ *              key generation.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+ *
+ * Description: If this option is set, the user must provide a runtime
+ *              function `static inline int mld_break_pct() { ... }` to
+ *              indicate whether the PCT should be made fail.
+ *
+ *              This option only has an effect if MLD_CONFIG_KEYGEN_PCT is set.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+   #if !defined(__ASSEMBLER__)
+   #include "sys.h"
+   static MLD_INLINE int mld_break_pct(void)
+   {
+       ... return 0/1 depending on whether PCT should be broken ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly.
+ *
+ *              By default, inline assembly is used to implement value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *              Inline assembly is also used to implement a secure zeroization
+ *              function on non-Windows platforms. If this option is set and
+ *              the target platform is not Windows, you MUST set
+ *              MLD_CONFIG_CUSTOM_ZEROIZE and provide a custom zeroization
+ *              function.
+ *
+ *              If this option is set, MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 and
+ *              and MLD_CONFIG_USE_NATIVE_BACKEND_ARITH will be ignored, and no
+ *              native backends will be used.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM_VALUE_BARRIER
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly for value barriers.
+ *
+ *              By default, inline assembly (if available) is used to implement
+ *              value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
+/* Enable valgrind-based assertions in mlkem-native through macro
+ * from libOQS. */
+#if !defined(__ASSEMBLER__)
+#include <oqs/common.h>
+#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
+#define MLK_CONFIG_CT_TESTING_ENABLED
+#endif
+#endif /* !__ASSEMBLER__ */
+
+#endif /* !MLD_INTEGRATION_LIBOQS_CONFIG_X86_64_H */

--- a/mldsa/randombytes.h
+++ b/mldsa/randombytes.h
@@ -11,11 +11,13 @@
 #include "cbmc.h"
 #include "common.h"
 
+#if !defined(MLD_CONFIG_CUSTOM_RANDOMBYTES)
 void randombytes(uint8_t *out, size_t outlen);
 static MLD_INLINE void mld_randombytes(uint8_t *out, size_t outlen)
 __contract__(
   requires(memory_no_alias(out, outlen))
   assigns(memory_slice(out, outlen))
 ) { randombytes(out, outlen); }
+#endif /* !MLD_CONFIG_CUSTOM_RANDOMBYTES */
 
 #endif /* !MLD_RANDOMBYTES_H */


### PR DESCRIPTION
This adds integration code for liboqs. The integration code is being tested here: https://github.com/open-quantum-safe/liboqs/pull/2222. Please note, that the current integration does not integrate liboqs' FIPS202 into mldsa-native (earlier mentioned here: https://github.com/pq-code-package/mldsa-native/issues/162#issuecomment-3141093735) 

Errors, as recorded at the link above and observed from testing locally, are primarily because of two issues:
1. All FIPS202 code is namespaced as `mldsa_*` which isn't presently a valid liboqs namespace. This is controlled by the [`FIPS202_NAMESPACE`](https://github.com/pq-code-package/mldsa-native/blob/77976820d20cf173c7fe466a6f272565764ec5cf/mldsa/fips202/fips202.h#L20) macro. If integration of liboqs' FIP202 into mldsa-native is not desirable/feasible at the moment I will add the required configuration option to `config.h` and switch these functions to a `PQCP_` namespace.
2. ACVP tests are disabled because mldsa-native does not expose internal function. This can be fixed once #354 is resolved. 