### PR TITLE
Nix: Introduce separate shells for cross compilation

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,6 +35,7 @@ jobs:
           archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
           cflags: "-flto -DMLD_FORCE_AARCH64"
           bench_extra_args: ""
+          nix_shell: ci-bench
           only_no_opt: false
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
@@ -42,6 +43,7 @@ jobs:
           archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
           cflags: "-flto -DMLD_FORCE_AARCH64"
           bench_extra_args: ""
+          nix_shell: ci-bench
           only_no_opt: false
         - system: a55
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
@@ -49,6 +51,7 @@ jobs:
           archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
           cflags: "-flto -static -DMLD_FORCE_AARCH64"
           bench_extra_args: -w exec-on-a55
+          nix_shell: ci-bench
           only_no_opt: false
         - system: bpi
           name: SpacemiT K1 8 (Banana Pi F3) benchmarks
@@ -57,6 +60,7 @@ jobs:
           cflags: "-static"
           bench_extra_args: -w exec-on-bpi
           cross_prefix: riscv64-unknown-linux-gnu-
+          nix_shell: ci-cross-riscv64
           only_no_opt: true
         - system: m1-mac-mini
           name: Mac Mini (M1, 2020) benchmarks
@@ -64,6 +68,7 @@ jobs:
           archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
           cflags: "-flto"
           bench_extra_args: "-r"
+          nix_shell: ci-bench
           only_no_opt: false
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
     runs-on: self-hosted-${{ matrix.target.system }}
@@ -79,7 +84,7 @@ jobs:
           store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
           bench_extra_args: ${{ matrix.target.bench_extra_args }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci-bench' }}
+          nix-shell: ${{ matrix.target.nix_shell }}
           cross_prefix: ${{ matrix.target.cross_prefix }}
           opt: true
       - uses: ./.github/actions/bench
@@ -91,7 +96,7 @@ jobs:
           store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
           bench_extra_args: ${{ matrix.target.bench_extra_args }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci-bench' }}
+          nix-shell: ${{ matrix.target.nix_shell }}
           cross_prefix: ${{ matrix.target.cross_prefix }}
           opt: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,98 +21,116 @@ jobs:
            name: 'MacOS (aarch64)'
            arch: mac
            mode: native
+           nix_shell: ci
          - runner: macos-13
            name: 'MacOS (x86_64)'
            arch: mac
            mode: native
+           nix_shell: ci
          - runner: pqcp-arm64
            name: 'ubuntu-latest (aarch64)'
            arch: aarch64
            mode: native
+           nix_shell: ci
          - runner: pqcp-arm64
            name: 'ubuntu-latest (aarch64)'
            arch: x86_64
            mode: cross-x86_64
+           nix_shell: ci-cross-x86_64
          - runner: pqcp-arm64
            name: 'ubuntu-latest (aarch64)'
            arch: riscv64
            mode: cross-riscv64
+           nix_shell: ci-cross-riscv64
          - runner: pqcp-arm64
            name: 'ubuntu-latest (aarch64)'
            arch: riscv32
            mode: cross-riscv32
+           nix_shell: ci-cross-riscv32
          - runner: pqcp-arm64
            name: 'ubuntu-latest (ppc64le)'
            arch: ppc64le
            mode: cross-ppc64le
+           nix_shell: ci-cross-ppc64le
          - runner: pqcp-x64
            name: 'ubuntu-latest (x86_64)'
            arch: x86_64
            mode: native
+           nix_shell: ci
          - runner: pqcp-x64
            name: 'ubuntu-latest (x86_64)'
            arch: aarch64
            mode: cross-aarch64
+           nix_shell: ci-cross-aarch64
          - runner: pqcp-x64
            name: 'ubuntu-latest (x86_64)'
            arch: aarch64_be
            mode: cross-aarch64_be
+           nix_shell: ci-cross-aarch64_be
         exclude:
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'ubuntu-latest (aarch64)',
                arch: aarch64,
-               mode: native
+               mode: native,
+              nix_shell: ci
              }}
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'ubuntu-latest (aarch64)',
                arch: x86_64,
-               mode: cross-x86_64
+               mode: cross-x86_64,
+               nix_shell: ci-cross-x86_64
              }}
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'ubuntu-latest (aarch64)',
                arch: riscv64,
-               mode: cross-riscv64
+               mode: cross-riscv64,
+               nix_shell: ci-corss-riscv64
              }}
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'ubuntu-latest (aarch64)',
                arch: riscv32,
-               mode: cross-riscv32
+               mode: cross-riscv32,
+               nix_shell: ci-cross-riscv32
              }}
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'ubuntu-latest (ppc64le)',
                arch: ppc64le,
