### PR TITLE
Autogen liboqs file list

### DIFF
--- a/integration/liboqs/ML-DSA-44_META.yml
+++ b/integration/liboqs/ML-DSA-44_META.yml
@@ -10,56 +10,70 @@ length-signature: 2420
 nistkat-sha256: 9a196e7fb32fbc93757dc2d8dc1924460eab66303c0c08aeb8b798fb8d8f8cf3
 testvectors-sha256: 5f0d135c0f7fd43f3fb9727265fcd6ec3651eb8c67c04ea5f3d8dfa1d99740d2
 principal-submitters:
-  - Vadim Lyubashevsky
+- Vadim Lyubashevsky
 auxiliary-submitters:
-  - Shi Bai
-  - Léo Ducas
-  - Eike Kiltz
-  - Tancrède Lepoint
-  - Peter Schwabe
-  - Gregor Seiler
-  - Damien Stehlé
+- Shi Bai
+- Léo Ducas
+- Eike Kiltz
+- Tancrède Lepoint
+- Peter Schwabe
+- Gregor Seiler
+- Damien Stehlé
 implementations:
-  - name: ref
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_C_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_C_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-  - name: x86_64
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/native/api.h mldsa/native/meta.h mldsa/native/x86_64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Darwin
-          - Linux
-        required_flags:
-          - avx2
-          - bmi2
-          - popcnt
-  - name: aarch64
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/native/api.h mldsa/native/meta.h mldsa/native/aarch64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-    supported_platforms:
-      - architecture: arm_8
-        operating_systems:
-            - Linux
-            - Darwin
-        required_flags:
-            - asimd
+- name: ref
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_C_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_C_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c
+    mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h
+    mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+- name: x86_64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/native/api.h mldsa/native/meta.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c
+    mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h
+    mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h
+    mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc mldsa/native/x86_64
+  supported_platforms:
+  - architecture: x86_64
+    operating_systems:
+    - Darwin
+    - Linux
+    required_flags:
+    - avx2
+    - bmi2
+    - popcnt
+- name: aarch64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/native/api.h mldsa/native/meta.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c
+    mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h
+    mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h
+    mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc mldsa/native/aarch64
+  supported_platforms:
+  - architecture: arm_8
+    operating_systems:
+    - Linux
+    - Darwin
+    required_flags:
+    - asimd

--- a/integration/liboqs/ML-DSA-65_META.yml
+++ b/integration/liboqs/ML-DSA-65_META.yml
@@ -10,56 +10,70 @@ length-signature: 3309
 nistkat-sha256: 7cb96242eac9907a55b5c84c202f0ebd552419c50b2e986dc2e28f07ecebf072
 testvectors-sha256: 14bf84918ee90e7afbd580191d3eb890d4557e0900b1145e39a8399ef7dd3fba
 principal-submitters:
-  - Vadim Lyubashevsky
+- Vadim Lyubashevsky
 auxiliary-submitters:
-  - Shi Bai
-  - Léo Ducas
-  - Eike Kiltz
-  - Tancrède Lepoint
-  - Peter Schwabe
-  - Gregor Seiler
-  - Damien Stehlé
+- Shi Bai
+- Léo Ducas
+- Eike Kiltz
+- Tancrède Lepoint
+- Peter Schwabe
+- Gregor Seiler
+- Damien Stehlé
 implementations:
-  - name: ref
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_C_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_C_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-  - name: x86_64
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/native/api.h mldsa/native/meta.h mldsa/native/x86_64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Darwin
-          - Linux
-        required_flags:
-          - avx2
-          - bmi2
-          - popcnt
-  - name: aarch64
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/native/api.h mldsa/native/meta.h mldsa/native/aarch64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-    supported_platforms:
-      - architecture: arm_8
-        operating_systems:
-            - Linux
-            - Darwin
-        required_flags:
-            - asimd
+- name: ref
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_C_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_C_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c
+    mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h
+    mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+- name: x86_64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/native/api.h mldsa/native/meta.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c
+    mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h
+    mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h
+    mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc mldsa/native/x86_64
+  supported_platforms:
+  - architecture: x86_64
+    operating_systems:
+    - Darwin
+    - Linux
+    required_flags:
+    - avx2
+    - bmi2
+    - popcnt
+- name: aarch64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/native/api.h mldsa/native/meta.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c
+    mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h
+    mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h
+    mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc mldsa/native/aarch64
+  supported_platforms:
+  - architecture: arm_8
+    operating_systems:
+    - Linux
+    - Darwin
+    required_flags:
+    - asimd

