### PR TITLE
Test: Autogenerate test configurations

### DIFF
--- a/mldsa/config.h
+++ b/mldsa/config.h
@@ -103,7 +103,7 @@
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -69,17 +69,21 @@ def file_updated(filename):
     print(f"\r{BOLD}updated {filename}{NORMAL}")
 
 
-def gen_header():
-    yield "/*"
-    yield " * Copyright (c) The mldsa-native project authors"
-    yield " * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT"
-    yield " */"
+def gen_autogen_warning():
     yield ""
     yield "/*"
     yield " * WARNING: This file is auto-generated from scripts/autogen"
     yield " *          in the mldsa-native repository."
     yield " *          Do not modify it directly."
     yield " */"
+
+
+def gen_header():
+    yield "/*"
+    yield " * Copyright (c) The mldsa-native project authors"
+    yield " * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT"
+    yield " */"
+    yield from gen_autogen_warning()
     yield ""
 
 
@@ -465,6 +469,7 @@ def update_file(
     force_format=False,
     skip_preprocessor_comments=False,
 ):
+
     if force_format is True or filename.endswith((".c", ".h", ".i")):
         if skip_preprocessor_comments is False:
             content = adjust_preprocessor_comments_for_filename(content, filename)
@@ -1713,6 +1718,140 @@ def gen_citations(dry_run=False):
     gen_bib_file(bibliography, dry_run=dry_run)
 
 
+def gen_test_config(config_path, config_spec, default_config_content, dry_run=False):
+    """Generate a config file by modifying the default config."""
+    status_update("test configs", config_path)
+
+    # Start with the default config
+    lines = default_config_content.split("\n")
+
+    # Find copyright and reference header
+    references_start = None
+    references_end = None
+
+    # NOTE: This needs further work if any custom config contains citations
+    # not included in the default configuration. In this case, the reference
+    # section needs to be updated.
+
+    for i, line in enumerate(lines):
+        if "/* References" in line:
+            references_start = i
+        elif (
+            references_start is not None
+            and references_end is None
+            and line.strip() == "*/"
+        ):
+            references_end = i + 1
+            break
+
+    header = lines[:references_end]
+    header += list(gen_autogen_warning())
+
+    header.append("")
+    header.append("/*")
+    header.append(f" * Test configuration: {config_spec['description']}")
+    header.append(" *")
+    header.append(
+        " * This configuration differs from the default mldsa/src/config.h in the following places:"
+    )
+
+    def spec_has_value(opt_value):
+        if not isinstance(opt_value, dict):
+            return True
+        else:
+            return "value" in opt_value.keys() or "content" in opt_value.keys()
+
+    for opt_name, opt_value in config_spec["defines"].items():
+        if not spec_has_value(opt_value):
+            continue
+        header.append(f" *   - {opt_name}")
+    header.append(" */")
+    header.append("")
+
+    # Combine: new header + config body
+    lines = header + lines[references_end:]
+
+    def locate_config_option(lines, opt_name):
+        """Locate configuration option in lines. Returns (start, end) line indices"""
+        i = 0
+        while i < len(lines):
+            if re.search(rf"\* Name:\s+{re.escape(opt_name)}\b", lines[i]):
+                # Skip to the end of this comment block (find the closing */)
+                while i < len(lines) and not lines[i].strip().endswith("*/"):
+                    i += 1
+                i += 1  # Skip the closing */
+
+                start = i
+                # Find the next config option (starts with /*****)
+                while i < len(lines):
+                    if lines[i].strip().startswith("/****"):
+                        # Back up to exclude empty line before next option
+                        while i > start and lines[i - 1].strip() == "":
+                            i -= 1
+                        return (start, i)
+                    i += 1
+                # If no next option found, go to end
+                return (start, len(lines))
+            i += 1
+        raise Exception(f"Could not find config option {opt_name} in default config")
+
+    def replace_config_option(lines, opt_name, opt_value):
+        """Replace config option with new value"""
+        block_start, block_end = locate_config_option(lines, opt_name)
+
+        def content_from_value(value):
+            if value is True:
+                return [f"#define {opt_name}"]
+            elif value is False:
+                return [f"/* #define {opt_name} */"]
+            else:
+                return [f"#define {opt_name} {str(value)}"]
+
+        if isinstance(opt_value, dict):
+            if "content" in opt_value:
+                content = opt_value.get("content").split("\n")
+            elif "value" in opt_value:
+                content = content_from_value(opt_value["value"])
+            else:
+                # Use original content
+                content = lines[block_start:block_end]
+            if "comment" in opt_value:
+                comment = opt_value.get("comment").split("\n")
+            else:
+                comment = []
+        else:
+            content = content_from_value(opt_value)
+            comment = []
+
+        lines[block_start:block_end] = comment + content
+
+    # Apply modifications for each defined option
+    for opt_name, opt_value in config_spec["defines"].items():
+        replace_config_option(lines, opt_name, opt_value)
+
+    content = "\n".join(lines)
+    update_file(
+        config_path,
+        content,
+        dry_run=dry_run,
+    )
+
+
+def gen_test_configs(dry_run=False):
+    """Generate all test configuration files from metadata."""
+    # Load metadata
+    with open("test/configs.yml", "r") as f:
+        metadata = yaml.safe_load(f)
+
+    # Load default config
+    with open("mldsa/config.h", "r") as f:
+        default_config = f.read()
+
+    # Generate each test config
+    for config_spec in metadata["configs"]:
+        gen_test_config(config_spec["path"], config_spec, default_config, dry_run)
+
+
 def _main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -1759,6 +1898,8 @@ def _main():
         no_simplify=args.no_simplify,
     )
     high_level_status("Completed final backend synchronization")