-               mode: cross-ppc64le
+               mode: cross-ppc64le,
+               nix_shell: ci-cross-ppc64le
              }}
           - {external: true,
              target: {
                runner: pqcp-x64,
                name: 'ubuntu-latest (x86_64)',
                arch: x86_64,
-               mode: native
+               mode: native,
+               nix_shell: ci
              }}
           - {external: true,
              target: {
                runner: pqcp-x64,
                name: 'ubuntu-latest (x86_64)',
                arch: aarch64,
-               mode: cross-aarch64
+               mode: cross-aarch64,
+               nix_shell: ci-cross-aarch64
              }}
           - {external: true,
              target: {
                runner: pqcp-x64,
                name: 'ubuntu-latest (x86_64)',
                arch: aarch64_be,
-               mode: cross-aarch64_be
+               mode: cross-aarch64_be,
+               nix_shell: ci-cross-aarch64_be
              }}
     name: Functional tests (${{ matrix.target.arch }}${{ matrix.target.mode != 'native' && ', cross' || ''}})
     runs-on: ${{ matrix.target.runner }}
@@ -121,7 +139,7 @@ jobs:
       - name: build + test
         uses: ./.github/actions/multi-functest
         with:
-          nix-shell: ${{ matrix.target.mode == 'native' && 'ci' || 'ci-cross' }}
+          nix-shell: ${{ matrix.target.nix_shell }}
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,12 @@
           packages.slothy = util.slothy;
           packages.toolchains = util.toolchains;
           packages.toolchains_native = util.toolchains_native;
+          packages.toolchain_x86_64 = util.toolchain_x86_64;
+          packages.toolchain_aarch64 = util.toolchain_aarch64;
+          packages.toolchain_riscv64 = util.toolchain_riscv64;
+          packages.toolchain_riscv32 = util.toolchain_riscv32;
+          packages.toolchain_ppc64le = util.toolchain_ppc64le;
+          packages.toolchain_aarch64_be = util.toolchain_aarch64_be;
 
           devShells.default = util.mkShell {
             packages = builtins.attrValues
@@ -97,6 +103,24 @@
           };
           devShells.ci-cross = util.mkShell {
             packages = builtins.attrValues { inherit (config.packages) linters toolchains; };
+          };
+          devShells.ci-cross-x86_64 = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchain_x86_64; };
+          };
+          devShells.ci-cross-aarch64 = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchain_aarch64; };
+          };
+          devShells.ci-cross-riscv64 = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchain_riscv64; };
+          };
+          devShells.ci-cross-riscv32 = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchain_riscv32; };
+          };
+          devShells.ci-cross-ppc64le = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchain_ppc64le; };
+          };
+          devShells.ci-cross-aarch64_be = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchain_aarch64_be; };
           };
           devShells.ci-linter = util.mkShellNoCC {
             packages = builtins.attrValues { inherit (config.packages) linters; };

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -103,6 +103,54 @@ rec {
   s2n_bignum = pkgs.callPackage ./s2n_bignum { };
   slothy = pkgs.callPackage ./slothy { };
 
+  # Helper function to build individual cross toolchains
+  _individual_toolchain = { name, cross_compilers }:
+    let
+      common_deps = builtins.attrValues
+        {
+          inherit (pkgs.python3Packages) sympy pyyaml;
+          inherit (pkgs)
+            gnumake
+            python3
+            qemu;
+        } ++ pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.git ];
+    in
+    pkgs.symlinkJoin {
+      name = "toolchain-${name}";
+      paths = cross_compilers ++ common_deps ++ [ native-gcc ];
+    };
+
+  # Individual cross toolchains
+  toolchain_x86_64 = _individual_toolchain {
+    name = "x86_64";
+    cross_compilers = [ (wrap-gcc pkgs.pkgsCross.gnu64) ];
+  };
+
+  toolchain_aarch64 = _individual_toolchain {
+    name = "aarch64";
+    cross_compilers = [ (wrap-gcc pkgs.pkgsCross.aarch64-multiplatform) ];
+  };
+
+  toolchain_riscv64 = _individual_toolchain {
+    name = "riscv64";
+    cross_compilers = [ (wrap-gcc pkgs.pkgsCross.riscv64) ];
+  };
+
+  toolchain_riscv32 = _individual_toolchain {
+    name = "riscv32";
+    cross_compilers = [ (wrap-gcc pkgs.pkgsCross.riscv32) ];
+  };
+
+  toolchain_ppc64le = _individual_toolchain {
+    name = "ppc64le";
+    cross_compilers = [ (wrap-gcc pkgs.pkgsCross.powernv) ];
+  };
+
+  toolchain_aarch64_be = _individual_toolchain {
+    name = "aarch64_be";
+    cross_compilers = pkgs.lib.optionals (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64) [ (pkgs.callPackage ./aarch64_be-none-linux-gnu-gcc.nix { }) ];
+  };
+
   toolchains = pkgs.symlinkJoin {
     name = "toolchains";
     paths = _toolchains { };


### PR DESCRIPTION
- Resolves: #439 
- Previously, we used a single `ci-cross` nix shell for all cross-compilation tool chains. This shell takes a very long time to build and is therefore inconvenient to use for cross-compilation on a specific target.
- This commit extends the nix flake by architecture specific ci cross shells:
  - ci-cross-x86_64
  - ci-cross-aarch64
  - ci-cross-riscv64
  - ci-cross-riscv32
  - ci-cross-ppc64le
  - ci-cross-aarch64_be
- It also adjusts CI to use those shells.
- This commit is port from mlkem-native: https://github.com/pq-code-package/mlkem-native/pull/1104