### PR TITLE
autogen/simpasm: Add support for Intel syntax

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -241,6 +241,20 @@ jobs:
             ./scripts/autogen ${{ matrix.simplify.arg }}
             make clean
             OPT=1 make quickcheck
+  x86_64_intel_syntax:
+    name: x86_64 Intel syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Generate with Intel syntax and test
+        uses: ./.github/actions/setup-shell
+        with:
+          nix-shell: 'ci'
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            ./scripts/autogen --x86-64-syntax intel
+            make clean
+            ./scripts/tests all
   scan-build:
     strategy:
       fail-fast: false

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1377,6 +1377,7 @@ def update_via_simpasm(
     preserve_header=True,
     dry_run=False,
     force_cross=False,
+    x86_64_syntax="att",
 ):
     status_update("simpasm", infile_full)
 
@@ -1432,6 +1433,9 @@ def update_via_simpasm(
                 cmd += [f'--cflags="{cflags}"']
             if preserve_header is True:
                 cmd += ["-p"]
+            # Add syntax option for x86_64
+            if arch == "x86_64" and x86_64_syntax != "att":
+                cmd += ["--syntax", x86_64_syntax]
             r = subprocess.run(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -1542,7 +1546,13 @@ def synchronize_backend(
 
 
 def synchronize_backends(
-    *, dry_run=False, force_cross=False, clean=False, delete=False, no_simplify=False
+    *,
+    dry_run=False,
+    force_cross=False,
+    clean=False,
+    delete=False,
+    no_simplify=False,
+    x86_64_syntax="att",
 ):
     if clean is False:
         ty = "opt"
@@ -1603,6 +1613,7 @@ def synchronize_backends(
         delete=delete,
         force_cross=force_cross,
         no_simplify=no_simplify,
+        x86_64_syntax=x86_64_syntax,
         # Turn off control-flow protection (CET) explicitly. Newer versions of
         # clang turn it on by default and insert endbr64 instructions at every
         # global symbol.
@@ -2226,7 +2237,13 @@ def _main():
     parser.add_argument("--aarch64-clean", default=True, action="store_true")
     parser.add_argument("--no-simplify", default=False, action="store_true")
     parser.add_argument("--force-cross", default=False, action="store_true")
-
+    parser.add_argument(
+        "--x86-64-syntax",
+        type=str,
+        choices=["att", "intel"],
+        default="att",
+        help="Assembly syntax for x86_64 disassembly output (att or intel)",
+    )
     args = parser.parse_args()
 
     os.chdir(os.path.join(os.path.dirname(__file__), ".."))
@@ -2248,6 +2265,7 @@ def _main():
         clean=args.aarch64_clean,
         no_simplify=args.no_simplify,
         force_cross=args.force_cross,
+        x86_64_syntax=args.x86_64_syntax,
     )
     high_level_status("Synchronized backends")
 
@@ -2264,6 +2282,7 @@ def _main():
         delete=True,
         force_cross=args.force_cross,
         no_simplify=args.no_simplify,
+        x86_64_syntax=args.x86_64_syntax,
     )
     high_level_status("Completed final backend synchronization")
     gen_test_configs(args.dry_run)

--- a/scripts/cfify
+++ b/scripts/cfify
@@ -217,8 +217,8 @@ def add_cfi_directives(text, arch):
                 i += 1
                 continue
 
-            # x86_64: retq -> .cfi_endproc after retq
-            match = re.match(r"(\s*)retq\s*$", line, re.IGNORECASE)
+            # x86_64: ret/retq -> .cfi_endproc after ret
+            match = re.match(r"(\s*)retq?\s*$", line, re.IGNORECASE)
             if match:
                 indent = match.group(1)
                 result.append(line)

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -250,6 +250,10 @@ def simplify(logger, args, asm_input, asm_output=None):
         if platform.system() == "Darwin":
             cmd += ["--triple=aarch64"]
 
+        # Add syntax option if specified
+        if args.syntax and args.syntax.lower() != "att":
+            cmd += [f"--x86-asm-syntax={args.syntax}"]
+
         logger.debug(f"Disassembling temporary object file {tmp_objfile0} ...")
         disasm = run_cmd(cmd).stdout
 
@@ -267,6 +271,10 @@ def simplify(logger, args, asm_input, asm_output=None):
             ".text",
             ".balign 4",
         ]
+
+        # Add syntax specifier for Intel syntax
+        if args.syntax and args.syntax.lower() == "intel":
+            autogen_header.append(".intel_syntax noprefix")
 
         if args.preserve_preprocessor_directives is False:
             if platform.system() == "Darwin" and sym[0] == "_":
@@ -412,6 +420,14 @@ def _main():
         type=str,
         default="aarch64",
         help="Target architecture for CFI directives",
+    )
+
+    parser.add_argument(
+        "--syntax",
+        type=str,
+        choices=["att", "intel"],
+        default="att",
+        help="Assembly syntax for disassembly output (att or intel)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
- Resolves: #612 
- This PR is ported from: https://github.com/pq-code-package/mlkem-native/pull/1275
- This PR extends `scripts/simpasm` to support the emission of x86_64 assembly in Intel syntax via `--x86-64-syntax` intel, also the CI is extended to exercise this on an x86_64 runner and run the full tests afterwards.