### PR TITLE
Fix autogen script

### DIFF
--- a/scripts/autogen
+++ b/scripts/autogen
@@ -459,6 +459,7 @@ def update_file(
     force_format=False,
     skip_preprocessor_comments=False,
 ):
+
     if force_format is True or filename.endswith((".c", ".h", ".i")):
         if skip_preprocessor_comments is False:
             content = adjust_preprocessor_comments_for_filename(content, filename)


### PR DESCRIPTION
- This PR fixes the `autogen` script by aligning the behavior of `update_file` between `mldsa-native` and `mlkem-native`.
- During PR #517 , I noticed that the current script keeps calling `file_updated(filename)` even when the file has not actually changed. 
This causes the terminal keep showing:
```
MacBookPro:mldsa-native willieyz$ autogen
 updated mldsa/zetas.inc
 updated mldsa/native/aarch64/src/aarch64_zetas.c
 updated mldsa/native/aarch64/src/rej_uniform_table.c
 updated mldsa/native/aarch64/src/rej_uniform_eta_table.c
 updated mldsa/native/x86_64/src/x86_64_zetas.i
 updated mldsa/native/x86_64/src/rej_uniform_table.c
 ✓ Generated zeta and lookup tables
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           updated mldsa/debug.h
 updated mldsa/randombytes.h
 updated mldsa/params.h
```
Even there is no any changed actually been apply.
- I reference from the following commit in https://github.com/pq-code-package/mlkem-native/pull/976, to solve this problem:
  - Commit SHA: 4b8875033917c18164d5889c3452eed5020f6e9e 