+    gen_test_configs(args.dry_run)
+    high_level_status("Generated test configs")
 
 
 if __name__ == "__main__":

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -17,6 +17,22 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration for PCT breakage testing
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_KEYGEN_PCT
+ *   - MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -103,7 +119,7 @@
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient
@@ -153,7 +169,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -189,9 +204,9 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
- *.             function calls.
+ *              function calls.
  *
  *              Set this option and define `mld_zeroize_native` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
@@ -221,6 +236,78 @@
    #include <stdint.h>
    #include "sys.h"
    static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMCPY
+ *
+ * Description: Set this option and define `mld_memcpy` if you want to
+ *              use a custom method to copy memory instead of the standard
+ *              library memcpy function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memcpy function:
+ *              void *mld_memcpy(void *dest, const void *src, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMCPY
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMSET
+ *
+ * Description: Set this option and define `mld_memset` if you want to
+ *              use a custom method to set memory instead of the standard
+ *              library memset function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memset function:
+ *              void *mld_memset(void *s, int c, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMSET
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
    {
        ... your implementation ...
    }
@@ -266,8 +353,47 @@ static MLD_INLINE int mld_break_pct(void)
   const char *val = getenv("MLD_BREAK_PCT");
   return val != NULL && strcmp(val, "1") == 0;
 }
-#endif
+#endif /* !__ASSEMBLER__ */
 
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_EXTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of mldsa-native's
+ *              public API.
+ *
+ *              The primary use case for this option are single-CU builds
+ *              where the public API exposed by mldsa-native is wrapped by
+ *              another API in the consuming application. In this case,
+ *              even mldsa-native's public API can be marked `static`.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CT_TESTING_ENABLED
+ *
+ * Description: If set, mldsa-native annotates data as secret / public using
+ *              valgrind's annotations VALGRIND_MAKE_MEM_UNDEFINED and
+ *              VALGRIND_MAKE_MEM_DEFINED, enabling various checks for secret-
+ *              dependent control flow of variable time execution (depending
+ *              on the exact version of valgrind installed).
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CT_TESTING_ENABLED */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_NO_ASM
@@ -306,6 +432,8 @@ static MLD_INLINE int mld_break_pct(void)
  *****************************************************************************/
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
+
+
 /*************************  Config internals  ********************************/
 
 /* Default namespace
@@ -317,7 +445,7 @@ static MLD_INLINE int mld_break_pct(void)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44

--- a/test/configs.yml
+++ b/test/configs.yml
@@ -1,0 +1,165 @@
+# Copyright (c) The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# Metadata for test configuration files
+# Each entry describes how a test config differs from mldsa/config.h
+
+configs:
+  - path: test/no_asm_config.h
+    description: "Test configuration with no assembly code"
+    defines:
+      MLD_CONFIG_NO_ASM: true
+      MLD_CONFIG_CUSTOM_ZEROIZE:
+        content: |
+          #define MLD_CONFIG_CUSTOM_ZEROIZE
+          #if !defined(__ASSEMBLER__)
+          #include <stdint.h>
+          #include <string.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+          {
+            explicit_bzero(ptr, len);
+          }
+          #endif
+
+  - path: test/custom_randombytes_config.h
+    description: "Test configuration with custom randombytes"
+    defines:
+      MLD_CONFIG_CUSTOM_RANDOMBYTES:
+        content: |
+          #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+          #if !defined(__ASSEMBLER__)
+          #include <stdint.h>
+          #include "../mldsa/sys.h"
+          #include "notrandombytes/notrandombytes.h"
+          static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+          {
+            randombytes(ptr, len);
+          }
+          #endif /* !__ASSEMBLER__ */
+
+  - path: test/custom_zeroize_config.h
+    description: "Test configuration with custom zeroize"
+    defines:
+      MLD_CONFIG_CUSTOM_ZEROIZE:
+        content: |
+          #define MLD_CONFIG_CUSTOM_ZEROIZE
+          #if !defined(__ASSEMBLER__)
+          #include <stdint.h>
+          #include <string.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+          {
+            explicit_bzero(ptr, len);
+          }
+          #endif
+
+  - path: test/custom_memcpy_config.h
+    description: "Test configuration with custom memcpy"
+    defines:
+      MLD_CONFIG_CUSTOM_MEMCPY:
+        content: |
+          #define MLD_CONFIG_CUSTOM_MEMCPY
+          #if !defined(__ASSEMBLER__)
+          #include <stddef.h>
+          #include <stdint.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
+          {
+            /* Simple byte-by-byte copy implementation for testing */
+            unsigned char *d = (unsigned char *)dest;
+            const unsigned char *s = (const unsigned char *)src;
+            for (size_t i = 0; i < n; i++)
+            {
+              d[i] = s[i];
+            }
+            return dest;
+          }
+          #endif /* !__ASSEMBLER__ */
+
+  - path: test/custom_memset_config.h
+    description: "Test configuration with custom memset"
+    defines:
+      MLD_CONFIG_CUSTOM_MEMSET:
+        content: |
+          #define MLD_CONFIG_CUSTOM_MEMSET
+          #if !defined(__ASSEMBLER__)
+          #include <stddef.h>
+          #include <stdint.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
+          {
+            /* Simple byte-by-byte set implementation for testing */
+            unsigned char *ptr = (unsigned char *)s;
+            for (size_t i = 0; i < n; i++)
+            {
+              ptr[i] = (unsigned char)c;
+            }
+            return s;
+          }
+          #endif
+
+  - path: test/custom_stdlib_config.h
+    description: "Test configuration with custom stdlib functions"
+    defines:
+      MLD_CONFIG_CUSTOM_MEMCPY:
+        content: |
+          #define MLD_CONFIG_CUSTOM_MEMCPY
+          #if !defined(__ASSEMBLER__)
+          #include <stddef.h>
+          #include <stdint.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
+          {
+            /* Simple byte-by-byte copy implementation for testing */
+            unsigned char *d = (unsigned char *)dest;
+            const unsigned char *s = (const unsigned char *)src;
+            for (size_t i = 0; i < n; i++)
+            {
+              d[i] = s[i];
+            }
+            return dest;
+          }
+          #endif /* !__ASSEMBLER__ */
+      MLD_CONFIG_CUSTOM_MEMSET:
+        content: |
+          #define MLD_CONFIG_CUSTOM_MEMSET
+          #if !defined(__ASSEMBLER__)
+          #include <stddef.h>
+          #include <stdint.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
+          {
+            /* Simple byte-by-byte set implementation for testing */
+            unsigned char *ptr = (unsigned char *)s;
+            for (size_t i = 0; i < n; i++)
+            {
+              ptr[i] = (unsigned char)c;
+            }
+            return s;
+          }
+          #endif
+
+  - path: test/break_pct_config.h
+    description: "Test configuration for PCT breakage testing"
+    defines:
+      MLD_CONFIG_KEYGEN_PCT: true
+      MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST:
+        content: |
+          #define MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+          #if !defined(__ASSEMBLER__)
+          #include <stdlib.h>
+          #include <string.h>
+          #include "../mldsa/sys.h"
+          static MLD_INLINE int mld_break_pct(void)
+          {
+            /* Break PCT if and only if MLD_BREAK_PCT is set to 1 */
+            const char *val = getenv("MLD_BREAK_PCT");
+            return val != NULL && strcmp(val, "1") == 0;
+          }
+          #endif
+
+
+  # Example configs
+

