### PR TITLE
Use COUNTER instead of LINE for quantified variables

### DIFF
--- a/mldsa/cbmc.h
+++ b/mldsa/cbmc.h
@@ -126,7 +126,7 @@
   }
 
 #define array_bound(array_var, qvar_lb, qvar_ub, value_lb, value_ub) \
-  array_bound_core(CBMC_CONCAT(_cbmc_idx, __LINE__), (qvar_lb),      \
+  array_bound_core(CBMC_CONCAT(_cbmc_idx, __COUNTER__), (qvar_lb),      \
       (qvar_ub), (array_var), (value_lb), (value_ub))
 /* clang-format on */
 


### PR DESCRIPTION
Use COUNTER instead of LINE when creating names of quantified variables. This improves proof stability, since minor changes (such as adding a single blank line) do not affect naming of such variables.

Proof times for all proofs for MLDSA_MODE=2,3,5 respectively:

macOS (8 cores): 8m20s, 10m6s, 9m23s
Grv3/Ubuntu (64 cores): 3m4s, 6m14s, 5m29s
