### PR TITLE
Proof time stability for polyveck_power2round()

### DIFF
--- a/proofs/cbmc/polyveck_power2round/Makefile
+++ b/proofs/cbmc/polyveck_power2round/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --slice-formula
 
 FUNCTION_NAME = polyveck_power2round
 


### PR DESCRIPTION
Local benchmarking shows that proof times for polyveck_power2round() are unstable on macOS.

On main/HEAD, proof times are follows for MLDSA_MODE=[2,3,5] respectively:
```
Apple M1/macOS: 8s, 14s, 905s
EC2 Grv3/Ubuntu 24.04: 7s, 13s, 11s
```
Addition of the `--slice-formula` option to CBMC makes a noticeable improvement:
```
Apple M1/macOS: 8s, 8s, 9s
EC2 Grv3/Ubuntu 24.04: 9s, 10s, 45s
```
While the slow-down on Grv3 when MLDSA_MODE=5 is not ideal, the improvement on macOS is notable.