--- a/test/custom_memcpy_config.h
+++ b/test/custom_memcpy_config.h
@@ -17,6 +17,21 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration with custom memcpy
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_CUSTOM_MEMCPY
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -103,7 +118,7 @@
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient
@@ -153,7 +168,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -189,7 +203,7 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
@@ -282,6 +296,32 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
 */
 
 /******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
  * Name:        MLD_CONFIG_KEYGEN_PCT
  *
  * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
@@ -318,7 +358,6 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
    }
    #endif
 */
-
 
 /******************************************************************************
  * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
@@ -396,6 +435,8 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  *****************************************************************************/
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
+
+
 /*************************  Config internals  ********************************/
 
 /* Default namespace
@@ -407,7 +448,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44

--- a/test/custom_memset_config.h
+++ b/test/custom_memset_config.h
@@ -17,6 +17,21 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration with custom memset
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_CUSTOM_MEMSET
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -99,12 +114,11 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient
@@ -154,7 +168,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -190,7 +203,7 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
@@ -278,8 +291,34 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
   }
   return s;
 }
-#endif
+#endif /* !__ASSEMBLER__ */
 
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
 
 /******************************************************************************
  * Name:        MLD_CONFIG_KEYGEN_PCT
@@ -318,7 +357,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
    }
    #endif
 */
