### PR TITLE
Adjust LICENSE after AArch64 iNTT/NTT reimplementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,36 +6,6 @@ implementation are made available under the Apache-2.0 license OR
 the ISC license OR the MIT license. These licenses are
 reproduced at the bottom of this file.
 
-License for AArch64 assembly
-----------------------------
-
-The AArch64 assembly in mldsa/* implementing the forward and
-inverse NTT for ML-DSA, carries the MIT license.
-
-Copyright (c) 2022 Arm Limited
-Copyright (c) 2022 Hanno Becker
-Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
-Copyright (c) The mldsa-native project authors
-SPDX-License-Identifier: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 The code in test/notrandombytes/* is derived from
 https://cr.yp.to/papers.html#surf and licensed under
 LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT.


### PR DESCRIPTION
https://github.com/pq-code-package/mldsa-native/pull/570 reimplemented the iNTT/NTT to achieve uniform Apache-2.0 OR ISC OR MIT licensing. This commit updates the LICENSE to remove the outdated license for the old NTT and INTT - these were the last files covered by that license.