### PR TITLE
Add initial support for Armv8.1-M targets

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -19,6 +19,9 @@ inputs:
   archflags:
     description: ARCHFLAGS to pass to compilation
     default: ""
+  ldflags:
+    description: LDFLAGS to pass to compilation
+    default: ""
   opt:
     description: opt flag to set for tests script
     default: "true"
@@ -77,11 +80,13 @@ runs:
       run: |
         ./scripts/tests bench -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
               --cflags="${{ inputs.cflags }} ${{ inputs.archflags }}" \
+              --ldflags="${{ inputs.ldflags }}" \
               --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v --output=output.json ${{ inputs.bench_extra_args }}
 
         ./scripts/tests bench --components -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
               --cflags="${{ inputs.cflags }} ${{ inputs.archflags }}" \
+              --ldflags="${{ inputs.ldflags }}" \
               --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v  ${{ inputs.bench_extra_args }}
     - name: Store benchmark result

--- a/.github/actions/config-variations/action.yml
+++ b/.github/actions/config-variations/action.yml
@@ -24,6 +24,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-DMLD_CONFIG_KEYGEN_PCT -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true
@@ -51,6 +52,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_zeroize_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true
@@ -63,6 +65,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/no_asm_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true
@@ -75,6 +78,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_randombytes_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true
@@ -87,6 +91,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_memcpy_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true
@@ -99,6 +104,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_memset_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true
@@ -111,6 +117,7 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_stdlib_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true
         acvp: true

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -24,6 +24,9 @@ inputs:
   cflags:
     description: CFLAGS to pass to compilation
     default: ""
+  ldflags:
+    description: LDFLAGS to pass to linking
+    default: ""
   cross_prefix:
     description: Binary prefix for cross compilation
     default: ""
@@ -95,7 +98,7 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v
+          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -24,6 +24,9 @@ inputs:
   cflags:
     description: CFLAGS to pass to compilation
     default: ""
+  ldflags:
+    description: LDFLAGS to pass to linking
+    default: ""
   compile_mode:
     description: all | native | cross-x86_64 | cross-aarch64 | cross-riscv64
     default: "native"
@@ -58,6 +61,7 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
+          ldflags: ${{ inputs.ldflags }}
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -74,6 +78,7 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_X86_64"
+          ldflags: ${{ inputs.ldflags }}
           cross_prefix: x86_64-unknown-linux-gnu-
           exec_wrapper: qemu-x86_64
           opt: ${{ inputs.opt }}
@@ -92,6 +97,7 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_AARCH64"
+          ldflags: ${{ inputs.ldflags }}
           cross_prefix: aarch64-unknown-linux-gnu-
           exec_wrapper: qemu-aarch64
           opt: ${{ inputs.opt }}
@@ -110,6 +116,7 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_PPC64LE"
+          ldflags: ${{ inputs.ldflags }}
           cross_prefix: powerpc64le-unknown-linux-gnu-
           exec_wrapper: qemu-ppc64le
           opt: ${{ inputs.opt }}
@@ -127,7 +134,8 @@ runs:
           nix-verbose: ${{ inputs.nix-verbose }}
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
-          cflags: "${{ inputs.cflags }} -static  -DMLD_FORCE_AARCH64_EB"
+          cflags: "${{ inputs.cflags }} -DMLD_FORCE_AARCH64_EB"
+          ldflags: "${{ inputs.ldflags }} -static"
           cross_prefix: aarch64_be-none-linux-gnu-
           exec_wrapper: qemu-aarch64_be
           opt: ${{ inputs.opt }}
