### PR TITLE
iNTT: Relax output bound to MLDSA_Q

### DIFF
--- a/mldsa/src/ntt.h
+++ b/mldsa/src/ntt.h
@@ -22,7 +22,7 @@
 /* Absolute exclusive upper bound for the output of the forward NTT */
 #define MLD_NTT_BOUND (9 * MLDSA_Q)
 /* Absolute exclusive upper bound for the output of the inverse NTT*/
-#define MLD_INTT_BOUND (MLDSA_Q * 3 / 4)
+#define MLD_INTT_BOUND MLDSA_Q
 
 #define mld_ntt MLD_NAMESPACE(ntt)
 /*************************************************

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -198,6 +198,17 @@ int crypto_sign_keypair_internal(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
   /* Add error vector s2 */
   mld_polyveck_add(&t1, &s2);
 
+  /* Reference: The following reduction is not present in the reference
+   *            implementation. Omitting this reduction requires the output of
+   *            the invntt to be small enough such that the addition of s2 does
+   *            not result in absolute values >= MLDSA_Q. While our C, x86_64,
+   *            and AArch64 invntt implementations produce small enough
+   *            values for this to work out, it complicates the bounds
+   *            reasoning. We instead add an additional reduction, and can
+   *            consequently, relax the bounds requirements for the invntt.
+   */
+  mld_polyveck_reduce(&t1);
+
   /* Extract t1 and write public key */
   mld_polyveck_caddq(&t1);
   mld_polyveck_power2round(&t2, &t0, &t1);


### PR DESCRIPTION
Currently, we use 3*q/4 as the output bound for the inverse NTT. We have proven
these bounds for both the C (through CBMC) and the AVX2 (through manual proof)
implementation. The main reason for this to work is that Montgomery
multiplication by a signed canonical constant is bounded by 3*q/4. See
https://github.com/pq-code-package/mldsa-native/pull/560 for details.

Unfortunately, this bound is much harder to proof for the Barrett
multiplication used in the AArch64 iNTT. While we think we have confirmed
that the multiplication by n^-1 results in values smaller than 3*q/4, only
half coefficients are multiplied by n^-1 - for the other half, the scaling is
merged into the butterflies in last layer of the iNTT.
There multiplication by -294725 is performed which may exceed 3q/4 assuming
the other multiplicand is bounded by 256Q.
Credits for finding is problem and figuring out the numbers above go to
Chun-Ming Chiu.

Now we could figure out a new bound for the problematic multiplications above -
exhaustive search suggests that value is bounded by 6390331.
I've tried changing MLD_INTT_BOUND to 6390331 + 1 and all CBMC proofs still
pass, so there indeed seems to be now risk of overflow in our implementation

However, working out this bound was tedious and may be error-prone - this would
definitely complicate adding more backends in the future.
The only reason we require a bound smaller than MLDSA_Q is the following
sequence in keypair:

mld_polyveck_invntt_tomont(&t1);
mld_polyveck_add(&t1, &s2);
mld_polyveck_caddq(&t1);

Here caddq requires absolute values smaller than Q, so that is produces
unsigned canonical values. That means that the invntt output need to be
small enough such that the addition of s2 (which is small) does not exceed
Q.

This problem goes away when adding a reduction after the addition - then
the outputs of invntt can be much larger.
This commit adds that reductions and changes MLD_INTT_BOUND to MLDSA_Q -
a bound that should be straightforward to proof for future INTT implementations
too.

The performance impact is minimal.