### PR TITLE
Switch mac (x86_64) github runner from `macos-13` to `macos-15-intel`

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -42,7 +42,7 @@ jobs:
            name: 'x86_64'
          - runner: macos-latest
            name: 'macos (aarch64)'
-         - runner: macos-13
+         - runner: macos-15-intel
            name: 'macos (x86_64)'
         exclude:
           - {external: true,
@@ -103,7 +103,7 @@ jobs:
            name: 'x86_64'
          - runner: macos-latest
            name: 'macos (aarch64)'
-         - runner: macos-13
+         - runner: macos-15-intel
            name: 'macos (x86_64)'
         exclude:
           - {external: true,
@@ -211,7 +211,7 @@ jobs:
     name: Quickcheck lib
     strategy:
       matrix:
-        system: [macos-latest, macos-13, ubuntu-latest, pqcp-arm64]
+        system: [macos-latest, macos-15-intel, ubuntu-latest, pqcp-arm64]
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
            arch: mac
            mode: native
            nix_shell: ci
-         - runner: macos-13
+         - runner: macos-15-intel
            name: 'MacOS (x86_64)'
            arch: mac
            mode: native


### PR DESCRIPTION
- Related: https://github.com/pq-code-package/mlkem-native/issues/1213
- This PR switch the macos (x86_64) runners from macos-13 to macos-15-intel, due to the macos-13 runners will not be
- supported anymore from December 3, 2025, check the following link:
- https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/