@@ -146,6 +154,7 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
+          ldflags: ${{ inputs.ldflags }}
           cross_prefix: riscv64-unknown-linux-gnu-
           exec_wrapper: qemu-riscv64
           opt: ${{ inputs.opt }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -59,3 +59,11 @@ jobs:
     needs: [ base, nix ]
     uses: ./.github/workflows/ct-tests.yml
     secrets: inherit
+  baremetal:
+    name: Baremetal
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/baremetal.yml
+    secrets: inherit

--- a/.github/workflows/baremetal.yml
+++ b/.github/workflows/baremetal.yml
@@ -1,0 +1,37 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: Baremetal
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  baremetal_tests:
+    name: Baremetal tests (${{ matrix.target.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+         - runner: ubuntu-latest
+           name: 'M55-AN547'
+           makefile: test/baremetal/platform/m55-an547/platform.mk
+           nix-shell: arm-embedded
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: baremetal build + test
+        uses: ./.github/actions/functest
+        env:
+          EXTRA_MAKEFILE: ${{ matrix.target.makefile }}
+        with:
+          nix-shell: ${{ matrix.target.nix-shell }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          opt: no_opt
+          func: true
+          kat: true
+          acvp: true
+          examples: false
+          stack: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,6 +34,7 @@ jobs:
           bench_pmu: PMU
           archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
           cflags: "-flto -DMLD_FORCE_AARCH64"
+          ldflags: "-flto"
           bench_extra_args: ""
           nix_shell: ci-bench
           only_no_opt: false
@@ -42,6 +43,7 @@ jobs:
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
           cflags: "-flto -DMLD_FORCE_AARCH64"
+          ldflags: "-flto"
           bench_extra_args: ""
           nix_shell: ci-bench
           only_no_opt: false
@@ -49,7 +51,8 @@ jobs:
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: "-flto -static -DMLD_FORCE_AARCH64"
+          cflags: "-flto -DMLD_FORCE_AARCH64"
+          ldflags: "-flto -static"
           bench_extra_args: -w exec-on-a55
           nix_shell: ci-bench
           only_no_opt: false
@@ -57,7 +60,8 @@ jobs:
           name: SpacemiT K1 8 (Banana Pi F3) benchmarks
           bench_pmu: PERF
           archflags: "-march=rv64imafdcv_zicsr_zifencei"
-          cflags: "-static"
+          cflags: ""
+          ldflags: "-static"
           bench_extra_args: -w exec-on-bpi
           cross_prefix: riscv64-unknown-linux-gnu-
           nix_shell: ci-cross-riscv64
@@ -67,6 +71,7 @@ jobs:
           bench_pmu: MAC
           archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
           cflags: "-flto"
+          ldflags: "-flto"
           bench_extra_args: "-r"
           nix_shell: ci-bench
           only_no_opt: false
@@ -80,6 +85,7 @@ jobs:
           name: ${{ matrix.target.name }} (opt)
           cflags: ${{ matrix.target.cflags }}
           archflags: ${{ matrix.target.archflags }}
+          ldflags: ${{ matrix.target.ldflags }}
           perf: ${{ matrix.target.bench_pmu }}
           store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
           bench_extra_args: ${{ matrix.target.bench_extra_args }}
@@ -92,6 +98,7 @@ jobs:
           name: ${{ matrix.target.name }} (no-opt)
           cflags: ${{ matrix.target.cflags }}
           archflags: ${{ matrix.target.archflags }}
+          ldflags: ${{ matrix.target.ldflags }}
           perf: ${{ matrix.target.bench_pmu }}
           store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
           bench_extra_args: ${{ matrix.target.bench_extra_args }}
@@ -115,42 +122,49 @@ jobs:
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -mcpu=cortex-a76 -march=armv8.2-a
             cflags: "-flto -DMLD_FORCE_AARCH64"
+            ldflags: "-flto"
             perf: PERF
           - name: Graviton3
             ec2_instance_type: c7g.medium
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv8.4-a+sha3
             cflags: "-flto -DMLD_FORCE_AARCH64"
+            ldflags: "-flto"
             perf: PERF
           - name: Graviton4
             ec2_instance_type: c8g.medium
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv9-a+sha3
             cflags: "-flto -DMLD_FORCE_AARCH64"
+            ldflags: "-flto"
             perf: PERF
           - name: AMD EPYC 4th gen (c7a)
             ec2_instance_type: c7a.medium
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver4
             cflags: "-flto -DMLD_FORCE_X86_64"
+            ldflags: "-flto"
             perf: PMU
           - name: Intel Xeon 4th gen (c7i)
             ec2_instance_type: c7i.metal-24xl
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=sapphirerapids
             cflags: "-flto -DMLD_FORCE_X86_64"
+            ldflags: "-flto"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
             ec2_instance_type: c6a.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver3
             cflags: "-flto -DMLD_FORCE_X86_64"
+            ldflags: "-flto"
             perf: PMU
           - name: Intel Xeon 3rd gen (c6i)
             ec2_instance_type: c6i.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=icelake-server
             cflags: "-flto -DMLD_FORCE_X86_64"
+            ldflags: "-flto"
             perf: PMU
     uses: ./.github/workflows/bench_ec2_reusable.yml
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
@@ -159,6 +173,7 @@ jobs:
       ec2_ami: ${{ matrix.target.ec2_ami }}
       archflags: ${{ matrix.target.archflags }}
       cflags: ${{ matrix.target.cflags }}
+      ldflags: ${{ matrix.target.ldflags }}
       opt: "all"
       store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
       name: ${{ matrix.target.name }}

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -32,6 +32,9 @@ on:
       archflags:
         description: Custom ARCH flags for compilation
         default: ''
+      ldflags:
+        description: Custom LDFLAGS for linking
+        default: ''
       opt:
         description: Benchmark optimized, non-optimized, or both
         type: choice
@@ -61,6 +64,7 @@ jobs:
       ec2_ami_id: ${{ inputs.ec2_ami_id }}
       cflags: ${{ inputs.cflags }}
       archflags: ${{ inputs.archflags }}
+      ldflags: ${{ inputs.ldflags }}
       opt: ${{ inputs.opt }}
       name: ${{ inputs.name }}
       store_results: false

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -48,9 +48,6 @@ on:
       compiler:
         description: Compiler to use. When unset, default nix shell is used.
         default: ''
-      additional_packages:
-        description: Additional packages to install when custom compiler is used.
-        default: ''
 jobs:
   bench-ec2-any:
     name: Ad-hoc benchmark on $${{ inputs.ec2_instance_type }}
@@ -70,5 +67,4 @@ jobs:
       store_results: false
       bench_extra_args: ${{ inputs.bench_extra_args }}
       compiler: ${{ inputs.compiler }}
-      additional_packages: ${{ inputs.additional_packages }}
     secrets: inherit

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -30,6 +30,10 @@ on:
         type: string
         description: Custom ARCH flags for compilation
         default: -mcpu=neoverse-n1 -march=armv8.2-a
+      ldflags:
+        type: string
+        description: Custom LDFLAGS for linking
+        default: ""
       opt:
         type: string
         description: Runs with optimized code if enabled (opt, no_opt, all)
@@ -133,6 +137,7 @@ jobs:
           name: ${{ inputs.name }}
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
+          ldflags: ${{ inputs.ldflags }}
           opt: true
           perf: ${{ inputs.perf }}
           store_results: ${{ inputs.store_results }}
@@ -145,6 +150,7 @@ jobs:
           name: ${{ inputs.name }} (no-opt)
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
+          ldflags: ${{ inputs.ldflags }}
           opt: false
           perf: ${{ inputs.perf }}
           store_results: ${{ inputs.store_results }}
@@ -177,6 +183,7 @@ jobs:
           name: ${{ inputs.name }} (${{ inputs.compiler }})
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
+          ldflags: ${{ inputs.ldflags }}
           opt: true
           perf: ${{ inputs.perf }}
           store_results: ${{ inputs.store_results }}
@@ -192,6 +199,7 @@ jobs:
           name: ${{ inputs.name }} (${{ inputs.compiler }}) (no-opt)
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
+          ldflags: ${{ inputs.ldflags }}
           opt: false
           perf: ${{ inputs.perf }}
           store_results: ${{ inputs.store_results }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
           cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+          ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
   compiler_tests:
     name: Compiler tests  (${{ matrix.compiler.name }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ SHELL := /bin/bash
 
 all: build
 
+# Extra Makefile to include, e.g., for baremetal targets
+ifneq ($(EXTRA_MAKEFILE),)
+include $(EXTRA_MAKEFILE)
+endif
+
 W := $(EXEC_WRAPPER)
 
 # Detect available SHA256 command

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ run_func_87: func_87
 run_func: run_func_44 run_func_65 run_func_87
 
 run_acvp: acvp
-	python3 ./test/acvp_client.py $(if $(ACVP_VERSION),--version $(ACVP_VERSION))
+	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/acvp_client.py $(if $(ACVP_VERSION),--version $(ACVP_VERSION))
 
 func_44: $(MLDSA44_DIR)/bin/test_mldsa44
 	$(Q)echo "  FUNC       ML-DSA-44:   $^"

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,15 @@
               } ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ config.packages.valgrind_varlat ];
           };
 
+          # arm-none-eabi-gcc + platform files from pqmx
+          packages.m55-an547 = util.m55-an547;
+          devShells.arm-embedded = util.mkShell {
+            packages = builtins.attrValues
+              {
+                inherit (config.packages) m55-an547;
+                inherit (pkgs) gcc-arm-embedded qemu coreutils python3 git;
+              };
+          };
           devShells.hol_light = util.mkShell {
             packages = builtins.attrValues {
               inherit (config.packages) hol_light s2n_bignum;

--- a/nix/m55-an547-arm-none-eabi/default.nix
+++ b/nix/m55-an547-arm-none-eabi/default.nix
@@ -1,0 +1,38 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+{ stdenvNoCC
+, fetchFromGitHub
+, writeText
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "mldsa-native-m55-an547";
+  version = "main-2025-10-02";
+
+
+  # Fetch platform files from pqmx (envs/m55-an547)
+  src = fetchFromGitHub {
+    owner = "slothy-optimizer";
+    repo = "pqmx";
+    rev = "4ed493d3cf2af62a08fd9fe36c3472a0dc50ad9f";
+    hash = "sha256-jLIqwknjRwcoDeEAETlMhRqZQ5a3QGCDZX9DENelGeQ=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/platform/m55-an547/src/platform/
+    cp -r envs/m55-an547/src/platform/. $out/platform/m55-an547/src/platform/
+    cp integration/*.c $out/platform/m55-an547/src/platform/
+  '';
+
+  setupHook = writeText "setup-hook.sh" ''
+    export M55_AN547_PATH="$1/platform/m55-an547/src/platform/"
+  '';
+
+  meta = {
+    description = "Platform files for the Cortex-M55 (AN547)";
+    homepage = "https://github.com/slothy-optimizer/pqmx";
+  };
+}

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -30,6 +30,7 @@ rec {
       riscv64-gcc = wrap-gcc pkgs.pkgsCross.riscv64;
       riscv32-gcc = wrap-gcc pkgs.pkgsCross.riscv32;
       ppc64le-gcc = wrap-gcc pkgs.pkgsCross.powernv;
+      arm-embedded-gcc = wrap-gcc pkgs.armToolchain;
       aarch64_be-gcc = (pkgs.callPackage ./aarch64_be-none-linux-gnu-gcc.nix { });
     in
     # NOTE:
@@ -102,6 +103,7 @@ rec {
   hol_light' = pkgs.callPackage ./hol_light { };
   s2n_bignum = pkgs.callPackage ./s2n_bignum { };
   slothy = pkgs.callPackage ./slothy { };
+  m55-an547 = pkgs.callPackage ./m55-an547-arm-none-eabi { };
 
   # Helper function to build individual cross toolchains
   _individual_toolchain = { name, cross_compilers }:

--- a/scripts/tests
+++ b/scripts/tests
@@ -351,6 +351,9 @@ class Tests:
         cflags = self.args.cflags
         if cflags is None:
             cflags = ""
+        ldflags = self.args.ldflags
+        if ldflags is None:
+            ldflags = ""
 
         if test_type.is_example() and self.args.cross_prefix != "":
             cflags += " -static"
@@ -358,6 +361,8 @@ class Tests:
         env_update = {}
         if cflags != "":
             env_update["CFLAGS"] = cflags
+        if ldflags != "":
+            env_update["LDFLAGS"] = ldflags
         if self.args.cross_prefix != "":
             env_update["CROSS_PREFIX"] = self.args.cross_prefix
 
@@ -797,6 +802,9 @@ def cli():
     )
     common_parser.add_argument(
         "--cflags", help="Extra cflags to passed in (e.g. '-mcpu=cortex-a72')"
+    )
+    common_parser.add_argument(
+        "--ldflags", help="Extra ldflags to passed in (e.g. '-static')"
     )
     common_parser.add_argument(
         "-j",

--- a/test/baremetal/platform/m55-an547/exec_wrapper.py
+++ b/test/baremetal/platform/m55-an547/exec_wrapper.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+import struct as st
+import sys
+import subprocess
+import tempfile
+import os
+
+
+def err(msg, **kwargs):
+    print(msg, file=sys.stderr, **kwargs)
+
+
+binpath = sys.argv[1]
+args = sys.argv[1:]
+cmdline_offset = 0x70000
+
+arg0_offset = cmdline_offset + 4 + len(args) * 4
+
+arg_offsets = [sum(map(len, args[:i])) + i + arg0_offset for i in range(len(args))]
+
+binargs = st.pack(
+    f"<{1+len(args)}I" + "".join(f"{len(a)+1}s" for a in args),
+    len(args),
+    *arg_offsets,
+    *map(lambda x: x.encode("utf-8"), args),
+)
+
+with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".bin") as fd:
+    args_file = fd.name
+    fd.write(binargs)
+
+try:
+    qemu_cmd = f"qemu-system-arm -M mps3-an547 -nographic -semihosting -kernel {binpath} -device loader,file={args_file},addr=0x{cmdline_offset:x}".split()
+    result = subprocess.run(qemu_cmd, encoding="utf-8", capture_output=True)
+finally:
+    os.unlink(args_file)
+if result.returncode != 0:
+    err("FAIL!")
+    err(f"{qemu_cmd} failed with error code {result.returncode}")
+    err(result.stderr)
+    exit(1)
+
+for line in result.stdout.splitlines():
+    print(line)

--- a/test/baremetal/platform/m55-an547/platform.mk
+++ b/test/baremetal/platform/m55-an547/platform.mk
@@ -1,0 +1,61 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+PLATFORM_PATH:=test/baremetal/platform/m55-an547
+
+CROSS_PREFIX=arm-none-eabi-
+CC=gcc
+
+CFLAGS += \
+	-O3 \
+	-Wall -Wextra -Wshadow \
+	-Wno-pedantic \
+	-Wno-redundant-decls \
+	-Wno-missing-prototypes \
+	-fno-common \
+	-ffunction-sections \
+	-fdata-sections \
+	--sysroot=$(SYSROOT) \
+	-DDEVICE=an547 \
+	-I$(M55_AN547_PATH) \
+	-DARMCM55 \
+	-DSEMIHOSTING
+
+ARCH_FLAGS += \
+	-march=armv8.1-m.main+mve.fp \
+	-mcpu=cortex-m55 \
+	-mthumb \
+	-mfloat-abi=hard -mfpu=fpv4-sp-d16
+
+CFLAGS += \
+	$(ARCH_FLAGS) \
+	--specs=nosys.specs
+
+CFLAGS += $(CFLAGS_EXTRA)
+
+LDSCRIPT = $(M55_AN547_PATH)/mps3.ld
+
+LDFLAGS += \
+	-Wl,--gc-sections \
+	-Wl,--no-warn-rwx-segments \
+	-L.
+
+LDFLAGS += \
+	--specs=nosys.specs \
+	-Wl,--wrap=_open \
+	-Wl,--wrap=_close \
+	-Wl,--wrap=_read \
+	-Wl,--wrap=_write \
+	-Wl,--wrap=_fstat \
+	-Wl,--wrap=_getpid \
+	-Wl,--wrap=_isatty \
+	-Wl,--wrap=_kill \
+	-Wl,--wrap=_lseek \
+	-Wl,--wrap=main \
+	-ffreestanding \
+	-T$(LDSCRIPT) \
+	$(ARCH_FLAGS)
+
+# Extra sources to be included in test binaries
+EXTRA_SOURCES = $(wildcard $(M55_AN547_PATH)/*.c)
+EXEC_WRAPPER := $(realpath $(PLATFORM_PATH)/exec_wrapper.py)

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -67,6 +67,6 @@ $(foreach scheme,mldsa44 mldsa65 mldsa87, \
 	) \
 )
 
-$(ALL_TESTS:%=$(MLDSA44_DIR)/bin/%44): $(call MAKE_OBJS, $(MLDSA44_DIR), $(wildcard test/notrandombytes/*.c))
-$(ALL_TESTS:%=$(MLDSA65_DIR)/bin/%65): $(call MAKE_OBJS, $(MLDSA65_DIR), $(wildcard test/notrandombytes/*.c))
-$(ALL_TESTS:%=$(MLDSA87_DIR)/bin/%87): $(call MAKE_OBJS, $(MLDSA87_DIR), $(wildcard test/notrandombytes/*.c))
+$(ALL_TESTS:%=$(MLDSA44_DIR)/bin/%44): $(call MAKE_OBJS, $(MLDSA44_DIR), $(wildcard test/notrandombytes/*.c) $(EXTRA_SOURCES))
+$(ALL_TESTS:%=$(MLDSA65_DIR)/bin/%65): $(call MAKE_OBJS, $(MLDSA65_DIR), $(wildcard test/notrandombytes/*.c) $(EXTRA_SOURCES))
+$(ALL_TESTS:%=$(MLDSA87_DIR)/bin/%87): $(call MAKE_OBJS, $(MLDSA87_DIR), $(wildcard test/notrandombytes/*.c) $(EXTRA_SOURCES))

--- a/test/mk/rules.mk
+++ b/test/mk/rules.mk
@@ -5,17 +5,17 @@
 $(BUILD_DIR)/mldsa44/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(Q)$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/mldsa65/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(Q)$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/mldsa87/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(Q)$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/%.a: $(CONFIG)
 	$(Q)echo "  AR      $@"


### PR DESCRIPTION
This PR adds initial support for baremetal targets.

General build system changes:
  - Add separate LDFLAGS (previously only CFLAGS for both compilation and linking)
  - Add EXTRA_MAKEFILE to include custom makefiles with platform-specific configuration
  - Add EXTRA_SOURCES to compile and link additional platform files
  - Fix ACVP tests to respect EXEC_WRAPPER

  Baremetal support for MPS3 AN547 (Arm Cortex-M55):
  - Add nix shell (arm-embedded) with arm-none-eabi-gcc, qemu, and platform support files from pqmx
  - Add test/baremetal/platform/m55-an547/platform.mk with compiler flags, and build configuration
  - Add exec_wrapper.py to pass test arguments via QEMU
  - Add CI workflow for functional, KAT, and ACVP tests on AN547