--- a/integration/liboqs/ML-DSA-87_META.yml
+++ b/integration/liboqs/ML-DSA-87_META.yml
@@ -10,55 +10,69 @@ length-signature: 4627
 nistkat-sha256: 4537905d2aabcf302fab2f242baed293459ecda7c230e6a67063b02c7e2840ed
 testvectors-sha256: 759a3ba35210c7e27ff90a7ce5e399295533b82ef125e6ec98af158e00268e44
 principal-submitters:
-  - Vadim Lyubashevsky
+- Vadim Lyubashevsky
 auxiliary-submitters:
-  - Shi Bai
-  - Léo Ducas
-  - Eike Kiltz
-  - Tancrède Lepoint
-  - Peter Schwabe
-  - Gregor Seiler
-  - Damien Stehlé
+- Shi Bai
+- Léo Ducas
+- Eike Kiltz
+- Tancrède Lepoint
+- Peter Schwabe
+- Gregor Seiler
+- Damien Stehlé
 implementations:
-  - name: ref
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_C_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_C_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-  - name: x86_64
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/native/api.h mldsa/native/meta.h mldsa/native/x86_64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Darwin
-          - Linux
-        required_flags:
-          - avx2
-          - popcnt
-  - name: aarch64
-    version: FIPS204
-    folder_name: .
-    compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
-    signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair
-    signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature
-    signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify
-    api-with-context-string: true
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h mldsa/native/api.h mldsa/native/meta.h mldsa/native/aarch64 mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
-    supported_platforms:
-      - architecture: arm_8
-        operating_systems:
-            - Linux
-            - Darwin
-        required_flags:
-            - asimd
+- name: ref
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../integration/liboqs/config_c.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_C_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_C_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/ntt.c mldsa/ntt.h mldsa/packing.c mldsa/packing.h mldsa/params.h mldsa/poly.c
+    mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h mldsa/randombytes.h mldsa/reduce.h
+    mldsa/rounding.h mldsa/sign.c mldsa/sign.h mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc
+- name: x86_64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/native/api.h mldsa/native/meta.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c
+    mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h
+    mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h
+    mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc mldsa/native/x86_64
+  supported_platforms:
+  - architecture: x86_64
+    operating_systems:
+    - Darwin
+    - Linux
+    required_flags:
+    - avx2
+    - popcnt
+- name: aarch64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../integration/liboqs/config_aarch64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify
+  api-with-context-string: true
+  sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    mldsa/cbmc.h mldsa/common.h mldsa/ct.c mldsa/ct.h mldsa/debug.c mldsa/debug.h
+    mldsa/native/api.h mldsa/native/meta.h mldsa/ntt.c mldsa/ntt.h mldsa/packing.c
+    mldsa/packing.h mldsa/params.h mldsa/poly.c mldsa/poly.h mldsa/polyvec.c mldsa/polyvec.h
+    mldsa/randombytes.h mldsa/reduce.h mldsa/rounding.h mldsa/sign.c mldsa/sign.h
+    mldsa/symmetric.h mldsa/sys.h mldsa/zetas.inc mldsa/native/aarch64
+  supported_platforms:
+  - architecture: arm_8
+    operating_systems:
+    - Linux
+    - Darwin
+    required_flags:
+    - asimd

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -83,6 +83,12 @@ def gen_header():
     yield ""
 
 
+def gen_yaml_header():
+    yield "# Copyright (c) The mldsa-native project authors"
+    yield "# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT"
+    yield ""
+
+
 def get_files(pattern):
     return [str(p) for p in pathlib.Path().glob(pattern) if p.is_file()]
 
