### PR TITLE
CBMC: Increase CBMC_OBJECT_BITS to improve proof runtime

### DIFF
--- a/proofs/cbmc/polyvec_matrix_pointwise_montgomery/Makefile
+++ b/proofs/cbmc/polyvec_matrix_pointwise_montgomery/Makefile
@@ -37,7 +37,7 @@ FUNCTION_NAME = polyvec_matrix_pointwise_montgomery
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 10
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -37,7 +37,7 @@ FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 10
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
This improves CBMC proof run-time for ML-DSA-44 from 25 minutes to 5 minutes, for ML-DSA-65 from 8 minutes to 6 minutes, and for ML-DSA-87 from 8 minutes to 7 minutes. 