-
 
 /******************************************************************************
  * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
@@ -396,6 +434,8 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  *****************************************************************************/
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
+
+
 /*************************  Config internals  ********************************/
 
 /* Default namespace
@@ -407,7 +447,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44

--- a/test/custom_randombytes_config.h
+++ b/test/custom_randombytes_config.h
@@ -17,6 +17,21 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration with custom randombytes
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_CUSTOM_RANDOMBYTES
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -103,7 +118,7 @@
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient
@@ -153,7 +168,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -189,7 +203,7 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
@@ -228,6 +242,52 @@
 */
 
 /******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMCPY
+ *
+ * Description: Set this option and define `mld_memcpy` if you want to
+ *              use a custom method to copy memory instead of the standard
+ *              library memcpy function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memcpy function:
+ *              void *mld_memcpy(void *dest, const void *src, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMCPY
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMSET
+ *
+ * Description: Set this option and define `mld_memset` if you want to
+ *              use a custom method to set memory instead of the standard
+ *              library memset function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memset function:
+ *              void *mld_memset(void *s, int c, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMSET
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mldsa-native does not provide a secure randombytes
@@ -252,6 +312,7 @@ static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
   randombytes(ptr, len);
 }
 #endif /* !__ASSEMBLER__ */
+
 
 /******************************************************************************
  * Name:        MLD_CONFIG_KEYGEN_PCT
@@ -290,7 +351,6 @@ static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
-
 
 /******************************************************************************
  * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
@@ -381,7 +441,7 @@ static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44
@@ -391,4 +451,5 @@ static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
 #elif MLD_CONFIG_PARAMETER_SET == 87
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA87
 #endif
+
 #endif /* !MLD_CONFIG_H */

