### PR TITLE
Align native api.h with meta.h

### DIFF
--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -166,24 +166,24 @@ static MLD_INLINE void mld_poly_pointwise_montgomery_native(
 }
 
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l4_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N])
+    int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
+    const int32_t v[4][MLDSA_N])
 {
   mld_pointwise_acc_l4_avx2((__m256i *)w, (const __m256i *)u,
                             (const __m256i *)v, mld_qdata.vec);
 }
 
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l5_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N])
+    int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
+    const int32_t v[5][MLDSA_N])
 {
   mld_pointwise_acc_l5_avx2((__m256i *)w, (const __m256i *)u,
                             (const __m256i *)v, mld_qdata.vec);
 }
 
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l7_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N])
+    int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
+    const int32_t v[7][MLDSA_N])
 {
   mld_pointwise_acc_l7_avx2((__m256i *)w, (const __m256i *)u,
                             (const __m256i *)v, mld_qdata.vec);

--- a/mldsa/src/native/api.h
+++ b/mldsa/src/native/api.h
@@ -96,7 +96,7 @@ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t p[MLDSA_N]);
  *
  * Arguments:   - uint32_t p[MLDSA_N]: pointer to in/output polynomial
  **************************************************/
-static MLD_INLINE void mld_intt_native(int16_t p[MLDSA_N]);
+static MLD_INLINE void mld_intt_native(int32_t p[MLDSA_N]);
 #endif /* MLD_USE_NATIVE_INTT */
 
 #if defined(MLD_USE_NATIVE_REJ_UNIFORM)
@@ -332,8 +332,8 @@ static MLD_INLINE void mld_poly_pointwise_montgomery_native(
  *              - const int32_t v[MLDSA_L][MLDSA_N]: second input vector
  **************************************************/
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l4_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N]);
+    int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
+    const int32_t v[4][MLDSA_N]);
 #endif /* MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L4 */
 
 #if defined(MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L5)
@@ -352,8 +352,8 @@ static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l4_native(
  *              - const int32_t v[MLDSA_L][MLDSA_N]: second input vector
  **************************************************/
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l5_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N]);
+    int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
+    const int32_t v[5][MLDSA_N]);
 #endif /* MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L5 */
 
 #if defined(MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7)
@@ -372,8 +372,8 @@ static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l5_native(
  *              - const int32_t v[MLDSA_L][MLDSA_N]: second input vector
  **************************************************/
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l7_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N]);
+    int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
+    const int32_t v[7][MLDSA_N]);
 #endif /* MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7 */
 
 #endif /* !MLD_NATIVE_API_H */

--- a/mldsa/src/native/x86_64/meta.h
+++ b/mldsa/src/native/x86_64/meta.h
@@ -166,24 +166,24 @@ static MLD_INLINE void mld_poly_pointwise_montgomery_native(
 }
 
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l4_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N])
+    int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
+    const int32_t v[4][MLDSA_N])
 {
   mld_pointwise_acc_l4_avx2((__m256i *)w, (const __m256i *)u,
                             (const __m256i *)v, mld_qdata.vec);
 }
 
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l5_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N])
+    int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
+    const int32_t v[5][MLDSA_N])
 {
   mld_pointwise_acc_l5_avx2((__m256i *)w, (const __m256i *)u,
                             (const __m256i *)v, mld_qdata.vec);
 }
 
 static MLD_INLINE void mld_polyvecl_pointwise_acc_montgomery_l7_native(
-    int32_t w[MLDSA_N], const int32_t u[MLDSA_L][MLDSA_N],
-    const int32_t v[MLDSA_L][MLDSA_N])
+    int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
+    const int32_t v[7][MLDSA_N])
 {
   mld_pointwise_acc_l7_avx2((__m256i *)w, (const __m256i *)u,
                             (const __m256i *)v, mld_qdata.vec);


### PR DESCRIPTION
- During PR #607, we found some differences in the functions parameter between `mata.h` and `api.h`, and we have aligned them in this PR.
- This PR fix two problem:
  - Correcting the parameter type for `mld_intt_native`, aligned with `meta.h`
  - Making array dimensions explicit in the polyvecl pointwise accumulation functions, aligned with `meta.h`