### PR TITLE
CI: Port config-variation action from mlkem-native

### DIFF
--- a/.github/actions/config-variations/action.yml
+++ b/.github/actions/config-variations/action.yml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: 'Custom config tests'
+description: 'Build and test mldsa-native with various custom configs'
+inputs:
+  gh_token:
+    description: 'GitHub token'
+    required: true
+  tests:
+    description: 'List of tests to run (space-separated IDs) or "all" for all tests. Available IDs: pct-enabled, pct-enabled-broken, custom-zeroize, no-asm, custom-randombytes, custom-memcpy, custom-memset, custom-stdlib'
+    required: false
+    default: 'all'
+  opt:
+    description: 'Optimization level to pass to multi-functest'
+    required: false
+    default: 'all'
+runs:
+  using: 'composite'
+  steps:
+    - name: "PCT enabled"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'pct-enabled') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-DMLD_CONFIG_KEYGEN_PCT -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: true
+    - name: "PCT enabled + broken"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'pct-enabled-broken') }}
+      shell: bash
+      run: |
+        make clean
+        CFLAGS='-DMLD_CONFIG_FILE=\"../test/break_pct_config.h\"' make func -j4
+        # PCT breakage is done at runtime via MLD_BREAK_PCT
+        make run_func                 # Should be OK
+        MLD_BREAK_PCT=0 make run_func # Should be OK
+        if (MLD_BREAK_PCT=1 make run_func 2>&1 >/dev/null); then
+           echo "PCT failure expected"
+           exit 1
+        else
+           echo "PCT failed as expected"
+        fi
+    - name: "Custom zeroization (explicit_bzero)"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-zeroize') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_zeroize_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: false # Some examples use a custom config themselves
+    - name: "No ASM"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'no-asm') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/no_asm_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: false # Some examples use a custom config themselves
+    - name: "Custom randombytes"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-randombytes') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_randombytes_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: false # Some examples use a custom config themselves
+    - name: "Custom memcpy"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-memcpy') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_memcpy_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: false # Some examples use a custom config themselves
+    - name: "Custom memset"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-memset') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_memset_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: false # Some examples use a custom config themselves
+    - name: "Custom stdlib (memcpy + memset)"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-stdlib') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_stdlib_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        opt: ${{ inputs.opt }}
+        examples: false # Some examples use a custom config themselves

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,86 +419,10 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: "PCT enabled"
-        uses: ./.github/actions/multi-functest
+      - name: "Config Variations"
+        uses: ./.github/actions/config-variations
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-          cflags: "-DMLD_CONFIG_KEYGEN_PCT -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-      - name: "PCT enabled + broken"
-        run: |
-          make clean
-          CFLAGS='-DMLD_CONFIG_FILE=\"../test/break_pct_config.h\"' make func -j4
-          # PCT breakage is done at runtime via MLD_BREAK_PCT
-          make run_func                 # Should be OK
-          MLD_BREAK_PCT=0 make run_func # Should be OK
-          if (MLD_BREAK_PCT=1 make run_func 2>&1 >/dev/null); then
-             echo "PCT failure expected"
-             exit 1
-          else
-             echo "PCT failed as expected"
-          fi
-      - name: "Custom zeroization (explicit_bzero)"
-        uses: ./.github/actions/multi-functest
-        with:
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-          cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_zeroize_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-          examples: false # Some examples use a custom config themselves
-      - name: "No ASM"
-        uses: ./.github/actions/multi-functest
-        with:
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-          cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/no_asm_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-          examples: false # Some examples use a custom config themselves
-      - name: "Custom memcpy"
-        uses: ./.github/actions/multi-functest
-        with:
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-          cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_memcpy_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-          examples: false # Some examples use a custom config themselves
-      - name: "Custom memset"
-        uses: ./.github/actions/multi-functest
-        with:
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-          cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_memset_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-          examples: false # Some examples use a custom config themselves
-      - name: "Custom stdlib (memcpy + memset)"
-        uses: ./.github/actions/multi-functest
-        with:
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-          cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_stdlib_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-          examples: false # Some examples use a custom config themselves
-      - name: "Custom randombytes"
-        uses: ./.github/actions/multi-functest
-        with:
-          cflags: "-std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/custom_randombytes_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-          func: true
-          kat: true
-          acvp: true
-          examples: false # Some examples use a custom config themselves
   check-cf-protections:
     name: Test control-flow protections  (${{ matrix.compiler.name }}, x86_64)
     strategy:

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -55,6 +55,10 @@ on:
       test:
         type: boolean
         default: true
+      config_variations:
+        type: string
+        description: List of configuration variation tests to run (space-separated IDs) or empty for no tests
+        default: ''
       cbmc:
         type: boolean
         default: false
@@ -168,6 +172,13 @@ jobs:
           func: ${{ inputs.functest }}
           kat: ${{ inputs.kattest }}
           acvp: ${{ inputs.acvptest }}
+      - name: Config Variations
+        if: ${{ inputs.config_variations != '' && (success() || failure()) }}
+        uses: ./.github/actions/config-variations
+        with:
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          tests: ${{ inputs.config_variations }}
+          opt: opt
       - name: CBMC
         if: ${{ inputs.cbmc && (success() || failure()) }}
         uses: ./.github/actions/cbmc


### PR DESCRIPTION
- Resolves: #472 
- This commit introduce separate action in ci, called "config-varation" to align with mlkem-native.