--- a/test/custom_stdlib_config.h
+++ b/test/custom_stdlib_config.h
@@ -17,6 +17,22 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration with custom stdlib functions
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_CUSTOM_MEMCPY
+ *   - MLD_CONFIG_CUSTOM_MEMSET
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -103,7 +119,7 @@
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient
@@ -153,7 +169,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -189,7 +204,7 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
@@ -287,6 +302,33 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
 }
 #endif /* !__ASSEMBLER__ */
 
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
 /******************************************************************************
  * Name:        MLD_CONFIG_KEYGEN_PCT
  *
@@ -324,7 +366,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
    }
    #endif
 */
-
 
 /******************************************************************************
  * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
@@ -415,7 +456,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44
@@ -425,4 +466,5 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
 #elif MLD_CONFIG_PARAMETER_SET == 87
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA87
 #endif
+
 #endif /* !MLD_CONFIG_H */

--- a/test/custom_zeroize_config.h
+++ b/test/custom_zeroize_config.h
@@ -17,6 +17,21 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration with custom zeroize
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_CUSTOM_ZEROIZE
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -103,7 +118,7 @@
  * Name:        MLD_CONFIG_FILE
  *
  * Description: If defined, this is a header that will be included instead
- *              of this default configuration file mldsa/config.h.
+ *              of the default configuration file mldsa/config.h.
  *
  *              When you need to build mldsa-native in multiple configurations,
  *              using varying MLD_CONFIG_FILE can be more convenient
@@ -153,7 +168,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -189,7 +203,7 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
@@ -225,7 +239,80 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
 {
   explicit_bzero(ptr, len);
 }