@@ -997,6 +1003,96 @@ def gen_avx2_zeta_file(dry_run=False):
     )
 
 
+def get_oqs_shared_sources(backend):
+    """Get shared source files for OQS integration"""
+    mldsa_dir = "mldsa"
+
+    # add files mldsa/*
+    sources = [
+        f"mldsa/{f}"
+        for f in os.listdir(mldsa_dir)
+        if os.path.isfile(f"{mldsa_dir}/{f}") and not f.endswith(".o")
+    ]
+
+    if backend != "ref":
+        # add files mldsa/native/* (API definitions)
+        sources += [
+            f"mldsa/native/{f}"
+            for f in os.listdir(f"{mldsa_dir}/native")
+            if os.path.isfile(f"{mldsa_dir}/native/{f}")
+        ]
+    # We use a custom config
+    sources.remove("mldsa/config.h")
+    # Add FIPS202 glue code
+    sources += [
+        "integration/liboqs/fips202_glue.h",
+        "integration/liboqs/fips202x4_glue.h",
+    ]
+    # Add custom config
+    if backend == "ref":
+        backend = "c"
+    sources.append(f"integration/liboqs/config_{backend.lower()}.h")
+
+    return sources
+
+
+def get_oqs_native_sources(backend):
+    """Get native source files for OQS integration"""
+    return [f"mldsa/native/{backend}"]
+
+
+def gen_oqs_meta_file(filename, dry_run=False):
+    """Generate OQS META.yml file with updated source lists"""
+    status_update("OQS META", filename)
+
+    with open(filename, "r") as f:
+        content = f.read()
+
+    # Parse YAML while preserving structure
+    yml_data = yaml.safe_load(content)
+
+    for impl in yml_data["implementations"]:
+        name = impl["name"]
+
+        sources = get_oqs_shared_sources(name)
+
+        # NOTE: Sorting at the end causes the libOQS importer to fail.
+        # Somehow, the native directory cannot be imported too early.
+        sources.sort()
+
+        if name != "ref":
+            sources += get_oqs_native_sources(name)
+        impl["sources"] = " ".join(sources)
+
+    # Convert back to YAML string with standard copyright header
+    yaml_header = "\n".join(gen_yaml_header())
+
+    new_content = yaml.dump(
+        yml_data,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        encoding=None,
+    )
+
+    # Combine copyright header with new YAML content
+    new_content = yaml_header + new_content
+
+    update_file(filename, new_content, dry_run=dry_run)
+
+
+def gen_oqs_meta_files(dry_run=False):
+    """Generate all OQS META.yml files"""
+    meta_files = [
+        "integration/liboqs/ML-DSA-44_META.yml",
+        "integration/liboqs/ML-DSA-65_META.yml",
+        "integration/liboqs/ML-DSA-87_META.yml",
+    ]
+
+    for meta_file in meta_files:
+        gen_oqs_meta_file(meta_file, dry_run=dry_run)
+
+
 def adjust_header_guard_for_filename(content, header_file):
 
     status_update("header guards", header_file)
@@ -1384,7 +1480,8 @@ def _main():
 
     gen_citations(args.dry_run)
     high_level_status("Generated citations")
-
+    gen_oqs_meta_files(args.dry_run)
+    high_level_status("Generated OQS META.yml files")
     gen_c_zeta_file(args.dry_run)
     gen_aarch64_zeta_file(args.dry_run)
     gen_aarch64_rej_uniform_table(args.dry_run)


### PR DESCRIPTION
- Resolves: #517 
- This PR port the OQS source list automatically updating feature from `mlkem-native` to `mldsa-native`,
- The reference code in `mlkem-native`: https://github.com/pq-code-package/mlkem-native/blob/9ae2223e835c1abcc8d6857dd3b7f8ce00a05216/scripts/autogen#L2625
- After porting, run the `autogen` again, add the additional source for each implementations(align with `mlkem-native`) in `ML-DSA-*_META.yml`.