### PR TITLE
Stabilize proof time for polyvecl_pointwise_acc_montgomery()

### DIFF
--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula --no-array-field-sensitivity
+CBMCFLAGS=--smt2 --slice-formula
 
 FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 


### PR DESCRIPTION
Remove --no-array-field-sensitivity to stabilize proof times on all platforms.