-#endif
+#endif /* !__ASSEMBLER__ */
+
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMCPY
+ *
+ * Description: Set this option and define `mld_memcpy` if you want to
+ *              use a custom method to copy memory instead of the standard
+ *              library memcpy function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memcpy function:
+ *              void *mld_memcpy(void *dest, const void *src, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMCPY
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMSET
+ *
+ * Description: Set this option and define `mld_memset` if you want to
+ *              use a custom method to set memory instead of the standard
+ *              library memset function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memset function:
+ *              void *mld_memset(void *s, int c, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMSET
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
 
 /******************************************************************************
  * Name:        MLD_CONFIG_KEYGEN_PCT
@@ -264,6 +351,45 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
    }
    #endif
 */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_EXTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of mldsa-native's
+ *              public API.
+ *
+ *              The primary use case for this option are single-CU builds
+ *              where the public API exposed by mldsa-native is wrapped by
+ *              another API in the consuming application. In this case,
+ *              even mldsa-native's public API can be marked `static`.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CT_TESTING_ENABLED
+ *
+ * Description: If set, mldsa-native annotates data as secret / public using
+ *              valgrind's annotations VALGRIND_MAKE_MEM_UNDEFINED and
+ *              VALGRIND_MAKE_MEM_DEFINED, enabling various checks for secret-
+ *              dependent control flow of variable time execution (depending
+ *              on the exact version of valgrind installed).
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CT_TESTING_ENABLED */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_NO_ASM
@@ -315,7 +441,7 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44
@@ -325,4 +451,5 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
 #elif MLD_CONFIG_PARAMETER_SET == 87
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA87
 #endif
+
 #endif /* !MLD_CONFIG_H */

--- a/test/no_asm_config.h
+++ b/test/no_asm_config.h
@@ -17,6 +17,22 @@
  *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mldsa-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Test configuration with no assembly code
+ *
+ * This configuration differs from the default mldsa/src/config.h in the
+ * following places:
+ *   - MLD_CONFIG_NO_ASM
+ *   - MLD_CONFIG_CUSTOM_ZEROIZE
+ */
+
+
 #ifndef MLD_CONFIG_H
 #define MLD_CONFIG_H
 
@@ -100,6 +116,24 @@
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
 /******************************************************************************
+ * Name:        MLD_CONFIG_FILE
+ *
+ * Description: If defined, this is a header that will be included instead
+ *              of the default configuration file mldsa/config.h.
+ *
+ *              When you need to build mldsa-native in multiple configurations,
+ *              using varying MLD_CONFIG_FILE can be more convenient
+ *              then configuring everything through CFLAGS.
+ *
+ *              To use, MLD_CONFIG_FILE _must_ be defined prior
+ *              to the inclusion of any mldsa-native headers. For example,
+ *              it can be set by passing `-DMLD_CONFIG_FILE="..."`
+ *              on the command line.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_FILE "config.h" */
+
+/******************************************************************************
  * Name:        MLD_CONFIG_ARITH_BACKEND_FILE
  *
  * Description: The arithmetic backend to use.
@@ -135,7 +169,6 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
-
 /******************************************************************************
  * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -171,7 +204,7 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
  *
- * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
@@ -207,8 +240,80 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
 {
   explicit_bzero(ptr, len);
 }
-#endif
+#endif /* !__ASSEMBLER__ */
 
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMCPY
+ *
+ * Description: Set this option and define `mld_memcpy` if you want to
+ *              use a custom method to copy memory instead of the standard
+ *              library memcpy function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memcpy function:
+ *              void *mld_memcpy(void *dest, const void *src, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMCPY
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_MEMSET
+ *
+ * Description: Set this option and define `mld_memset` if you want to
+ *              use a custom method to set memory instead of the standard
+ *              library memset function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memset function:
+ *              void *mld_memset(void *s, int c, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_MEMSET
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
 
 /******************************************************************************
  * Name:        MLD_CONFIG_KEYGEN_PCT
@@ -249,6 +354,45 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
 */
 
 /******************************************************************************
+ * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_EXTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of mldsa-native's
+ *              public API.
+ *
+ *              The primary use case for this option are single-CU builds
+ *              where the public API exposed by mldsa-native is wrapped by
+ *              another API in the consuming application. In this case,
+ *              even mldsa-native's public API can be marked `static`.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CT_TESTING_ENABLED
+ *
+ * Description: If set, mldsa-native annotates data as secret / public using
+ *              valgrind's annotations VALGRIND_MAKE_MEM_UNDEFINED and
+ *              VALGRIND_MAKE_MEM_DEFINED, enabling various checks for secret-
+ *              dependent control flow of variable time execution (depending
+ *              on the exact version of valgrind installed).
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
+/******************************************************************************
  * Name:        MLD_CONFIG_NO_ASM
  *
  * Description: If this option is set, mldsa-native will be built without
@@ -261,7 +405,7 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_CONFIG_CUSTOM_ZEROIZE and provide a custom zeroization
+ *              MLD_CONFIG_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 and
@@ -270,6 +414,20 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
  *
  *****************************************************************************/
 #define MLD_CONFIG_NO_ASM
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_ASM_VALUE_BARRIER
+ *
+ * Description: If this option is set, mldsa-native will be built without
+ *              use of native code or inline assembly for value barriers.
+ *
+ *              By default, inline assembly (if available) is used to implement
+ *              value barriers.
+ *              Without inline assembly, mldsa-native will use a global volatile
+ *              'opt blocker' instead; see ct.h.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 
 
@@ -284,7 +442,7 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
  *
  *   PQCP_MLDSA_NATIVE_MLDSA<LEVEL>_
  *
- * e.g., PQCP_MLDSA_NATIVE_MLDSA65_
+ * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
 #if MLD_CONFIG_PARAMETER_SET == 44
@@ -294,4 +452,5 @@ static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
 #elif MLD_CONFIG_PARAMETER_SET == 87
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA87
 #endif
+
 #endif /* !MLD_CONFIG_H */


### PR DESCRIPTION
- This PR ported from: https://github.com/pq-code-package/mlkem-native/pull/1259
- This commit extends `autogen` to autogenerate all test configurations in `test/` from the default configuration and descriptions of the differences of the test configurations in a new file `test/configs.yml`.