### PR TITLE
CI: Do not use custom AMI for CBMC runners

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -18,8 +18,8 @@ jobs:
     with:
       name: CBMC (ML-DSA-44)
       ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
+      ec2_ami: ubuntu-latest (aarch64)
+      ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
       lint: false
@@ -40,8 +40,8 @@ jobs:
     with:
       name: CBMC (ML-DSA-65)
       ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
+      ec2_ami: ubuntu-latest (aarch64)
+      ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
       lint: false
@@ -62,8 +62,8 @@ jobs:
     with:
       name: CBMC (ML-DSA-87)
       ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-0d7f502261b31b27f # aarch64, ubuntu-latest, 64g
+      ec2_ami: ubuntu-latest (aarch64)
+      ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
       lint: false

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -24,6 +24,9 @@ on:
         type: string
         description: AMI ID
         default: ami-0e8c824f386e1de06
+      ec2_volume_size:
+        type: string
+        default: ""
       cflags:
         type: string
         description: Custom CFLAGS for compilation
@@ -113,6 +116,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
           ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
           subnet-id: subnet-094d73eb42eb6bf5b
           security-group-id: sg-0282706dbc92a1579
@@ -130,6 +134,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
           ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
           subnet-id: subnet-094d73eb42eb6bf5b
           security-group-id: sg-0282706dbc92a1579


### PR DESCRIPTION
This PR ports part of https://github.com/pq-code-package/mlkem-native/pull/1250

Currently we are using custom AMIs for the CBMC tests. The only
reason for using custom AMI is that require a disk of larger than
the default 8 GB.
This commit switches to default AMIs and instead uses the ec2_volume_size
argument of the ec2-github-runner action.
