### PR TITLE
[TEST] CBMC: Remove CBMC_OBJECT_BITS from all proof Makefiles and default to 12

### DIFF
--- a/proofs/cbmc/H/Makefile
+++ b/proofs/cbmc/H/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_h
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -356,7 +356,7 @@ DEFINES ?=
 # object size to be CBMC_MAX_OBJECT_SIZE.  You are likely to get
 # unexpected results if you try to malloc an object larger than this
 # bound.
-CBMC_OBJECT_BITS ?= 8
+CBMC_OBJECT_BITS ?= 12
 
 # CBMC loop unwinding (Normally set in the proof Makefile)
 #

--- a/proofs/cbmc/attempt_signature_generation/Makefile
+++ b/proofs/cbmc/attempt_signature_generation/Makefile
@@ -62,9 +62,6 @@ FUNCTION_NAME = mld_attempt_signature_generation
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 12
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/caddq/Makefile
+++ b/proofs/cbmc/caddq/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = caddq
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/check_pct/Makefile
+++ b/proofs/cbmc/check_pct/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_check_pct
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/sign.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign/Makefile
+++ b/proofs/cbmc/crypto_sign/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = crypto_sign
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_keypair/Makefile
+++ b/proofs/cbmc/crypto_sign_keypair/Makefile
@@ -40,9 +40,6 @@ FUNCTION_NAME = crypto_sign_keypair
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_keypair_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_keypair_internal/Makefile
@@ -51,9 +51,6 @@ FUNCTION_NAME = crypto_sign_keypair_internal
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_open/Makefile
+++ b/proofs/cbmc/crypto_sign_open/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = crypto_sign_open
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_signature/Makefile
+++ b/proofs/cbmc/crypto_sign_signature/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = crypto_sign_signature
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_signature_extmu/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_extmu/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = crypto_sign_signature_extmu
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_signature_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_internal/Makefile
@@ -45,9 +45,6 @@ FUNCTION_NAME = crypto_sign_signature_internal
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_signature_pre_hash_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_pre_hash_internal/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = crypto_sign_signature_pre_hash_internal
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_signature_pre_hash_shake256/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_pre_hash_shake256/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = crypto_sign_signature_pre_hash_shake256
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_verify/Makefile
+++ b/proofs/cbmc/crypto_sign_verify/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = crypto_sign_verify
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_verify_extmu/Makefile
+++ b/proofs/cbmc/crypto_sign_verify_extmu/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = crypto_sign_verify_extmu
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_verify_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_verify_internal/Makefile
@@ -56,9 +56,6 @@ FUNCTION_NAME = crypto_sign_verify_internal
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_verify_pre_hash_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_verify_pre_hash_internal/Makefile
@@ -47,9 +47,6 @@ FUNCTION_NAME = crypto_sign_verify_pre_hash_internal
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/crypto_sign_verify_pre_hash_shake256/Makefile
+++ b/proofs/cbmc/crypto_sign_verify_pre_hash_shake256/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = crypto_sign_verify_pre_hash_shake256
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ct_abs_i32/Makefile
+++ b/proofs/cbmc/ct_abs_i32/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ct_abs_i32
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ct_cmask_neg_i32/Makefile
+++ b/proofs/cbmc/ct_cmask_neg_i32/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ct_cmask_neg_i32
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ct_get_optblocker_i64/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_i64/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ct_get_optblocker_i64
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ct_get_optblocker_u32/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_u32/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ct_get_optblocker_u32
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ct_sel_int32/Makefile
+++ b/proofs/cbmc/ct_sel_int32/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ct_sel_int32
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/decompose/Makefile
+++ b/proofs/cbmc/decompose/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = decompose
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/fqmul/Makefile
+++ b/proofs/cbmc/fqmul/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_fqmul
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/fqscale/Makefile
+++ b/proofs/cbmc/fqscale/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_fqscale
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_invntt_layer
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/invntt_tomont/Makefile
+++ b/proofs/cbmc/invntt_tomont/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = invntt_tomont
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccak_absorb/Makefile
+++ b/proofs/cbmc/keccak_absorb/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = keccak_absorb
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccak_absorb_once_x4/Makefile
+++ b/proofs/cbmc/keccak_absorb_once_x4/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_keccak_absorb_once_x4
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccak_finalize/Makefile
+++ b/proofs/cbmc/keccak_finalize/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = keccak_finalize
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccak_init/Makefile
+++ b/proofs/cbmc/keccak_init/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = keccak_init
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccak_squeeze/Makefile
+++ b/proofs/cbmc/keccak_squeeze/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = keccak_squeeze
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
@@ -48,9 +48,6 @@ FUNCTION_NAME = mld_keccak_squeezeblocks_x4
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_keccakf1600_extract_bytes
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_keccakf1600_extract_bytes
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600_permute/Makefile
+++ b/proofs/cbmc/keccakf1600_permute/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_keccakf1600_permute
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600_xor_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_xor_bytes/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_keccakf1600_xor_bytes
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600_xor_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_xor_bytes_BE/Makefile
@@ -39,9 +39,6 @@ FUNCTION_NAME = mld_keccakf1600_xor_bytes
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600x4_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600x4_extract_bytes/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_keccakf1600x4_extract_bytes
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600x4_permute/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute/Makefile
@@ -48,9 +48,6 @@ FUNCTION_NAME = mld_keccakf1600x4_permute
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/keccakf1600x4_xor_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600x4_xor_bytes/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_keccakf1600x4_xor_bytes
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/make_hint/Makefile
+++ b/proofs/cbmc/make_hint/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = make_hint
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/montgomery_reduce/Makefile
+++ b/proofs/cbmc/montgomery_reduce/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = montgomery_reduce
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ntt/Makefile
+++ b/proofs/cbmc/ntt/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = ntt
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ntt_butterfly_block/Makefile
+++ b/proofs/cbmc/ntt_butterfly_block/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ntt_butterfly_block
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/ntt_layer/Makefile
+++ b/proofs/cbmc/ntt_layer/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_ntt_layer
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/pack_pk/Makefile
+++ b/proofs/cbmc/pack_pk/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = pack_pk
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/pack_sig/Makefile
+++ b/proofs/cbmc/pack_sig/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = pack_sig
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/pack_sk/Makefile
+++ b/proofs/cbmc/pack_sk/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = pack_sk
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_add/Makefile
+++ b/proofs/cbmc/poly_add/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_add
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_caddq/Makefile
+++ b/proofs/cbmc/poly_caddq/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_caddq
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_challenge/Makefile
+++ b/proofs/cbmc/poly_challenge/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = poly_challenge
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_chknorm/Makefile
+++ b/proofs/cbmc/poly_chknorm/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_chknorm
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_decompose/Makefile
+++ b/proofs/cbmc/poly_decompose/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_decompose
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_invntt_tomont/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_invntt_tomont
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_make_hint/Makefile
+++ b/proofs/cbmc/poly_make_hint/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_make_hint
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_ntt/Makefile
+++ b/proofs/cbmc/poly_ntt/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_ntt
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_pointwise_montgomery/Makefile
+++ b/proofs/cbmc/poly_pointwise_montgomery/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_pointwise_montgomery
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_power2round/Makefile
+++ b/proofs/cbmc/poly_power2round/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_power2round
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_reduce/Makefile
+++ b/proofs/cbmc/poly_reduce/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_reduce
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_shiftl/Makefile
+++ b/proofs/cbmc/poly_shiftl/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_shiftl
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_sub/Makefile
+++ b/proofs/cbmc/poly_sub/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_sub
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_uniform/Makefile
+++ b/proofs/cbmc/poly_uniform/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = poly_uniform
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_uniform_4x/Makefile
+++ b/proofs/cbmc/poly_uniform_4x/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = poly_uniform_4x
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_uniform_eta_4x/Makefile
+++ b/proofs/cbmc/poly_uniform_eta_4x/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = poly_uniform_eta_4x
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_uniform_gamma1/Makefile
+++ b/proofs/cbmc/poly_uniform_gamma1/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = poly_uniform_gamma1
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_uniform_gamma1_4x/Makefile
+++ b/proofs/cbmc/poly_uniform_gamma1_4x/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = poly_uniform_gamma1_4x
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/poly_use_hint/Makefile
+++ b/proofs/cbmc/poly_use_hint/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = poly_use_hint
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyeta_pack/Makefile
+++ b/proofs/cbmc/polyeta_pack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyeta_pack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyeta_unpack/Makefile
+++ b/proofs/cbmc/polyeta_unpack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyeta_unpack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyt0_pack/Makefile
+++ b/proofs/cbmc/polyt0_pack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyt0_pack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyt0_unpack/Makefile
+++ b/proofs/cbmc/polyt0_unpack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyt0_unpack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyt1_pack/Makefile
+++ b/proofs/cbmc/polyt1_pack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyt1_pack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyt1_unpack/Makefile
+++ b/proofs/cbmc/polyt1_unpack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyt1_unpack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvec_matrix_expand/Makefile
+++ b/proofs/cbmc/polyvec_matrix_expand/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvec_matrix_expand
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 11
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvec_matrix_pointwise_montgomery/Makefile
+++ b/proofs/cbmc/polyvec_matrix_pointwise_montgomery/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvec_matrix_pointwise_montgomery
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_add/Makefile
+++ b/proofs/cbmc/polyveck_add/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_add
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_caddq/Makefile
+++ b/proofs/cbmc/polyveck_caddq/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_caddq
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_chknorm/Makefile
+++ b/proofs/cbmc/polyveck_chknorm/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = polyveck_chknorm
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_decompose/Makefile
+++ b/proofs/cbmc/polyveck_decompose/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = polyveck_decompose
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_invntt_tomont/Makefile
+++ b/proofs/cbmc/polyveck_invntt_tomont/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_invntt_tomont
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_make_hint/Makefile
+++ b/proofs/cbmc/polyveck_make_hint/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_make_hint
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_ntt/Makefile
+++ b/proofs/cbmc/polyveck_ntt/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_ntt
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_pack_eta/Makefile
+++ b/proofs/cbmc/polyveck_pack_eta/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_pack_eta
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_pack_t0/Makefile
+++ b/proofs/cbmc/polyveck_pack_t0/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = polyveck_pack_t0
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_pack_w1/Makefile
+++ b/proofs/cbmc/polyveck_pack_w1/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_pack_w1
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_pointwise_poly_montgomery/Makefile
+++ b/proofs/cbmc/polyveck_pointwise_poly_montgomery/Makefile
@@ -35,9 +35,6 @@ FUNCTION_NAME = polyveck_pointwise_poly_montgomery
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_power2round/Makefile
+++ b/proofs/cbmc/polyveck_power2round/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_power2round
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 10
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_reduce/Makefile
+++ b/proofs/cbmc/polyveck_reduce/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_reduce
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_shiftl/Makefile
+++ b/proofs/cbmc/polyveck_shiftl/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_shiftl
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_sub/Makefile
+++ b/proofs/cbmc/polyveck_sub/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_sub
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_unpack_eta/Makefile
+++ b/proofs/cbmc/polyveck_unpack_eta/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_unpack_eta
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_unpack_t0/Makefile
+++ b/proofs/cbmc/polyveck_unpack_t0/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_unpack_t0
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyveck_use_hint/Makefile
+++ b/proofs/cbmc/polyveck_use_hint/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyveck_use_hint
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_add/Makefile
+++ b/proofs/cbmc/polyvecl_add/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_add
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_chknorm/Makefile
+++ b/proofs/cbmc/polyvecl_chknorm/Makefile
@@ -38,9 +38,6 @@ FUNCTION_NAME = polyvecl_chknorm
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 12
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_invntt_tomont/Makefile
+++ b/proofs/cbmc/polyvecl_invntt_tomont/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_invntt_tomont
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_ntt/Makefile
+++ b/proofs/cbmc/polyvecl_ntt/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_ntt
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_pack_eta/Makefile
+++ b/proofs/cbmc/polyvecl_pack_eta/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_pack_eta
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_pack_z/Makefile
+++ b/proofs/cbmc/polyvecl_pack_z/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_pack_z
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 12
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_pointwise_poly_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_poly_montgomery/Makefile
@@ -35,9 +35,6 @@ FUNCTION_NAME = polyvecl_pointwise_poly_montgomery
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_reduce/Makefile
+++ b/proofs/cbmc/polyvecl_reduce/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_reduce
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_uniform_gamma1/Makefile
+++ b/proofs/cbmc/polyvecl_uniform_gamma1/Makefile
@@ -40,9 +40,6 @@ FUNCTION_NAME = polyvecl_uniform_gamma1
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_unpack_eta/Makefile
+++ b/proofs/cbmc/polyvecl_unpack_eta/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_unpack_eta
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvecl_unpack_z/Makefile
+++ b/proofs/cbmc/polyvecl_unpack_z/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyvecl_unpack_z
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyw1_pack/Makefile
+++ b/proofs/cbmc/polyw1_pack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyw1_pack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyz_pack/Makefile
+++ b/proofs/cbmc/polyz_pack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyz_pack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyz_unpack/Makefile
+++ b/proofs/cbmc/polyz_unpack/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = polyz_unpack
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/power2round/Makefile
+++ b/proofs/cbmc/power2round/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = power2round
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/reduce32/Makefile
+++ b/proofs/cbmc/reduce32/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = reduce32
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/rej_eta/Makefile
+++ b/proofs/cbmc/rej_eta/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_rej_eta
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/rej_uniform/Makefile
+++ b/proofs/cbmc/rej_uniform/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_rej_uniform
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/sample_s1_s2/Makefile
+++ b/proofs/cbmc/sample_s1_s2/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_sample_s1_s2
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128_absorb/Makefile
+++ b/proofs/cbmc/shake128_absorb/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake128_absorb
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128_finalize/Makefile
+++ b/proofs/cbmc/shake128_finalize/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake128_finalize
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128_init/Makefile
+++ b/proofs/cbmc/shake128_init/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake128_init
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128_release/Makefile
+++ b/proofs/cbmc/shake128_release/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake128_release
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128_squeeze/Makefile
+++ b/proofs/cbmc/shake128_squeeze/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake128_squeeze
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128x4_absorb_once/Makefile
+++ b/proofs/cbmc/shake128x4_absorb_once/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_shake128x4_absorb_once
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake128x4_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake128x4_squeezeblocks/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_shake128x4_squeezeblocks
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256/Makefile
+++ b/proofs/cbmc/shake256/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake256
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256_absorb/Makefile
+++ b/proofs/cbmc/shake256_absorb/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake256_absorb
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256_finalize/Makefile
+++ b/proofs/cbmc/shake256_finalize/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake256_finalize
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256_init/Makefile
+++ b/proofs/cbmc/shake256_init/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake256_init
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256_release/Makefile
+++ b/proofs/cbmc/shake256_release/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake256_release
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256_squeeze/Makefile
+++ b/proofs/cbmc/shake256_squeeze/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = shake256_squeeze
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256x4_absorb_once/Makefile
+++ b/proofs/cbmc/shake256x4_absorb_once/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_shake256x4_absorb_once
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/shake256x4_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake256x4_squeezeblocks/Makefile
@@ -37,9 +37,6 @@ FUNCTION_NAME = mld_shake256x4_squeezeblocks
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/unpack_hints/Makefile
+++ b/proofs/cbmc/unpack_hints/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_unpack_hints
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/unpack_pk/Makefile
+++ b/proofs/cbmc/unpack_pk/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = unpack_pk
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/unpack_sig/Makefile
+++ b/proofs/cbmc/unpack_sig/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = unpack_sig
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/unpack_sk/Makefile
+++ b/proofs/cbmc/unpack_sk/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = unpack_sk
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 9
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/use_hint/Makefile
+++ b/proofs/cbmc/use_hint/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = use_hint
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/value_barrier_i64/Makefile
+++ b/proofs/cbmc/value_barrier_i64/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_value_barrier_i64
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/value_barrier_u32/Makefile
+++ b/proofs/cbmc/value_barrier_u32/Makefile
@@ -36,9 +36,6 @@ FUNCTION_NAME = mld_value_barrier_u32
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
-# This function is large enough to need...
-CBMC_OBJECT_BITS = 8
-
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mldsa/poly.c") in PROJECT_SOURCES).


### PR DESCRIPTION
I'm tired of constantly debugging CBMC proofs just to find out that some unrelated proof ran out of addressing space and needs the OBJECT_BITS to be bumped from 8 to 10.
This commit changes the default to 12, which is the largest value that we are currently using, and removes the CBMC_OBJECT_BITS from the individual Makefiles.