### PR TITLE
HOL-Light: Add HOL-Light proof framework and x86 AVX2 NTT proof

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: HOL-Light
+permissions:
+  contents: read
+on:
+  push:
+    branches: ["main"]
+    paths:
+     - '.github/workflows/hol_light.yml'
+     - 'proofs/hol_light/x86_64/Makefile'
+     - 'proofs/hol_light/x86_64/**/*.S'
+     - 'proofs/hol_light/x86_64/**/*.ml'
+     - 'nix/hol_light/*'
+     - 'nix/s2n_bignum/*'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - '.github/workflows/hol_light.yml'
+      - 'proofs/hol_light/x86_64/Makefile'
+      - 'proofs/hol_light/x86_64/**/*.S'
+      - 'proofs/hol_light/x86_64/**/*.ml'
+      - 'nix/hol_light/*'
+      - 'nix/s2n_bignum/*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # The proofs also check that the byte code is up to date,
+  # but we use this as a fast path to not even start the proofs
+  # if the byte code needs updating.
+  hol_light_bytecode:
+    name: HOL-Light bytecode check
+    runs-on: pqcp-x64
+    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-shell
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: 'hol_light'
+          script: |
+            autogen --update-hol-light-bytecode --dry-run
+  hol_light_interactive:
+    name: HOL-Light interactive shell test
+    runs-on: pqcp-x64
+    needs: [ hol_light_bytecode ]
+    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-shell
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: 'hol_light'
+          script: |
+            # Load base infrastructure and specs to validate HOL-Light environment
+            # When we have smaller/faster proofs, we can run them here instead:
+            # make -C proofs/hol_light/x86_64 mldsa/mldsa_ntt.o
+            # echo 'needs "proofs/mldsa_ntt.ml";;' | hol.sh
+            echo 'needs "x86/proofs/base.ml";; needs "proofs/mldsa_specs.ml";; #quit;;' | hol.sh
+  hol_light_proofs:
+    needs: [ hol_light_bytecode ]
+    strategy:
+      fail-fast: false
+      matrix:
+        proof:
+          # Dependencies on {name}.{S,ml} are implicit
+          - name: mldsa_ntt
+            needs: ["mldsa_specs.ml", "mldsa_utils.ml"]
+    name: HOL Light proof for ${{ matrix.proof.name }}.S
+    runs-on: pqcp-x64
+    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+      - name: Check if dependencies changed
+        id: check_run
+        shell: bash
+        run: |
+          run_needed=0
+          changed_files="${{ steps.changed-files.outputs.all_changed_files }}"
+          dependencies="${{ join(matrix.proof.needs, ' ') }} ${{ format('{0}.S {0}.ml', matrix.proof.name) }}"
+          for changed in $changed_files; do
+            for needs in $dependencies; do
+               if [[ "$changed" == *"$needs" ]]; then
+                 run_needed=1
+               fi
+            done
+          done
+
+          # Always re-run upon change to nix files for HOL-Light
+          if [[ "$changed_files" == *"nix/"* ]] || [[ "$changed_files" == *"hol_light.yml"* ]] || [[ "$changed_files" == *"flake"* ]] || [[ "$changed_files" == *"proofs/hol_light/x86_64/Makefile"* ]]; then
+            run_needed=1
+          fi
+
+          echo "run_needed=${run_needed}" >> $GITHUB_OUTPUT
+      - uses: ./.github/actions/setup-shell
+        if: |
+          steps.check_run.outputs.run_needed == '1'
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: 'hol_light'
+          script: |
+            tests hol_light -p ${{ matrix.proof.name }} --verbose

--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -228,6 +228,7 @@ source code and documentation.
   - [mldsa/src/native/x86_64/src/rej_uniform_avx2.c](mldsa/src/native/x86_64/src/rej_uniform_avx2.c)
   - [mldsa/src/native/x86_64/src/rej_uniform_eta2_avx2.c](mldsa/src/native/x86_64/src/rej_uniform_eta2_avx2.c)
   - [mldsa/src/native/x86_64/src/rej_uniform_eta4_avx2.c](mldsa/src/native/x86_64/src/rej_uniform_eta4_avx2.c)
+  - [proofs/hol_light/x86_64/mldsa/mldsa_ntt.S](proofs/hol_light/x86_64/mldsa/mldsa_ntt.S)
 
 ### `Round3_Spec`
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ make test
 
 We use the [C Bounded Model Checker (CBMC)](https://github.com/diffblue/cbmc) to prove absence of various classes of undefined behaviour in C, including out of bounds memory accesses and integer overflows. The proofs cover all C code in [mldsa/src/*](mldsa) and [mldsa/src/fips202/*](mldsa/src/fips202) involved in running mldsa-native with its C backend. See [proofs/cbmc](proofs/cbmc) for details.
 
+HOL-Light functional correctness proofs can be found in [proofs/hol_light/x86_64](proofs/hol_light/x86_64). So far, the following functions have been proven correct:
+
+- x86_64 NTT [ntt.S](mldsa/src/native/x86_64/src/ntt.S)
+
+
+These proofs are utilizing the verification infrastructure in [s2n-bignum](https://github.com/awslabs/s2n-bignum).
+
 ## Security
 
 All assembly in mldsa-native is constant-time in the sense that it is free of secret-dependent control flow, memory access,

--- a/flake.nix
+++ b/flake.nix
@@ -100,8 +100,8 @@
           }).overrideAttrs (old: {
             shellHook = ''
               export PATH=$PWD/scripts:$PATH
-              # Set PROOF_DIR_ARM based on where we entered the shell
-              export PROOF_DIR_ARM="$PWD/proofs/hol_light/arm"
+              # Set proof directory for x86_64
+              export PROOF_DIR_X86_64="$PWD/proofs/hol_light/x86_64"
             '';
           });
           devShells.ci = util.mkShell {

--- a/nix/hol_light/0005-Configure-hol-sh-for-mldsa-native.patch
+++ b/nix/hol_light/0005-Configure-hol-sh-for-mldsa-native.patch
@@ -21,10 +21,10 @@ index 1311255..8b2bc36 100755
 +SITELIB=$(dirname $(ocamlfind query findlib 2>/dev/null) 2>/dev/null)
 +
 +# Set HOLLIGHT_LOAD_PATH to include S2N_BIGNUM_DIR and mldsa-native proofs
-+export HOLLIGHT_LOAD_PATH="${S2N_BIGNUM_DIR}:${PROOF_DIR_ARM}:${HOLLIGHT_LOAD_PATH}"
++export HOLLIGHT_LOAD_PATH="${S2N_BIGNUM_DIR}:${PROOF_DIR_X86_64}:${HOLLIGHT_LOAD_PATH}"
 +
 +# Change to mldsa-native proofs directory if set, so define_from_elf can find object files
-+[ -n "${PROOF_DIR_ARM}" ] && cd "${PROOF_DIR_ARM}"
++[ -n "${PROOF_DIR_X86_64}" ] && cd "${PROOF_DIR_X86_64}"
 +
 +${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR} ${SITELIB:+-I "$SITELIB"}
 diff --git a/hol_4.sh b/hol_4.sh

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -4,12 +4,12 @@
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";
-  version = "1fcccc89cc7762ae5c56ec660f25b5f1358ba308";
+  version = "2ab2252b8505e58a7c3392f8ad823782032b61e7";
   src = fetchFromGitHub {
-    owner = "jargh";
-    repo = "s2n-bignum-dev";
+    owner = "awslabs";
+    repo = "s2n-bignum";
     rev = "${version}";
-    hash = "sha256-hSJ2WlrwVlTF3wSdMfdBbovBXMG5vltfPxp36hOMd5c=";
+    hash = "sha256-7lil3jAFo5NiyNOSBYZcRjduXkotV3x4PlxXSKt63M8=";
   };
   setupHook = writeText "setup-hook.sh" ''
     export S2N_BIGNUM_DIR="$1"

--- a/proofs/README.md
+++ b/proofs/README.md
@@ -7,3 +7,7 @@ This directory contains material related to the formal verification of the sourc
 ## C verification: CBMC
 
 We use the [C Bounded Model Checker (CBMC)](https://github.com/diffblue/cbmc) to show the absence of various classes of undefined behaviour in the mldsa-native C source, including out of bounds memory accesses and integer overflows. See [proofs/cbmc](cbmc), or the [proof_guide](https://github.com/pq-code-package/mlkem-native/blob/main/proofs/cbmc/proof_guide.md).
+
+## Assembly verification: HOL-Light
+
+We use the [HOL-Light](https://github.com/jrh13/hol-light) interactive theorem prover alongside the verification infrastructure from [s2n-bignum](https://github.com/awslabs/s2n-bignum) to show the functional correctness of highly optimized assembly routines in mlkem-native at the object-code level. See [proofs/hol_light/x86_64](hol_light/x86_64).

--- a/proofs/hol_light/.gitignore
+++ b/proofs/hol_light/.gitignore
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+**/*.o
+**/*.native
+**/*.correct

--- a/proofs/hol_light/x86_64/Makefile
+++ b/proofs/hol_light/x86_64/Makefile
@@ -1,0 +1,133 @@
+#############################################################################
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+#############################################################################
+
+#
+# This Makefile is derived from the Makefile x86/Makefile in s2n-bignum.
+# - Remove all s2n-bignum proofs and tutorial, add mldsa-native proofs
+# - Minor path modifications to support base theories from s2n-bignum
+#   to reside in a separate read-only directory
+#
+
+.DEFAULT_GOAL := run_proofs
+
+OSTYPE_RESULT=$(shell uname -s)
+ARCHTYPE_RESULT=$(shell uname -m)
+
+SRC ?= $(S2N_BIGNUM_DIR)
+SRC_X86 ?= $(SRC)/x86
+
+# Add explicit language input parameter to cpp, otherwise the use of #n for
+# numeric literals in x86 code is a problem when used inside #define macros
+# since normally that means stringization.
+#
+# Some clang-based preprocessors seem to behave differently, and get confused
+# by single-quote characters in comments, so we eliminate // comments first.
+
+ifeq ($(OSTYPE_RESULT),Darwin)
+PREPROCESS=sed -e 's/\/\/.*//' | $(CC) -E -xassembler-with-cpp -
+else
+PREPROCESS=$(CC) -E -xassembler-with-cpp -
+endif
+
+# Generally GNU-type assemblers are happy with multiple instructions on
+# a line, but we split them up anyway just in case.
+
+SPLIT=tr ';' '\n'
+
+# If actually on an x86_64 machine, just use the assembler (as). Otherwise
+# use a cross-assembling version so that the code can still be assembled
+# and the proofs checked against the object files (though you won't be able
+# to run code without additional emulation infrastructure). For the clang
+# version on OS X we just add the "-arch x86_64" option. For the Linux/gcc
+# toolchain we assume the presence of the special cross-assembler. This
+# can be installed via something like:
+#
+#  sudo apt-get install binutils-x86-64-linux-gnu
+
+ifeq ($(ARCHTYPE_RESULT),x86_64)
+ASSEMBLE=as
+OBJDUMP=objdump -d
+else
+ifeq ($(OSTYPE_RESULT),Darwin)
+ASSEMBLE=as -arch x86_64
+OBJDUMP=otool -tvV
+else
+ASSEMBLE=x86_64-linux-gnu-as
+OBJDUMP=x86_64-linux-gnu-objdump -d
+endif
+endif
+
+OBJ = mldsa/mldsa_ntt.o
+
+# Build object files from assembly sources
+$(OBJ): %.o : %.S
+	@echo "Preparing $@ ..."
+	@echo "AS: `$(ASSEMBLE) --version`"
+	@echo "OBJDUMP: `$(OBJDUMP) --version`"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	cat $< | $(PREPROCESS) | $(SPLIT) | $(ASSEMBLE) -o $@ -
+	# MacOS may generate relocations in non-text sections that break
+	# the object file parser in HOL-Light
+	strip $@
+
+clean:; rm -f */*.o */*/*.o */*.correct */*.native
+
+# Proof-related parts
+#
+# The proof files are all independent, though each one loads the
+# same common infrastructure "base.ml". So you can potentially
+# run the proofs in parallel for more speed, e.g.
+#
+#    nohup make -j 16 proofs &
+#
+# If you build hol-light yourself (see https://github.com/jrh13/hol-light)
+# in your home directory, and do "make" inside the subdirectory hol-light,
+# then the following HOLDIR setting should be right:
+
+HOLDIR?=$(HOLLIGHTDIR)
+HOLLIGHT:=$(HOLDIR)/hol.sh
+
+BASE?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+PROOF_BINS = $(OBJ:.o=.native)
+PROOF_LOGS = $(OBJ:.o=.correct)
+
+# Build precompiled binary for dumping bytecodes
+proofs/dump_bytecode.native: proofs/dump_bytecode.ml $(OBJ)
+	./proofs/build-proof.sh $(BASE)/$< "$(HOLLIGHT)" "$@"
+
+# Build precompiled native binaries of HOL Light proofs
+
+.SECONDEXPANSION:
+%.native: proofs/$$(*F).ml %.o ; ./proofs/build-proof.sh $(BASE)/$< "$(HOLLIGHT)" "$@"
+
+# Run them and print the standard output+error at *.correct
+%.correct: %.native
+	$< 2>&1 | tee $@
+	@if (grep -i "error:\|exception:" "$@" >/dev/null); then  \
+		echo "$< had errors!";			          \
+		exit 1;					          \
+	else							  \
+		echo "$< OK";					  \
+	fi
+
+build_proofs: $(PROOF_BINS);
+run_proofs: build_proofs $(PROOF_LOGS);
+
+proofs: run_proofs ; $(SRC)/tools/count-proofs.sh .
+
+dump_bytecode: proofs/dump_bytecode.native
+	./$<
+
+.PHONY: proofs build_proofs run_proofs sematest clean dump_bytecode
+
+# Always run sematest regardless of dependency check
+FORCE: ;
+# Always use max. # of cores because in Makefile one cannot get the passed number of -j.
+# A portable way of getting the number of max. cores:
+# https://stackoverflow.com/a/23569003/1488216
+NUM_CORES_FOR_SEMATEST = $(shell getconf _NPROCESSORS_ONLN)
+sematest: FORCE $(OBJ) $(SRC_X86)/proofs/simulator_iclasses.ml $(SRC_X86)/proofs/simulator.native
+	$(SRC)/tools/run-sematest.sh x86 $(NUM_CORES_FOR_SEMATEST)

--- a/proofs/hol_light/x86_64/README.md
+++ b/proofs/hol_light/x86_64/README.md
@@ -1,0 +1,108 @@
+[//]: # (SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0)
+
+# HOL Light functional correctness proofs
+
+This directory contains functional correctness proofs for some of the x86_64 assembly routines
+used in mldsa-native. The proofs were largely developed by John Harrison and Jake Massimo,
+and are written in the [HOL Light](https://hol-light.github.io/) theorem
+prover, utilizing the assembly verification infrastructure from [s2n-bignum](https://github.com/awslabs/s2n-bignum).
+
+Each function is proved in a separate `.ml` file in [proofs/](proofs). Each file
+contains the byte code being verified, as well as the specification that is being
+proved.
+
+## Primer
+
+Proofs are 'post-hoc' in the sense that HOL-Light/s2n-bignum operate on the final object code. In particular, the means by which the code was generated need not be trusted.
+
+Specifications are essentially [Hoare triples](https://en.wikipedia.org/wiki/Hoare_logic), with the noteworthy difference that the program is implicit as the content of memory at the PC; which is asserted to
+be the code under verification as part of the precondition. For example, the following is the specification of the `mldsa_ntt` function:
+
+```ocaml
+ (* For all (abbreviated by `!` in HOL):
+    - a: Polynomial coefficients pointer
+    - zetas: NTT constants pointer
+    - x: Original polynomial coefficients
+    - pc: Current value of Program Counter (PC)
+    - stackpointer: Stack pointer
+    - returnaddress: Return address on the stack *)
+`!a zetas x pc stackpointer returnaddress.
+    (* Alignment and non-overlapping requirements *)
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc,LENGTH mldsa_ntt_mc) (a, 1024) /\
+    nonoverlapping (word pc,LENGTH mldsa_ntt_mc) (zetas, 2496) /\
+    nonoverlapping (a, 1024) (zetas, 2496) /\
+    nonoverlapping (stackpointer,8) (a, 1024) /\
+    nonoverlapping (stackpointer,8) (zetas, 2496)
+    ==> ensures x86
+      (* Precondition *)
+      (\s. (* The memory at the current PC is the byte-code of mldsa_ntt() *)
+        bytes_loaded s (word pc) mldsa_ntt_mc /\
+        read RIP s = word pc /\
+        read RSP s = stackpointer /\
+        (* The return address is on the stack *)
+        read (memory :> bytes64 stackpointer) s = returnaddress /\
+        (* Arguments are passed via C calling convention *)
+        C_ARGUMENTS [a; zetas] s /\
+        (* NTT constants are properly loaded *)
+        wordlist_from_memory(zetas,624) s = MAP (iword: int -> 32 word) mldsa_complete_qdata /\
+        (* Input bounds checking *)
+        (!i. i < 256 ==> abs(ival(x i)) <= &8380416) /\
+        (* Give a name to the memory contents at the source pointer *)
+        !i. i < 256
+            ==> read(memory :> bytes32(word_add a (word(4 * i)))) s = x i)
+      (* Postcondition: Eventually we reach a state where ... *)
+      (\s.
+        (* The PC is the return address *)
+        read RIP s = returnaddress /\
+        (* Stack pointer is adjusted *)
+        read RSP s = word_add stackpointer (word 8) /\
+        (* The integers represented by the final memory contents
+         * are congruent to the ML-DSA forward NTT transformation
+         * of the original coefficients, modulo 8380417, with proper bounds *)
+        !i. i < 256
+            ==> let zi = read(memory :> bytes32(word_add a (word(4 * i)))) s in
+                (ival zi == mldsa_forward_ntt (ival o x) i) (mod &8380417) /\
+                abs(ival zi) <= &42035261)
+      (* Footprint: The program may modify (only) the ABI permitted registers
+       * and flags, stack pointer, and the memory contents at the source pointer. *)
+      (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+       MAYCHANGE [memory :> bytes(a,1024)])`
+```
+
+## Platform Compatibility
+
+These x86_64 assembly proofs are expected to work on the following platforms:
+
+- **Linux x86_64**: Fully supported (native build and execution)
+- **Linux AArch64**: Not currently supported. Requires x86_64 cross-compilation tools (`x86_64-linux-gnu-as` and `x86_64-linux-gnu-objdump`).
+- **macOS x86_64**: Fully supported (native build and execution)
+- **macOS ARM (Apple Silicon)**: Not currently supported. Differences in assembler behavior between clang-based (macOS) and gcc-based (Linux) toolchains can cause verification mismatches, particularly with regard to argument ordering optimizations for commutative instructions.
+
+## Reproducing the proofs
+
+To reproduce the proofs, enter the nix shell via
+
+```bash
+nix develop --experimental-features 'nix-command flakes'
+```
+
+from mldsa-native's base directory. Then
+
+```bash
+make -C proofs/hol_light/x86_64
+```
+
+will build and run the proofs. Note that this make take hours even on powerful machines.
+
+For convenience, you can also use `tests hol_light` which wraps the `make` invocation above; see `tests hol_light --help`.
+
+## What is covered?
+
+Currently this includes:
+
+- ML-DSA Arithmetic:
+  * x86_64 forward NTT: [mldsa_ntt.S](mldsa/mldsa_ntt.S)
+
+The NTT function is optimized using AVX2 instructions and follows the s2n-bignum x86_64 assembly verification patterns.

--- a/proofs/hol_light/x86_64/list_proofs.sh
+++ b/proofs/hol_light/x86_64/list_proofs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# This tiny script just lists the names of source files for which
+# we have a spec and proof in HOL-Light.
+
+ROOT=$(git rev-parse --show-toplevel)
+cd $ROOT
+ls -1 proofs/hol_light/x86_64/mldsa/*.S | cut -d '/' -f 5 | sed 's/\.S//'

--- a/proofs/hol_light/x86_64/mldsa/mldsa_ntt.S
+++ b/proofs/hol_light/x86_64/mldsa/mldsa_ntt.S
@@ -1,0 +1,2378 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/* References
+ * ==========
+ *
+ * - [REF_AVX2]
+ *   CRYSTALS-Dilithium optimized AVX2 implementation
+ *   Bai, Ducas, Kiltz, Lepoint, Lyubashevsky, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/dilithium/tree/master/avx2
+ */
+
+ /*
+  * This file is derived from the public domain
+  * AVX2 Dilithium implementation @[REF_AVX2].
+  */
+
+
+/*
+ * WARNING: This file is auto-derived from the mldsa-native source file
+ *   dev/x86_64/src/ntt.S using scripts/simpasm. Do not modify it directly.
+ */
+
+
+.text
+.balign 4
+#ifdef __APPLE__
+.global _PQCP_MLDSA_NATIVE_MLDSA44_ntt_avx2
+_PQCP_MLDSA_NATIVE_MLDSA44_ntt_avx2:
+#else
+.global PQCP_MLDSA_NATIVE_MLDSA44_ntt_avx2
+PQCP_MLDSA_NATIVE_MLDSA44_ntt_avx2:
+#endif
+
+        .cfi_startproc
+        endbr64
+        vmovdqa	(%rsi), %ymm0
+        vpbroadcastd	0x84(%rsi), %ymm1
+        vpbroadcastd	0x524(%rsi), %ymm2
+        vmovdqa	(%rdi), %ymm4
+        vmovdqa	0x80(%rdi), %ymm5
+        vmovdqa	0x100(%rdi), %ymm6
+        vmovdqa	0x180(%rdi), %ymm7
+        vmovdqa	0x200(%rdi), %ymm8
+        vmovdqa	0x280(%rdi), %ymm9
+        vmovdqa	0x300(%rdi), %ymm10
+        vmovdqa	0x380(%rdi), %ymm11
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpbroadcastd	0x88(%rsi), %ymm1
+        vpbroadcastd	0x528(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm5, %ymm12
+        vpaddd	%ymm7, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpbroadcastd	0x8c(%rsi), %ymm1
+        vpbroadcastd	0x52c(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	%ymm4, (%rdi)
+        vmovdqa	%ymm5, 0x80(%rdi)
+        vmovdqa	%ymm6, 0x100(%rdi)
+        vmovdqa	%ymm7, 0x180(%rdi)
+        vmovdqa	%ymm8, 0x200(%rdi)
+        vmovdqa	%ymm9, 0x280(%rdi)
+        vmovdqa	%ymm10, 0x300(%rdi)
+        vmovdqa	%ymm11, 0x380(%rdi)
+        vpbroadcastd	0x84(%rsi), %ymm1
+        vpbroadcastd	0x524(%rsi), %ymm2
+        vmovdqa	0x20(%rdi), %ymm4
+        vmovdqa	0xa0(%rdi), %ymm5
+        vmovdqa	0x120(%rdi), %ymm6
+        vmovdqa	0x1a0(%rdi), %ymm7
+        vmovdqa	0x220(%rdi), %ymm8
+        vmovdqa	0x2a0(%rdi), %ymm9
+        vmovdqa	0x320(%rdi), %ymm10
+        vmovdqa	0x3a0(%rdi), %ymm11
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpbroadcastd	0x88(%rsi), %ymm1
+        vpbroadcastd	0x528(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm5, %ymm12
+        vpaddd	%ymm7, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpbroadcastd	0x8c(%rsi), %ymm1
+        vpbroadcastd	0x52c(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	%ymm4, 0x20(%rdi)
+        vmovdqa	%ymm5, 0xa0(%rdi)
+        vmovdqa	%ymm6, 0x120(%rdi)
+        vmovdqa	%ymm7, 0x1a0(%rdi)
+        vmovdqa	%ymm8, 0x220(%rdi)
+        vmovdqa	%ymm9, 0x2a0(%rdi)
+        vmovdqa	%ymm10, 0x320(%rdi)
+        vmovdqa	%ymm11, 0x3a0(%rdi)
+        vpbroadcastd	0x84(%rsi), %ymm1
+        vpbroadcastd	0x524(%rsi), %ymm2
+        vmovdqa	0x40(%rdi), %ymm4
+        vmovdqa	0xc0(%rdi), %ymm5
+        vmovdqa	0x140(%rdi), %ymm6
+        vmovdqa	0x1c0(%rdi), %ymm7
+        vmovdqa	0x240(%rdi), %ymm8
+        vmovdqa	0x2c0(%rdi), %ymm9
+        vmovdqa	0x340(%rdi), %ymm10
+        vmovdqa	0x3c0(%rdi), %ymm11
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpbroadcastd	0x88(%rsi), %ymm1
+        vpbroadcastd	0x528(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm5, %ymm12
+        vpaddd	%ymm7, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpbroadcastd	0x8c(%rsi), %ymm1
+        vpbroadcastd	0x52c(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	%ymm4, 0x40(%rdi)
+        vmovdqa	%ymm5, 0xc0(%rdi)
+        vmovdqa	%ymm6, 0x140(%rdi)
+        vmovdqa	%ymm7, 0x1c0(%rdi)
+        vmovdqa	%ymm8, 0x240(%rdi)
+        vmovdqa	%ymm9, 0x2c0(%rdi)
+        vmovdqa	%ymm10, 0x340(%rdi)
+        vmovdqa	%ymm11, 0x3c0(%rdi)
+        vpbroadcastd	0x84(%rsi), %ymm1
+        vpbroadcastd	0x524(%rsi), %ymm2
+        vmovdqa	0x60(%rdi), %ymm4
+        vmovdqa	0xe0(%rdi), %ymm5
+        vmovdqa	0x160(%rdi), %ymm6
+        vmovdqa	0x1e0(%rdi), %ymm7
+        vmovdqa	0x260(%rdi), %ymm8
+        vmovdqa	0x2e0(%rdi), %ymm9
+        vmovdqa	0x360(%rdi), %ymm10
+        vmovdqa	0x3e0(%rdi), %ymm11
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpbroadcastd	0x88(%rsi), %ymm1
+        vpbroadcastd	0x528(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm5, %ymm12
+        vpaddd	%ymm7, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpbroadcastd	0x8c(%rsi), %ymm1
+        vpbroadcastd	0x52c(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	%ymm4, 0x60(%rdi)
+        vmovdqa	%ymm5, 0xe0(%rdi)
+        vmovdqa	%ymm6, 0x160(%rdi)
+        vmovdqa	%ymm7, 0x1e0(%rdi)
+        vmovdqa	%ymm8, 0x260(%rdi)
+        vmovdqa	%ymm9, 0x2e0(%rdi)
+        vmovdqa	%ymm10, 0x360(%rdi)
+        vmovdqa	%ymm11, 0x3e0(%rdi)
+        vmovdqa	(%rdi), %ymm4
+        vmovdqa	0x20(%rdi), %ymm5
+        vmovdqa	0x40(%rdi), %ymm6
+        vmovdqa	0x60(%rdi), %ymm7
+        vmovdqa	0x80(%rdi), %ymm8
+        vmovdqa	0xa0(%rdi), %ymm9
+        vmovdqa	0xc0(%rdi), %ymm10
+        vmovdqa	0xe0(%rdi), %ymm11
+        vpbroadcastd	0x90(%rsi), %ymm1
+        vpbroadcastd	0x530(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vperm2i128	$0x20, %ymm8, %ymm4, %ymm3 # ymm3 = ymm4[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm4, %ymm8 # ymm8 = ymm4[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm5, %ymm4 # ymm4 = ymm5[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm5, %ymm9 # ymm9 = ymm5[2,3],ymm9[2,3]
+        vperm2i128	$0x20, %ymm10, %ymm6, %ymm5 # ymm5 = ymm6[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm6, %ymm10 # ymm10 = ymm6[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm7, %ymm6 # ymm6 = ymm7[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm7, %ymm11 # ymm11 = ymm7[2,3],ymm11[2,3]
+        vmovdqa	0xa0(%rsi), %ymm1
+        vmovdqa	0x540(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm3, %ymm12
+        vpaddd	%ymm5, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpunpcklqdq	%ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[0],ymm3[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm3, %ymm5 # ymm5 = ymm3[1],ymm5[1],ymm3[3],ymm5[3]
+        vpunpcklqdq	%ymm10, %ymm8, %ymm3 # ymm3 = ymm8[0],ymm10[0],ymm8[2],ymm10[2]
+        vpunpckhqdq	%ymm10, %ymm8, %ymm10 # ymm10 = ymm8[1],ymm10[1],ymm8[3],ymm10[3]
+        vpunpcklqdq	%ymm6, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm6[0],ymm4[2],ymm6[2]
+        vpunpckhqdq	%ymm6, %ymm4, %ymm6 # ymm6 = ymm4[1],ymm6[1],ymm4[3],ymm6[3]
+        vpunpcklqdq	%ymm11, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm11[0],ymm9[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm9, %ymm11 # ymm11 = ymm9[1],ymm11[1],ymm9[3],ymm11[3]
+        vmovdqa	0x120(%rsi), %ymm1
+        vmovdqa	0x5c0(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm7, %ymm12
+        vpaddd	%ymm8, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm5, %ymm12
+        vpaddd	%ymm6, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm3, %ymm12
+        vpaddd	%ymm4, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm10, %ymm12
+        vpaddd	%ymm11, %ymm10, %ymm10
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm10, %ymm10
+        vmovsldup	%ymm8, %ymm9    # ymm9 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm9, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+        vpsrlq	$0x20, %ymm7, %ymm7
+        vpblendd	$0xaa, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm8[1],ymm7[2],ymm8[3],ymm7[4],ymm8[5],ymm7[6],ymm8[7]
+        vmovsldup	%ymm6, %ymm7    # ymm7 = ymm6[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vmovsldup	%ymm4, %ymm5    # ymm5 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm11, %ymm3   # ymm3 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm10, %ymm3 # ymm3 = ymm10[0],ymm3[1],ymm10[2],ymm3[3],ymm10[4],ymm3[5],ymm10[6],ymm3[7]
+        vpsrlq	$0x20, %ymm10, %ymm10
+        vpblendd	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
+        vmovdqa	0x1a0(%rsi), %ymm1
+        vmovdqa	0x640(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm9, %ymm12
+        vpaddd	%ymm5, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm8, %ymm12
+        vpaddd	%ymm4, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm7, %ymm12
+        vpaddd	%ymm3, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm6, %ymm12
+        vpaddd	%ymm11, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vmovdqa	0x220(%rsi), %ymm1
+        vmovdqa	0x6c0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm9, %ymm12
+        vpaddd	%ymm7, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm8, %ymm12
+        vpaddd	%ymm6, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vmovdqa	0x2a0(%rsi), %ymm1
+        vmovdqa	0x740(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm5, %ymm12
+        vpaddd	%ymm3, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm4, %ymm12
+        vpaddd	%ymm11, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vmovdqa	0x320(%rsi), %ymm1
+        vmovdqa	0x7c0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm9, %ymm12
+        vpaddd	%ymm8, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	0x3a0(%rsi), %ymm1
+        vmovdqa	0x840(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm7, %ymm12
+        vpaddd	%ymm6, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vmovdqa	0x420(%rsi), %ymm1
+        vmovdqa	0x8c0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm5, %ymm12
+        vpaddd	%ymm4, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vmovdqa	0x4a0(%rsi), %ymm1
+        vmovdqa	0x940(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm3, %ymm12
+        vpaddd	%ymm11, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vmovdqa	%ymm9, (%rdi)
+        vmovdqa	%ymm8, 0x20(%rdi)
+        vmovdqa	%ymm7, 0x40(%rdi)
+        vmovdqa	%ymm6, 0x60(%rdi)
+        vmovdqa	%ymm5, 0x80(%rdi)
+        vmovdqa	%ymm4, 0xa0(%rdi)
+        vmovdqa	%ymm3, 0xc0(%rdi)
+        vmovdqa	%ymm11, 0xe0(%rdi)
+        vmovdqa	0x100(%rdi), %ymm4
+        vmovdqa	0x120(%rdi), %ymm5
+        vmovdqa	0x140(%rdi), %ymm6
+        vmovdqa	0x160(%rdi), %ymm7
+        vmovdqa	0x180(%rdi), %ymm8
+        vmovdqa	0x1a0(%rdi), %ymm9
+        vmovdqa	0x1c0(%rdi), %ymm10
+        vmovdqa	0x1e0(%rdi), %ymm11
+        vpbroadcastd	0x94(%rsi), %ymm1
+        vpbroadcastd	0x534(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vperm2i128	$0x20, %ymm8, %ymm4, %ymm3 # ymm3 = ymm4[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm4, %ymm8 # ymm8 = ymm4[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm5, %ymm4 # ymm4 = ymm5[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm5, %ymm9 # ymm9 = ymm5[2,3],ymm9[2,3]
+        vperm2i128	$0x20, %ymm10, %ymm6, %ymm5 # ymm5 = ymm6[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm6, %ymm10 # ymm10 = ymm6[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm7, %ymm6 # ymm6 = ymm7[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm7, %ymm11 # ymm11 = ymm7[2,3],ymm11[2,3]
+        vmovdqa	0xc0(%rsi), %ymm1
+        vmovdqa	0x560(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm3, %ymm12
+        vpaddd	%ymm5, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpunpcklqdq	%ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[0],ymm3[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm3, %ymm5 # ymm5 = ymm3[1],ymm5[1],ymm3[3],ymm5[3]
+        vpunpcklqdq	%ymm10, %ymm8, %ymm3 # ymm3 = ymm8[0],ymm10[0],ymm8[2],ymm10[2]
+        vpunpckhqdq	%ymm10, %ymm8, %ymm10 # ymm10 = ymm8[1],ymm10[1],ymm8[3],ymm10[3]
+        vpunpcklqdq	%ymm6, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm6[0],ymm4[2],ymm6[2]
+        vpunpckhqdq	%ymm6, %ymm4, %ymm6 # ymm6 = ymm4[1],ymm6[1],ymm4[3],ymm6[3]
+        vpunpcklqdq	%ymm11, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm11[0],ymm9[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm9, %ymm11 # ymm11 = ymm9[1],ymm11[1],ymm9[3],ymm11[3]
+        vmovdqa	0x140(%rsi), %ymm1
+        vmovdqa	0x5e0(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm7, %ymm12
+        vpaddd	%ymm8, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm5, %ymm12
+        vpaddd	%ymm6, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm3, %ymm12
+        vpaddd	%ymm4, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm10, %ymm12
+        vpaddd	%ymm11, %ymm10, %ymm10
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm10, %ymm10
+        vmovsldup	%ymm8, %ymm9    # ymm9 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm9, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+        vpsrlq	$0x20, %ymm7, %ymm7
+        vpblendd	$0xaa, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm8[1],ymm7[2],ymm8[3],ymm7[4],ymm8[5],ymm7[6],ymm8[7]
+        vmovsldup	%ymm6, %ymm7    # ymm7 = ymm6[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vmovsldup	%ymm4, %ymm5    # ymm5 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm11, %ymm3   # ymm3 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm10, %ymm3 # ymm3 = ymm10[0],ymm3[1],ymm10[2],ymm3[3],ymm10[4],ymm3[5],ymm10[6],ymm3[7]
+        vpsrlq	$0x20, %ymm10, %ymm10
+        vpblendd	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
+        vmovdqa	0x1c0(%rsi), %ymm1
+        vmovdqa	0x660(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm9, %ymm12
+        vpaddd	%ymm5, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm8, %ymm12
+        vpaddd	%ymm4, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm7, %ymm12
+        vpaddd	%ymm3, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm6, %ymm12
+        vpaddd	%ymm11, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vmovdqa	0x240(%rsi), %ymm1
+        vmovdqa	0x6e0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm9, %ymm12
+        vpaddd	%ymm7, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm8, %ymm12
+        vpaddd	%ymm6, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vmovdqa	0x2c0(%rsi), %ymm1
+        vmovdqa	0x760(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm5, %ymm12
+        vpaddd	%ymm3, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm4, %ymm12
+        vpaddd	%ymm11, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vmovdqa	0x340(%rsi), %ymm1
+        vmovdqa	0x7e0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm9, %ymm12
+        vpaddd	%ymm8, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	0x3c0(%rsi), %ymm1
+        vmovdqa	0x860(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm7, %ymm12
+        vpaddd	%ymm6, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vmovdqa	0x440(%rsi), %ymm1
+        vmovdqa	0x8e0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm5, %ymm12
+        vpaddd	%ymm4, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vmovdqa	0x4c0(%rsi), %ymm1
+        vmovdqa	0x960(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm3, %ymm12
+        vpaddd	%ymm11, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vmovdqa	%ymm9, 0x100(%rdi)
+        vmovdqa	%ymm8, 0x120(%rdi)
+        vmovdqa	%ymm7, 0x140(%rdi)
+        vmovdqa	%ymm6, 0x160(%rdi)
+        vmovdqa	%ymm5, 0x180(%rdi)
+        vmovdqa	%ymm4, 0x1a0(%rdi)
+        vmovdqa	%ymm3, 0x1c0(%rdi)
+        vmovdqa	%ymm11, 0x1e0(%rdi)
+        vmovdqa	0x200(%rdi), %ymm4
+        vmovdqa	0x220(%rdi), %ymm5
+        vmovdqa	0x240(%rdi), %ymm6
+        vmovdqa	0x260(%rdi), %ymm7
+        vmovdqa	0x280(%rdi), %ymm8
+        vmovdqa	0x2a0(%rdi), %ymm9
+        vmovdqa	0x2c0(%rdi), %ymm10
+        vmovdqa	0x2e0(%rdi), %ymm11
+        vpbroadcastd	0x98(%rsi), %ymm1
+        vpbroadcastd	0x538(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vperm2i128	$0x20, %ymm8, %ymm4, %ymm3 # ymm3 = ymm4[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm4, %ymm8 # ymm8 = ymm4[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm5, %ymm4 # ymm4 = ymm5[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm5, %ymm9 # ymm9 = ymm5[2,3],ymm9[2,3]
+        vperm2i128	$0x20, %ymm10, %ymm6, %ymm5 # ymm5 = ymm6[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm6, %ymm10 # ymm10 = ymm6[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm7, %ymm6 # ymm6 = ymm7[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm7, %ymm11 # ymm11 = ymm7[2,3],ymm11[2,3]
+        vmovdqa	0xe0(%rsi), %ymm1
+        vmovdqa	0x580(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm3, %ymm12
+        vpaddd	%ymm5, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpunpcklqdq	%ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[0],ymm3[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm3, %ymm5 # ymm5 = ymm3[1],ymm5[1],ymm3[3],ymm5[3]
+        vpunpcklqdq	%ymm10, %ymm8, %ymm3 # ymm3 = ymm8[0],ymm10[0],ymm8[2],ymm10[2]
+        vpunpckhqdq	%ymm10, %ymm8, %ymm10 # ymm10 = ymm8[1],ymm10[1],ymm8[3],ymm10[3]
+        vpunpcklqdq	%ymm6, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm6[0],ymm4[2],ymm6[2]
+        vpunpckhqdq	%ymm6, %ymm4, %ymm6 # ymm6 = ymm4[1],ymm6[1],ymm4[3],ymm6[3]
+        vpunpcklqdq	%ymm11, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm11[0],ymm9[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm9, %ymm11 # ymm11 = ymm9[1],ymm11[1],ymm9[3],ymm11[3]
+        vmovdqa	0x160(%rsi), %ymm1
+        vmovdqa	0x600(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm7, %ymm12
+        vpaddd	%ymm8, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm5, %ymm12
+        vpaddd	%ymm6, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm3, %ymm12
+        vpaddd	%ymm4, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm10, %ymm12
+        vpaddd	%ymm11, %ymm10, %ymm10
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm10, %ymm10
+        vmovsldup	%ymm8, %ymm9    # ymm9 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm9, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+        vpsrlq	$0x20, %ymm7, %ymm7
+        vpblendd	$0xaa, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm8[1],ymm7[2],ymm8[3],ymm7[4],ymm8[5],ymm7[6],ymm8[7]
+        vmovsldup	%ymm6, %ymm7    # ymm7 = ymm6[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vmovsldup	%ymm4, %ymm5    # ymm5 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm11, %ymm3   # ymm3 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm10, %ymm3 # ymm3 = ymm10[0],ymm3[1],ymm10[2],ymm3[3],ymm10[4],ymm3[5],ymm10[6],ymm3[7]
+        vpsrlq	$0x20, %ymm10, %ymm10
+        vpblendd	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
+        vmovdqa	0x1e0(%rsi), %ymm1
+        vmovdqa	0x680(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm9, %ymm12
+        vpaddd	%ymm5, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm8, %ymm12
+        vpaddd	%ymm4, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm7, %ymm12
+        vpaddd	%ymm3, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm6, %ymm12
+        vpaddd	%ymm11, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vmovdqa	0x260(%rsi), %ymm1
+        vmovdqa	0x700(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm9, %ymm12
+        vpaddd	%ymm7, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm8, %ymm12
+        vpaddd	%ymm6, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vmovdqa	0x2e0(%rsi), %ymm1
+        vmovdqa	0x780(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm5, %ymm12
+        vpaddd	%ymm3, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm4, %ymm12
+        vpaddd	%ymm11, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vmovdqa	0x360(%rsi), %ymm1
+        vmovdqa	0x800(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm9, %ymm12
+        vpaddd	%ymm8, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	0x3e0(%rsi), %ymm1
+        vmovdqa	0x880(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm7, %ymm12
+        vpaddd	%ymm6, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vmovdqa	0x460(%rsi), %ymm1
+        vmovdqa	0x900(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm5, %ymm12
+        vpaddd	%ymm4, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vmovdqa	0x4e0(%rsi), %ymm1
+        vmovdqa	0x980(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm3, %ymm12
+        vpaddd	%ymm11, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vmovdqa	%ymm9, 0x200(%rdi)
+        vmovdqa	%ymm8, 0x220(%rdi)
+        vmovdqa	%ymm7, 0x240(%rdi)
+        vmovdqa	%ymm6, 0x260(%rdi)
+        vmovdqa	%ymm5, 0x280(%rdi)
+        vmovdqa	%ymm4, 0x2a0(%rdi)
+        vmovdqa	%ymm3, 0x2c0(%rdi)
+        vmovdqa	%ymm11, 0x2e0(%rdi)
+        vmovdqa	0x300(%rdi), %ymm4
+        vmovdqa	0x320(%rdi), %ymm5
+        vmovdqa	0x340(%rdi), %ymm6
+        vmovdqa	0x360(%rdi), %ymm7
+        vmovdqa	0x380(%rdi), %ymm8
+        vmovdqa	0x3a0(%rdi), %ymm9
+        vmovdqa	0x3c0(%rdi), %ymm10
+        vmovdqa	0x3e0(%rdi), %ymm11
+        vpbroadcastd	0x9c(%rsi), %ymm1
+        vpbroadcastd	0x53c(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm4, %ymm12
+        vpaddd	%ymm8, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm9, %ymm13
+        vmovshdup	%ymm9, %ymm12   # ymm12 = ymm9[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm9, %ymm9
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm9, %ymm9    # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+        vpsubd	%ymm9, %ymm5, %ymm12
+        vpaddd	%ymm9, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm9
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm6, %ymm12
+        vpaddd	%ymm10, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm7, %ymm12
+        vpaddd	%ymm11, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vperm2i128	$0x20, %ymm8, %ymm4, %ymm3 # ymm3 = ymm4[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm4, %ymm8 # ymm8 = ymm4[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm5, %ymm4 # ymm4 = ymm5[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm5, %ymm9 # ymm9 = ymm5[2,3],ymm9[2,3]
+        vperm2i128	$0x20, %ymm10, %ymm6, %ymm5 # ymm5 = ymm6[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm6, %ymm10 # ymm10 = ymm6[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm7, %ymm6 # ymm6 = ymm7[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm7, %ymm11 # ymm11 = ymm7[2,3],ymm11[2,3]
+        vmovdqa	0x100(%rsi), %ymm1
+        vmovdqa	0x5a0(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm3, %ymm12
+        vpaddd	%ymm5, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm10, %ymm13
+        vmovshdup	%ymm10, %ymm12  # ymm12 = ymm10[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm10, %ymm10
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm10, %ymm10  # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm12[1],ymm10[2],ymm12[3],ymm10[4],ymm12[5],ymm10[6],ymm12[7]
+        vpsubd	%ymm10, %ymm8, %ymm12
+        vpaddd	%ymm10, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm10
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm4, %ymm12
+        vpaddd	%ymm6, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm9, %ymm12
+        vpaddd	%ymm11, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpunpcklqdq	%ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[0],ymm3[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm3, %ymm5 # ymm5 = ymm3[1],ymm5[1],ymm3[3],ymm5[3]
+        vpunpcklqdq	%ymm10, %ymm8, %ymm3 # ymm3 = ymm8[0],ymm10[0],ymm8[2],ymm10[2]
+        vpunpckhqdq	%ymm10, %ymm8, %ymm10 # ymm10 = ymm8[1],ymm10[1],ymm8[3],ymm10[3]
+        vpunpcklqdq	%ymm6, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm6[0],ymm4[2],ymm6[2]
+        vpunpckhqdq	%ymm6, %ymm4, %ymm6 # ymm6 = ymm4[1],ymm6[1],ymm4[3],ymm6[3]
+        vpunpcklqdq	%ymm11, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm11[0],ymm9[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm9, %ymm11 # ymm11 = ymm9[1],ymm11[1],ymm9[3],ymm11[3]
+        vmovdqa	0x180(%rsi), %ymm1
+        vmovdqa	0x620(%rsi), %ymm2
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm7, %ymm12
+        vpaddd	%ymm8, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm5, %ymm12
+        vpaddd	%ymm6, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm3, %ymm12
+        vpaddd	%ymm4, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm2, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm10, %ymm12
+        vpaddd	%ymm11, %ymm10, %ymm10
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm10, %ymm10
+        vmovsldup	%ymm8, %ymm9    # ymm9 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm9, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+        vpsrlq	$0x20, %ymm7, %ymm7
+        vpblendd	$0xaa, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm8[1],ymm7[2],ymm8[3],ymm7[4],ymm8[5],ymm7[6],ymm8[7]
+        vmovsldup	%ymm6, %ymm7    # ymm7 = ymm6[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vmovsldup	%ymm4, %ymm5    # ymm5 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm11, %ymm3   # ymm3 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm10, %ymm3 # ymm3 = ymm10[0],ymm3[1],ymm10[2],ymm3[3],ymm10[4],ymm3[5],ymm10[6],ymm3[7]
+        vpsrlq	$0x20, %ymm10, %ymm10
+        vpblendd	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
+        vmovdqa	0x200(%rsi), %ymm1
+        vmovdqa	0x6a0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm5, %ymm13
+        vmovshdup	%ymm5, %ymm12   # ymm12 = ymm5[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm5, %ymm5
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm5, %ymm5    # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm5, %ymm5 # ymm5 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+        vpsubd	%ymm5, %ymm9, %ymm12
+        vpaddd	%ymm5, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm5
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm8, %ymm12
+        vpaddd	%ymm4, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm7, %ymm12
+        vpaddd	%ymm3, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm6, %ymm12
+        vpaddd	%ymm11, %ymm6, %ymm6
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm6, %ymm6
+        vmovdqa	0x280(%rsi), %ymm1
+        vmovdqa	0x720(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm7, %ymm13
+        vmovshdup	%ymm7, %ymm12   # ymm12 = ymm7[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm7, %ymm7
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm7, %ymm7    # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+        vpsubd	%ymm7, %ymm9, %ymm12
+        vpaddd	%ymm7, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm7
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm8, %ymm12
+        vpaddd	%ymm6, %ymm8, %ymm8
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm8, %ymm8
+        vmovdqa	0x300(%rsi), %ymm1
+        vmovdqa	0x7a0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm3, %ymm13
+        vmovshdup	%ymm3, %ymm12   # ymm12 = ymm3[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm3, %ymm3
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm3, %ymm3    # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+        vpsubd	%ymm3, %ymm5, %ymm12
+        vpaddd	%ymm3, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm3
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm4, %ymm12
+        vpaddd	%ymm11, %ymm4, %ymm4
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm4, %ymm4
+        vmovdqa	0x380(%rsi), %ymm1
+        vmovdqa	0x820(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm8, %ymm13
+        vmovshdup	%ymm8, %ymm12   # ymm12 = ymm8[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm8, %ymm8
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm8, %ymm8    # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm12[1],ymm8[2],ymm12[3],ymm8[4],ymm12[5],ymm8[6],ymm12[7]
+        vpsubd	%ymm8, %ymm9, %ymm12
+        vpaddd	%ymm8, %ymm9, %ymm9
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm8
+        vpsubd	%ymm13, %ymm9, %ymm9
+        vmovdqa	0x400(%rsi), %ymm1
+        vmovdqa	0x8a0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm6, %ymm13
+        vmovshdup	%ymm6, %ymm12   # ymm12 = ymm6[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm6, %ymm6
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm6, %ymm6    # ymm6 = ymm6[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+        vpsubd	%ymm6, %ymm7, %ymm12
+        vpaddd	%ymm6, %ymm7, %ymm7
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm6
+        vpsubd	%ymm13, %ymm7, %ymm7
+        vmovdqa	0x480(%rsi), %ymm1
+        vmovdqa	0x920(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm4, %ymm13
+        vmovshdup	%ymm4, %ymm12   # ymm12 = ymm4[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm4, %ymm4
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm4, %ymm4    # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm4, %ymm4 # ymm4 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+        vpsubd	%ymm4, %ymm5, %ymm12
+        vpaddd	%ymm4, %ymm5, %ymm5
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm4
+        vpsubd	%ymm13, %ymm5, %ymm5
+        vmovdqa	0x500(%rsi), %ymm1
+        vmovdqa	0x9a0(%rsi), %ymm2
+        vpsrlq	$0x20, %ymm1, %ymm10
+        vmovshdup	%ymm2, %ymm15   # ymm15 = ymm2[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm1, %ymm11, %ymm13
+        vmovshdup	%ymm11, %ymm12  # ymm12 = ymm11[1,1,3,3,5,5,7,7]
+        vpmuldq	%ymm10, %ymm12, %ymm14
+        vpmuldq	%ymm2, %ymm11, %ymm11
+        vpmuldq	%ymm15, %ymm12, %ymm12
+        vpmuldq	%ymm0, %ymm13, %ymm13
+        vpmuldq	%ymm0, %ymm14, %ymm14
+        vmovshdup	%ymm11, %ymm11  # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+        vpsubd	%ymm11, %ymm3, %ymm12
+        vpaddd	%ymm11, %ymm3, %ymm3
+        vmovshdup	%ymm13, %ymm13  # ymm13 = ymm13[1,1,3,3,5,5,7,7]
+        vpblendd	$0xaa, %ymm14, %ymm13, %ymm13 # ymm13 = ymm13[0],ymm14[1],ymm13[2],ymm14[3],ymm13[4],ymm14[5],ymm13[6],ymm14[7]
+        vpaddd	%ymm13, %ymm12, %ymm11
+        vpsubd	%ymm13, %ymm3, %ymm3
+        vmovdqa	%ymm9, 0x300(%rdi)
+        vmovdqa	%ymm8, 0x320(%rdi)
+        vmovdqa	%ymm7, 0x340(%rdi)
+        vmovdqa	%ymm6, 0x360(%rdi)
+        vmovdqa	%ymm5, 0x380(%rdi)
+        vmovdqa	%ymm4, 0x3a0(%rdi)
+        vmovdqa	%ymm3, 0x3c0(%rdi)
+        vmovdqa	%ymm11, 0x3e0(%rdi)
+        retq
+        .cfi_endproc

--- a/proofs/hol_light/x86_64/proofs/build-proof.sh
+++ b/proofs/hol_light/x86_64/proofs/build-proof.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+#
+
+#
+# Compile proof script into executable binary
+#
+
+# This file is derived from s2n-bignum's tools/build-proof.sh
+# Notable changes:
+# - Modify HOL-Light's inline_load.ml to allow for a 3rd include path,
+#   in addition to S2N_BIGNUM_DIR and HOLLIGHT_DIR
+# - Removal of s2n-bignum specific code that is not relevant for
+#   the mldsa-native proofs.
+
+ROOT="$(realpath "$(dirname "$0")"/../)"
+
+if [ "$#" -ne 3 ]; then
+  echo "${ROOT}/build-proof.sh <.ml file path> <hol.sh> <output .native path>"
+  echo "This script builds HOL Light proof using OCaml native compiler and puts the "
+  echo "output binary at <output .native path>."
+  exit 1
+fi
+
+# Return the exit code if any statement fails
+set -e
+
+ml_path="$1"
+hol_sh_cmd=$2
+output_path=$3
+output_dir=$(dirname "$output_path")
+[ -d "$output_dir" ] || mkdir -p "$output_dir"
+
+export HOLLIGHT_DIR="$(dirname ${hol_sh_cmd})"
+if [ ! -f "${HOLLIGHT_DIR}/hol_lib.cmxa" ]; then
+  echo "hol_lib.cmxa does not exist in HOLLIGHT_DIR('${HOLLIGHT_DIR}')."
+  echo "Did you compile HOL Light with HOLLIGHT_USE_MODULE set to 1?"
+  exit 1
+fi
+
+template_ml="$(mktemp).ml"
+echo "Generating a template .ml that loads the file...: ${template_ml}"
+
+(
+  echo 'let proof_start_time = Unix.time();;'
+  echo "loadt \"${ml_path}\";;"
+  echo "check_axioms ();;"
+  echo 'let proof_end_time = Unix.time();;'
+  echo 'Printf.printf "Running time: %f sec, Start unixtime: %f, End unixtime: %f\n" (proof_end_time -. proof_start_time) proof_start_time proof_end_time;;'
+) >>${template_ml}
+
+inlined_prefix="$(mktemp)"
+inlined_ml="${inlined_prefix}.ml"
+inlined_cmx="${inlined_prefix}.cmx"
+(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH=${ROOT} ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
+
+# Give a large stack size.
+OCAMLRUNPARAM=l=2000000000 \
+  ocamlopt.byte -pp "$(${hol_sh_cmd} -pp)" -I "${HOLLIGHT_DIR}" -I +unix -c \
+  hol_lib.cmxa ${inlined_ml} -o ${inlined_cmx} -w -a
+ocamlfind ocamlopt -package zarith,unix -linkpkg hol_lib.cmxa \
+  -I "${HOLLIGHT_DIR}" ${inlined_cmx} \
+  -o "${output_path}"
+
+# Remove the intermediate files to save disk space
+rm -f ${inlined_cmx} ${template_ml} ${inlined_ml}

--- a/proofs/hol_light/x86_64/proofs/dump_bytecode.ml
+++ b/proofs/hol_light/x86_64/proofs/dump_bytecode.ml
@@ -1,0 +1,10 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+needs "x86/proofs/base.ml";;
+
+print_string "=== bytecode start: mldsa/mldsa_ntt.o ================\n";;
+print_literal_from_elf "mldsa/mldsa_ntt.o";;
+print_string "==== bytecode end =====================================\n\n";;

--- a/proofs/hol_light/x86_64/proofs/mldsa_ntt.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_ntt.ml
@@ -1,0 +1,4741 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+(* ========================================================================= *)
+(* ML-DSA Forward number theoretic transform.                                *)
+(* ========================================================================= *)
+
+needs "x86/proofs/base.ml";;
+needs "proofs/mldsa_specs.ml";;
+needs "proofs/mldsa_utils.ml";;
+
+(*** print_literal_from_elf "mldsa/mldsa_ntt.o";;
+ ***)
+
+let mldsa_ntt_mc = define_assert_from_elf "mldsa_ntt_mc" "mldsa/mldsa_ntt.o"
+(*** BYTECODE START ***)
+[
+  0xf3; 0x0f; 0x1e; 0xfa;  (* ENDBR64 *)
+  0xc5; 0xfd; 0x6f; 0x06;  (* VMOVDQA (%_% ymm0) (Memop Word256 (%% (rsi,0))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x84; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,132))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x24; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1316))) *)
+  0xc5; 0xfd; 0x6f; 0x27;  (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,0))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,128))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,256))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,384))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x00; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,512))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0x80; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,640))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0x00; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,768))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0x80; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,896))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x88; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,136))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x28; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1320))) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm7) *)
+  0xc5; 0xd5; 0xfe; 0xef;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x8c; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,140))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x2c; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1324))) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x7f; 0x27;  (* VMOVDQA (Memop Word256 (%% (rdi,0))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,128))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,256))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,384))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x00; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,512))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0x80; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,640))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x00; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,768))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0x80; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,896))) (%_% ymm11) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x84; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,132))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x24; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1316))) *)
+  0xc5; 0xfd; 0x6f; 0x67; 0x20;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,32))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,160))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,288))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,416))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x20; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,544))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,672))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0x20; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,800))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xa0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,928))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x88; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,136))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x28; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1320))) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm7) *)
+  0xc5; 0xd5; 0xfe; 0xef;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x8c; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,140))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x2c; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1324))) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x7f; 0x67; 0x20;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,32))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,160))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,288))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,416))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x20; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,544))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0xa0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,672))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x20; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,800))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xa0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,928))) (%_% ymm11) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x84; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,132))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x24; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1316))) *)
+  0xc5; 0xfd; 0x6f; 0x67; 0x40;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,64))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,192))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,320))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,448))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x40; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,576))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xc0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,704))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0x40; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,832))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xc0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,960))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x88; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,136))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x28; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1320))) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm7) *)
+  0xc5; 0xd5; 0xfe; 0xef;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x8c; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,140))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x2c; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1324))) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x7f; 0x67; 0x40;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,64))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,192))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,320))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,448))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x40; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,576))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0xc0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,704))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x40; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,832))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xc0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,960))) (%_% ymm11) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x84; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,132))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x24; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1316))) *)
+  0xc5; 0xfd; 0x6f; 0x67; 0x60;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,96))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,224))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,352))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,480))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x60; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,608))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xe0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,736))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0x60; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,864))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,992))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x88; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,136))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x28; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1320))) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm7) *)
+  0xc5; 0xd5; 0xfe; 0xef;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x8c; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,140))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x2c; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1324))) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x7f; 0x67; 0x60;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,96))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,224))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,352))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,480))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x60; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,608))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0xe0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,736))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x60; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,864))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,992))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0x27;  (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,0))) *)
+  0xc5; 0xfd; 0x6f; 0x6f; 0x20;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,32))) *)
+  0xc5; 0xfd; 0x6f; 0x77; 0x40;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,64))) *)
+  0xc5; 0xfd; 0x6f; 0x7f; 0x60;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,96))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,128))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,160))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,192))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,224))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x90; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,144))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x30; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1328))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xc3; 0x5d; 0x46; 0xd8; 0x20;
+                           (* VPERM2I128 (%_% ymm3) (%_% ymm4) (%_% ymm8) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x5d; 0x46; 0xc0; 0x31;
+                           (* VPERM2I128 (%_% ymm8) (%_% ymm4) (%_% ymm8) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x55; 0x46; 0xe1; 0x20;
+                           (* VPERM2I128 (%_% ymm4) (%_% ymm5) (%_% ymm9) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x55; 0x46; 0xc9; 0x31;
+                           (* VPERM2I128 (%_% ymm9) (%_% ymm5) (%_% ymm9) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x4d; 0x46; 0xea; 0x20;
+                           (* VPERM2I128 (%_% ymm5) (%_% ymm6) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x4d; 0x46; 0xd2; 0x31;
+                           (* VPERM2I128 (%_% ymm10) (%_% ymm6) (%_% ymm10) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x45; 0x46; 0xf3; 0x20;
+                           (* VPERM2I128 (%_% ymm6) (%_% ymm7) (%_% ymm11) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x46; 0xdb; 0x31;
+                           (* VPERM2I128 (%_% ymm11) (%_% ymm7) (%_% ymm11) (Imm8 (word 49)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,160))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x40; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1344))) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0xfe; 0xdd;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xe5; 0x6c; 0xfd;  (* VPUNPCKLQDQ (%_% ymm7) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0x6d; 0xed;  (* VPUNPCKHQDQ (%_% ymm5) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0xc1; 0x3d; 0x6c; 0xda;
+                           (* VPUNPCKLQDQ (%_% ymm3) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0x6d; 0xd2;
+                           (* VPUNPCKHQDQ (%_% ymm10) (%_% ymm8) (%_% ymm10) *)
+  0xc5; 0x5d; 0x6c; 0xc6;  (* VPUNPCKLQDQ (%_% ymm8) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0x6d; 0xf6;  (* VPUNPCKHQDQ (%_% ymm6) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0xc1; 0x35; 0x6c; 0xe3;
+                           (* VPUNPCKLQDQ (%_% ymm4) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0x6d; 0xdb;
+                           (* VPUNPCKHQDQ (%_% ymm11) (%_% ymm9) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,288))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xc0; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1472))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xf8;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm6) *)
+  0xc5; 0xd5; 0xfe; 0xee;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm4) *)
+  0xc5; 0xe5; 0xfe; 0xdc;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x2d; 0xfe; 0xd3;
+                           (* VPADDD (%_% ymm10) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xd5;
+                           (* VPSUBD (%_% ymm10) (%_% ymm10) (%_% ymm13) *)
+  0xc4; 0x41; 0x7e; 0x12; 0xc8;
+                           (* VMOVSLDUP (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc9; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm7) (%_% ymm9) (Imm8 (word 170)) *)
+  0xc5; 0xc5; 0x73; 0xd7; 0x20;
+                           (* VPSRLQ (%_% ymm7) (%_% ymm7) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc0; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm7) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xfe;  (* VMOVSLDUP (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xff; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm5) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc5; 0xd5; 0x73; 0xd5; 0x20;
+                           (* VPSRLQ (%_% ymm5) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xf6; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm5) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xec;  (* VMOVSLDUP (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xed; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm3) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc5; 0xe5; 0x73; 0xd3; 0x20;
+                           (* VPSRLQ (%_% ymm3) (%_% ymm3) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm3) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xdb;
+                           (* VMOVSLDUP (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xe3; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm10) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x2d; 0x73; 0xd2; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm10) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,416))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x40; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1600))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x35; 0xfe; 0xcd;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc5; 0x3d; 0xfe; 0xc4;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0xc5; 0xfe; 0xfb;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf3;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x20; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,544))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xc0; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1728))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm7) *)
+  0xc5; 0x35; 0xfe; 0xcf;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm6) *)
+  0xc5; 0x3d; 0xfe; 0xc6;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xa0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,672))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x40; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1856))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xd5; 0xfe; 0xeb;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe3;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x20; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,800))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xc0; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1984))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xc8;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xa0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,928))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x40; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2112))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm6) *)
+  0xc5; 0xc5; 0xfe; 0xfe;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x20; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1056))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xc0; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2240))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm4) *)
+  0xc5; 0xd5; 0xfe; 0xec;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xa0; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1184))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x40; 0x09; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2368))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x65; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xc1; 0x65; 0xfe; 0xdb;
+                           (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc5; 0x7d; 0x7f; 0x0f;  (* VMOVDQA (Memop Word256 (%% (rdi,0))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x47; 0x20;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,32))) (%_% ymm8) *)
+  0xc5; 0xfd; 0x7f; 0x7f; 0x40;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,64))) (%_% ymm7) *)
+  0xc5; 0xfd; 0x7f; 0x77; 0x60;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,96))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,128))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,160))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0x9f; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,192))) (%_% ymm3) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,224))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0xa7; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,256))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,288))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,320))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,352))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,384))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,416))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,448))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,480))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x94; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,148))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x34; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1332))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xc3; 0x5d; 0x46; 0xd8; 0x20;
+                           (* VPERM2I128 (%_% ymm3) (%_% ymm4) (%_% ymm8) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x5d; 0x46; 0xc0; 0x31;
+                           (* VPERM2I128 (%_% ymm8) (%_% ymm4) (%_% ymm8) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x55; 0x46; 0xe1; 0x20;
+                           (* VPERM2I128 (%_% ymm4) (%_% ymm5) (%_% ymm9) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x55; 0x46; 0xc9; 0x31;
+                           (* VPERM2I128 (%_% ymm9) (%_% ymm5) (%_% ymm9) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x4d; 0x46; 0xea; 0x20;
+                           (* VPERM2I128 (%_% ymm5) (%_% ymm6) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x4d; 0x46; 0xd2; 0x31;
+                           (* VPERM2I128 (%_% ymm10) (%_% ymm6) (%_% ymm10) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x45; 0x46; 0xf3; 0x20;
+                           (* VPERM2I128 (%_% ymm6) (%_% ymm7) (%_% ymm11) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x46; 0xdb; 0x31;
+                           (* VPERM2I128 (%_% ymm11) (%_% ymm7) (%_% ymm11) (Imm8 (word 49)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,192))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x60; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1376))) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0xfe; 0xdd;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xe5; 0x6c; 0xfd;  (* VPUNPCKLQDQ (%_% ymm7) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0x6d; 0xed;  (* VPUNPCKHQDQ (%_% ymm5) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0xc1; 0x3d; 0x6c; 0xda;
+                           (* VPUNPCKLQDQ (%_% ymm3) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0x6d; 0xd2;
+                           (* VPUNPCKHQDQ (%_% ymm10) (%_% ymm8) (%_% ymm10) *)
+  0xc5; 0x5d; 0x6c; 0xc6;  (* VPUNPCKLQDQ (%_% ymm8) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0x6d; 0xf6;  (* VPUNPCKHQDQ (%_% ymm6) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0xc1; 0x35; 0x6c; 0xe3;
+                           (* VPUNPCKLQDQ (%_% ymm4) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0x6d; 0xdb;
+                           (* VPUNPCKHQDQ (%_% ymm11) (%_% ymm9) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,320))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xe0; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1504))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xf8;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm6) *)
+  0xc5; 0xd5; 0xfe; 0xee;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm4) *)
+  0xc5; 0xe5; 0xfe; 0xdc;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x2d; 0xfe; 0xd3;
+                           (* VPADDD (%_% ymm10) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xd5;
+                           (* VPSUBD (%_% ymm10) (%_% ymm10) (%_% ymm13) *)
+  0xc4; 0x41; 0x7e; 0x12; 0xc8;
+                           (* VMOVSLDUP (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc9; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm7) (%_% ymm9) (Imm8 (word 170)) *)
+  0xc5; 0xc5; 0x73; 0xd7; 0x20;
+                           (* VPSRLQ (%_% ymm7) (%_% ymm7) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc0; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm7) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xfe;  (* VMOVSLDUP (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xff; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm5) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc5; 0xd5; 0x73; 0xd5; 0x20;
+                           (* VPSRLQ (%_% ymm5) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xf6; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm5) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xec;  (* VMOVSLDUP (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xed; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm3) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc5; 0xe5; 0x73; 0xd3; 0x20;
+                           (* VPSRLQ (%_% ymm3) (%_% ymm3) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm3) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xdb;
+                           (* VMOVSLDUP (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xe3; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm10) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x2d; 0x73; 0xd2; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm10) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,448))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x60; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1632))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x35; 0xfe; 0xcd;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc5; 0x3d; 0xfe; 0xc4;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0xc5; 0xfe; 0xfb;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf3;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x40; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,576))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xe0; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1760))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm7) *)
+  0xc5; 0x35; 0xfe; 0xcf;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm6) *)
+  0xc5; 0x3d; 0xfe; 0xc6;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xc0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,704))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x60; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1888))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xd5; 0xfe; 0xeb;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe3;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x40; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,832))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xe0; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2016))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xc8;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xc0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,960))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x60; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2144))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm6) *)
+  0xc5; 0xc5; 0xfe; 0xfe;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x40; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1088))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xe0; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2272))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm4) *)
+  0xc5; 0xd5; 0xfe; 0xec;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xc0; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1216))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x60; 0x09; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2400))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x65; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xc1; 0x65; 0xfe; 0xdb;
+                           (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,256))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,288))) (%_% ymm8) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,320))) (%_% ymm7) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,352))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,384))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,416))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0x9f; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,448))) (%_% ymm3) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,480))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0xa7; 0x00; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,512))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0x20; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,544))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x40; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,576))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0x60; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,608))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,640))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,672))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,704))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,736))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x98; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,152))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x38; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1336))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xc3; 0x5d; 0x46; 0xd8; 0x20;
+                           (* VPERM2I128 (%_% ymm3) (%_% ymm4) (%_% ymm8) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x5d; 0x46; 0xc0; 0x31;
+                           (* VPERM2I128 (%_% ymm8) (%_% ymm4) (%_% ymm8) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x55; 0x46; 0xe1; 0x20;
+                           (* VPERM2I128 (%_% ymm4) (%_% ymm5) (%_% ymm9) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x55; 0x46; 0xc9; 0x31;
+                           (* VPERM2I128 (%_% ymm9) (%_% ymm5) (%_% ymm9) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x4d; 0x46; 0xea; 0x20;
+                           (* VPERM2I128 (%_% ymm5) (%_% ymm6) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x4d; 0x46; 0xd2; 0x31;
+                           (* VPERM2I128 (%_% ymm10) (%_% ymm6) (%_% ymm10) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x45; 0x46; 0xf3; 0x20;
+                           (* VPERM2I128 (%_% ymm6) (%_% ymm7) (%_% ymm11) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x46; 0xdb; 0x31;
+                           (* VPERM2I128 (%_% ymm11) (%_% ymm7) (%_% ymm11) (Imm8 (word 49)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,224))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x80; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1408))) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0xfe; 0xdd;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xe5; 0x6c; 0xfd;  (* VPUNPCKLQDQ (%_% ymm7) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0x6d; 0xed;  (* VPUNPCKHQDQ (%_% ymm5) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0xc1; 0x3d; 0x6c; 0xda;
+                           (* VPUNPCKLQDQ (%_% ymm3) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0x6d; 0xd2;
+                           (* VPUNPCKHQDQ (%_% ymm10) (%_% ymm8) (%_% ymm10) *)
+  0xc5; 0x5d; 0x6c; 0xc6;  (* VPUNPCKLQDQ (%_% ymm8) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0x6d; 0xf6;  (* VPUNPCKHQDQ (%_% ymm6) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0xc1; 0x35; 0x6c; 0xe3;
+                           (* VPUNPCKLQDQ (%_% ymm4) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0x6d; 0xdb;
+                           (* VPUNPCKHQDQ (%_% ymm11) (%_% ymm9) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,352))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x00; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1536))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xf8;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm6) *)
+  0xc5; 0xd5; 0xfe; 0xee;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm4) *)
+  0xc5; 0xe5; 0xfe; 0xdc;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x2d; 0xfe; 0xd3;
+                           (* VPADDD (%_% ymm10) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xd5;
+                           (* VPSUBD (%_% ymm10) (%_% ymm10) (%_% ymm13) *)
+  0xc4; 0x41; 0x7e; 0x12; 0xc8;
+                           (* VMOVSLDUP (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc9; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm7) (%_% ymm9) (Imm8 (word 170)) *)
+  0xc5; 0xc5; 0x73; 0xd7; 0x20;
+                           (* VPSRLQ (%_% ymm7) (%_% ymm7) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc0; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm7) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xfe;  (* VMOVSLDUP (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xff; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm5) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc5; 0xd5; 0x73; 0xd5; 0x20;
+                           (* VPSRLQ (%_% ymm5) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xf6; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm5) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xec;  (* VMOVSLDUP (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xed; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm3) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc5; 0xe5; 0x73; 0xd3; 0x20;
+                           (* VPSRLQ (%_% ymm3) (%_% ymm3) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm3) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xdb;
+                           (* VMOVSLDUP (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xe3; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm10) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x2d; 0x73; 0xd2; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm10) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,480))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x80; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1664))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x35; 0xfe; 0xcd;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc5; 0x3d; 0xfe; 0xc4;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0xc5; 0xfe; 0xfb;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf3;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x60; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,608))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x00; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1792))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm7) *)
+  0xc5; 0x35; 0xfe; 0xcf;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm6) *)
+  0xc5; 0x3d; 0xfe; 0xc6;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xe0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,736))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x80; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1920))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xd5; 0xfe; 0xeb;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe3;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x60; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,864))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x00; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2048))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xc8;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xe0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,992))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x80; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2176))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm6) *)
+  0xc5; 0xc5; 0xfe; 0xfe;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x60; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1120))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x00; 0x09; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2304))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm4) *)
+  0xc5; 0xd5; 0xfe; 0xec;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0xe0; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1248))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x80; 0x09; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2432))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x65; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xc1; 0x65; 0xfe; 0xdb;
+                           (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0x00; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,512))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x20; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,544))) (%_% ymm8) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0x40; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,576))) (%_% ymm7) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x60; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,608))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0x80; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,640))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0xa0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,672))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0x9f; 0xc0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,704))) (%_% ymm3) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,736))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0xa7; 0x00; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,768))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0x20; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,800))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x40; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,832))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0x60; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,864))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,896))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,928))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,960))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,992))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x8e; 0x9c; 0x00; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm1) (Memop Doubleword (%% (rsi,156))) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0x96; 0x3c; 0x05; 0x00; 0x00;
+                           (* VPBROADCASTD (%_% ymm2) (Memop Doubleword (%% (rsi,1340))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe0;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x35; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe1;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x35; 0x28; 0xca;
+                           (* VPMULDQ (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc9;
+                           (* VMOVSHDUP (%_% ymm9) (%_% ymm9) *)
+  0xc4; 0x43; 0x35; 0x02; 0xcc; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm9) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x55; 0xfa; 0xe1;
+                           (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0xc1; 0x55; 0xfe; 0xe9;
+                           (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xcd;
+                           (* VPADDD (%_% ymm9) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf2;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xfb;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0xc3; 0x5d; 0x46; 0xd8; 0x20;
+                           (* VPERM2I128 (%_% ymm3) (%_% ymm4) (%_% ymm8) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x5d; 0x46; 0xc0; 0x31;
+                           (* VPERM2I128 (%_% ymm8) (%_% ymm4) (%_% ymm8) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x55; 0x46; 0xe1; 0x20;
+                           (* VPERM2I128 (%_% ymm4) (%_% ymm5) (%_% ymm9) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x55; 0x46; 0xc9; 0x31;
+                           (* VPERM2I128 (%_% ymm9) (%_% ymm5) (%_% ymm9) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x4d; 0x46; 0xea; 0x20;
+                           (* VPERM2I128 (%_% ymm5) (%_% ymm6) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x4d; 0x46; 0xd2; 0x31;
+                           (* VPERM2I128 (%_% ymm10) (%_% ymm6) (%_% ymm10) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x45; 0x46; 0xf3; 0x20;
+                           (* VPERM2I128 (%_% ymm6) (%_% ymm7) (%_% ymm11) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x46; 0xdb; 0x31;
+                           (* VPERM2I128 (%_% ymm11) (%_% ymm7) (%_% ymm11) (Imm8 (word 49)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,256))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xa0; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1440))) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0xfe; 0xdd;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe2;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x2d; 0x28; 0xd2;
+                           (* VPMULDQ (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xd2;
+                           (* VMOVSHDUP (%_% ymm10) (%_% ymm10) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xd4; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm10) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xe2;
+                           (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0xfe; 0xc2;
+                           (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xd5;
+                           (* VPADDD (%_% ymm10) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x5d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0xfe; 0xe6;  (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xcb;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xe5; 0x6c; 0xfd;  (* VPUNPCKLQDQ (%_% ymm7) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0xe5; 0x6d; 0xed;  (* VPUNPCKHQDQ (%_% ymm5) (%_% ymm3) (%_% ymm5) *)
+  0xc4; 0xc1; 0x3d; 0x6c; 0xda;
+                           (* VPUNPCKLQDQ (%_% ymm3) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x3d; 0x6d; 0xd2;
+                           (* VPUNPCKHQDQ (%_% ymm10) (%_% ymm8) (%_% ymm10) *)
+  0xc5; 0x5d; 0x6c; 0xc6;  (* VPUNPCKLQDQ (%_% ymm8) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0xdd; 0x6d; 0xf6;  (* VPUNPCKHQDQ (%_% ymm6) (%_% ymm4) (%_% ymm6) *)
+  0xc4; 0xc1; 0x35; 0x6c; 0xe3;
+                           (* VPUNPCKLQDQ (%_% ymm4) (%_% ymm9) (%_% ymm11) *)
+  0xc4; 0x41; 0x35; 0x6d; 0xdb;
+                           (* VPUNPCKHQDQ (%_% ymm11) (%_% ymm9) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,384))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x20; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1568))) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x45; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0xc1; 0x45; 0xfe; 0xf8;
+                           (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm6) *)
+  0xc5; 0xd5; 0xfe; 0xee;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x65; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm4) *)
+  0xc5; 0xe5; 0xfe; 0xdc;  (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xf1;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm1) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x62; 0x1d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x2d; 0xfe; 0xd3;
+                           (* VPADDD (%_% ymm10) (%_% ymm10) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x2d; 0xfa; 0xd5;
+                           (* VPSUBD (%_% ymm10) (%_% ymm10) (%_% ymm13) *)
+  0xc4; 0x41; 0x7e; 0x12; 0xc8;
+                           (* VMOVSLDUP (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc9; 0xaa;
+                           (* VPBLENDD (%_% ymm9) (%_% ymm7) (%_% ymm9) (Imm8 (word 170)) *)
+  0xc5; 0xc5; 0x73; 0xd7; 0x20;
+                           (* VPSRLQ (%_% ymm7) (%_% ymm7) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x45; 0x02; 0xc0; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm7) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xfe;  (* VMOVSLDUP (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xff; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm5) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc5; 0xd5; 0x73; 0xd5; 0x20;
+                           (* VPSRLQ (%_% ymm5) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xf6; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm5) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xec;  (* VMOVSLDUP (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xed; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm3) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc5; 0xe5; 0x73; 0xd3; 0x20;
+                           (* VPSRLQ (%_% ymm3) (%_% ymm3) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm3) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xdb;
+                           (* VMOVSLDUP (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xe3; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm10) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x2d; 0x73; 0xd2; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x2d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm10) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x00; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,512))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xa0; 0x06; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1696))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x55; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe5;  (* VMOVSHDUP (%_% ymm12) (%_% ymm5) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x55; 0x28; 0xea;
+                           (* VPMULDQ (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xed;  (* VMOVSHDUP (%_% ymm5) (%_% ymm5) *)
+  0xc4; 0xc3; 0x55; 0x02; 0xec; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm5) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe5;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x35; 0xfe; 0xcd;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm5) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xed;
+                           (* VPADDD (%_% ymm5) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc5; 0x3d; 0xfe; 0xc4;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0xc5; 0xfe; 0xfb;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x4d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0xc1; 0x4d; 0xfe; 0xf3;
+                           (* VPADDD (%_% ymm6) (%_% ymm6) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x4d; 0xfa; 0xf5;
+                           (* VPSUBD (%_% ymm6) (%_% ymm6) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x80; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,640))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x20; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1824))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x45; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe7;  (* VMOVSHDUP (%_% ymm12) (%_% ymm7) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x45; 0x28; 0xfa;
+                           (* VPMULDQ (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xff;  (* VMOVSHDUP (%_% ymm7) (%_% ymm7) *)
+  0xc4; 0xc3; 0x45; 0x02; 0xfc; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm7) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x35; 0xfa; 0xe7;  (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm7) *)
+  0xc5; 0x35; 0xfe; 0xcf;  (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm7) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xfd;
+                           (* VPADDD (%_% ymm7) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x3d; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm8) (%_% ymm6) *)
+  0xc5; 0x3d; 0xfe; 0xc6;  (* VPADDD (%_% ymm8) (%_% ymm8) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x3d; 0xfa; 0xc5;
+                           (* VPSUBD (%_% ymm8) (%_% ymm8) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x00; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,768))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xa0; 0x07; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,1952))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x65; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe3;  (* VMOVSHDUP (%_% ymm12) (%_% ymm3) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x65; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm3) (%_% ymm3) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xdb;  (* VMOVSHDUP (%_% ymm3) (%_% ymm3) *)
+  0xc4; 0xc3; 0x65; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm3) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe3;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xd5; 0xfe; 0xeb;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm3) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x5d; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0xc1; 0x5d; 0xfe; 0xe3;
+                           (* VPADDD (%_% ymm4) (%_% ymm4) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x5d; 0xfa; 0xe5;
+                           (* VPSUBD (%_% ymm4) (%_% ymm4) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x80; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,896))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x20; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2080))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm8) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe0;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x3d; 0x28; 0xc2;
+                           (* VPMULDQ (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xc0;
+                           (* VMOVSHDUP (%_% ymm8) (%_% ymm8) *)
+  0xc4; 0x43; 0x3d; 0x02; 0xc4; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm8) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xe0;
+                           (* VPSUBD (%_% ymm12) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x35; 0xfe; 0xc8;
+                           (* VPADDD (%_% ymm9) (%_% ymm9) (%_% ymm8) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xc5;
+                           (* VPADDD (%_% ymm8) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0x41; 0x35; 0xfa; 0xcd;
+                           (* VPSUBD (%_% ymm9) (%_% ymm9) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x00; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1024))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xa0; 0x08; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2208))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x4d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe6;  (* VMOVSHDUP (%_% ymm12) (%_% ymm6) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x4d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xf6;  (* VMOVSHDUP (%_% ymm6) (%_% ymm6) *)
+  0xc4; 0xc3; 0x4d; 0x02; 0xf4; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm6) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x45; 0xfa; 0xe6;  (* VPSUBD (%_% ymm12) (%_% ymm7) (%_% ymm6) *)
+  0xc5; 0xc5; 0xfe; 0xfe;  (* VPADDD (%_% ymm7) (%_% ymm7) (%_% ymm6) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xf5;
+                           (* VPADDD (%_% ymm6) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x45; 0xfa; 0xfd;
+                           (* VPSUBD (%_% ymm7) (%_% ymm7) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x80; 0x04; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1152))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x20; 0x09; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2336))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x5d; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm4) (%_% ymm1) *)
+  0xc5; 0x7e; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0xe2; 0x5d; 0x28; 0xe2;
+                           (* VPMULDQ (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc5; 0xfe; 0x16; 0xe4;  (* VMOVSHDUP (%_% ymm4) (%_% ymm4) *)
+  0xc4; 0xc3; 0x5d; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm4) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc5; 0x55; 0xfa; 0xe4;  (* VPSUBD (%_% ymm12) (%_% ymm5) (%_% ymm4) *)
+  0xc5; 0xd5; 0xfe; 0xec;  (* VPADDD (%_% ymm5) (%_% ymm5) (%_% ymm4) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x1d; 0xfe; 0xe5;
+                           (* VPADDD (%_% ymm4) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x55; 0xfa; 0xed;
+                           (* VPSUBD (%_% ymm5) (%_% ymm5) (%_% ymm13) *)
+  0xc5; 0xfd; 0x6f; 0x8e; 0x00; 0x05; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,1280))) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0xa0; 0x09; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,2464))) *)
+  0xc5; 0xad; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm10) (%_% ymm1) (Imm8 (word 32)) *)
+  0xc5; 0x7e; 0x16; 0xfa;  (* VMOVSHDUP (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x62; 0x25; 0x28; 0xe9;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm11) (%_% ymm1) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xe3;
+                           (* VMOVSHDUP (%_% ymm12) (%_% ymm11) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xf2;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x62; 0x25; 0x28; 0xda;
+                           (* VPMULDQ (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x42; 0x1d; 0x28; 0xe7;
+                           (* VPMULDQ (%_% ymm12) (%_% ymm12) (%_% ymm15) *)
+  0xc4; 0x62; 0x15; 0x28; 0xe8;
+                           (* VPMULDQ (%_% ymm13) (%_% ymm13) (%_% ymm0) *)
+  0xc4; 0x62; 0x0d; 0x28; 0xf0;
+                           (* VPMULDQ (%_% ymm14) (%_% ymm14) (%_% ymm0) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xdb;
+                           (* VMOVSHDUP (%_% ymm11) (%_% ymm11) *)
+  0xc4; 0x43; 0x25; 0x02; 0xdc; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm11) (%_% ymm12) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x65; 0xfa; 0xe3;
+                           (* VPSUBD (%_% ymm12) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0xc1; 0x65; 0xfe; 0xdb;
+                           (* VPADDD (%_% ymm3) (%_% ymm3) (%_% ymm11) *)
+  0xc4; 0x41; 0x7e; 0x16; 0xed;
+                           (* VMOVSHDUP (%_% ymm13) (%_% ymm13) *)
+  0xc4; 0x43; 0x15; 0x02; 0xee; 0xaa;
+                           (* VPBLENDD (%_% ymm13) (%_% ymm13) (%_% ymm14) (Imm8 (word 170)) *)
+  0xc4; 0x41; 0x1d; 0xfe; 0xdd;
+                           (* VPADDD (%_% ymm11) (%_% ymm12) (%_% ymm13) *)
+  0xc4; 0xc1; 0x65; 0xfa; 0xdd;
+                           (* VPSUBD (%_% ymm3) (%_% ymm3) (%_% ymm13) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0x00; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,768))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x20; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,800))) (%_% ymm8) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0x40; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,832))) (%_% ymm7) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x60; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,864))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0x80; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,896))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0xa0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,928))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0x9f; 0xc0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,960))) (%_% ymm3) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x03; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,992))) (%_% ymm11) *)
+  0xc3                     (* RET *)
+];;
+(*** BYTECODE END ***)
+
+let mldsa_ntt_tmc = define_trimmed "mldsa_ntt_tmc" mldsa_ntt_mc;;
+let MLDSA_NTT_TMC_EXEC = X86_MK_CORE_EXEC_RULE mldsa_ntt_tmc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Data tables that are assumed in the precondition.                         *)
+(* ------------------------------------------------------------------------- *)
+
+(*** ML-DSA NTT zeta array: 624 elements total
+ *** - [0-31]: ML-DSA constants (q=8380417, qinv=58728449, etc.)
+ *** - [32-39]: Initial twiddle factors
+ *** - [40-367]: 4x replicated twiddles for SIMD (82 unique values × 4 copies)
+ *** - [368-623]: Final twiddle section with 2x replication (128 unique values × 2 copies)
+ *** Follows bit-reversed indexing per FIPS 204 Appendix B with AVX2 optimization
+ ***)
+let mldsa_complete_qdata = define
+ `mldsa_complete_qdata:int list =
+   [
+   &8380417; &8380417; &8380417; &8380417; &8380417; &8380417; &8380417; &8380417;
+   &58728449; &58728449; &58728449; &58728449; &58728449; &58728449; &58728449; &58728449;
+   -- &8395782; -- &8395782; -- &8395782; -- &8395782; -- &8395782; -- &8395782; -- &8395782; -- &8395782;
+   &41978; &41978; &41978; &41978; &41978; &41978; &41978; &41978;
+   -- &151046689;
+   &1830765815; -- &1929875198; -- &1927777021; &1640767044; &1477910808; &1612161320; &1640734244; &308362795;
+   &308362795; &308362795; &308362795; -- &1815525077; -- &1815525077; -- &1815525077; -- &1815525077;
+   -- &1374673747; -- &1374673747; -- &1374673747; -- &1374673747; -- &1091570561; -- &1091570561; -- &1091570561;
+   -- &1091570561; -- &1929495947; -- &1929495947; -- &1929495947; -- &1929495947; &515185417; &515185417;
+   &515185417; &515185417; -- &285697463; -- &285697463; -- &285697463; -- &285697463; &625853735; &625853735;
+   &625853735; &625853735; &1727305304; &1727305304; &2082316400; &2082316400; -- &1364982364; -- &1364982364;
+   &858240904; &858240904; &1806278032; &1806278032; &222489248; &222489248; -- &346752664; -- &346752664;
+   &684667771; &684667771; &1654287830; &1654287830; -- &878576921; -- &878576921; -- &1257667337; -- &1257667337;
+   -- &748618600; -- &748618600; &329347125; &329347125; &1837364258; &1837364258; -- &1443016191; -- &1443016191;
+   -- &1170414139; -- &1170414139; -- &1846138265; -- &1631226336; -- &1404529459; &1838055109; &1594295555;
+   -- &1076973524; -- &1898723372; -- &594436433; -- &202001019; -- &475984260; -- &561427818; &1797021249;
+   -- &1061813248; &2059733581; -- &1661512036; -- &1104976547; -- &1750224323; -- &901666090; &418987550;
+   &1831915353; -- &1925356481; &992097815; &879957084; &2024403852; &1484874664; -- &1636082790; -- &285388938;
+   -- &1983539117; -- &1495136972; -- &950076368; -- &1714807468; -- &952438995; -- &1574918427; &1350681039;
+   -- &2143979939; &1599739335; -- &1285853323; -- &993005454; -- &1440787840; &568627424; -- &783134478;
+   -- &588790216; &289871779; -- &1262003603; &2135294594; -- &1018755525; -- &889861155; &1665705315; &1321868265;
+   &1225434135; -- &1784632064; &666258756; &675310538; -- &1555941048; -- &1999506068; -- &1499481951;
+   -- &695180180; -- &1375177022; &1777179795; &334803717; -- &178766299; -- &518252220; &1957047970; &1146323031;
+   -- &654783359; -- &1974159335; &1651689966; &140455867; -- &1039411342; &1955560694; &1529189038;
+   -- &2131021878; -- &247357819; &1518161567; -- &86965173; &1708872713; &1787797779; &1638590967; -- &120646188;
+   -- &1669960606; -- &916321552; &1155548552; &2143745726; &1210558298; -- &1261461890; -- &318346816; &628664287;
+   -- &1729304568; &1422575624; &1424130038; -- &1185330464; &235321234; &168022240; &1206536194; &985155484;
+   -- &894060583; -- &898413; -- &1363460238; -- &605900043; &2027833504; &14253662; &1014493059; &863641633;
+   &1819892093; &2124962073; -- &1223601433; -- &1920467227; -- &1637785316; -- &1536588520; &694382729;
+   &235104446; -- &1045062172; &831969619; -- &300448763; &756955444; -- &260312805; &1554794072; &1339088280;
+   -- &2040058690; -- &853476187; -- &2047270596; -- &1723816713; -- &1591599803; -- &440824168; &1119856484;
+   &1544891539; &155290192; -- &973777462; &991903578; &912367099; -- &44694137; &1176904444; -- &421552614;
+   -- &818371958; &1747917558; -- &325927722; &908452108; &1851023419; -- &1176751719; -- &1354528380; -- &72690498;
+   -- &314284737; &985022747; &963438279; -- &1078959975; &604552167; -- &1021949428; &608791570; &173440395;
+   -- &2126092136; -- &1316619236; -- &1039370342; &6087993; -- &110126092; &565464272; -- &1758099917; -- &1600929361;
+   &879867909; -- &1809756372; &400711272; &1363007700; &30313375; -- &326425360; &1683520342; -- &517299994;
+   &2027935492; -- &1372618620; &128353682; -- &1123881663; &137583815; -- &635454918; -- &642772911; &45766801;
+   &671509323; -- &2070602178; &419615363; &1216882040; -- &270590488; -- &1276805128; &371462360; -- &1357098057;
+   -- &384158533; &827959816; -- &596344473; &702390549; -- &279505433; -- &260424530; -- &71875110; -- &1208667171;
+   -- &1499603926; &2036925262; -- &540420426; &746144248; -- &1420958686; &2032221021; &1904936414; &1257750362;
+   &1926727420; &1931587462; &1258381762; &885133339; &1629985060; &1967222129; &6363718; -- &1287922800;
+   &1136965286; &1779436847; &1116720494; &1042326957; &1405999311; &713994583; &940195359; -- &1542497137;
+   &2061661095; -- &883155599; &1726753853; -- &1547952704; &394851342; &283780712; &776003547; &1123958025;
+   &201262505; &1934038751; &374860238;
+   -- &3975713; &25847; -- &2608894; -- &518909; &237124; -- &777960; -- &876248; &466468; &1826347; &1826347; &1826347;
+   &1826347; &2353451; &2353451; &2353451; &2353451; -- &359251; -- &359251; -- &359251; -- &359251; -- &2091905;
+   -- &2091905; -- &2091905; -- &2091905; &3119733; &3119733; &3119733; &3119733; -- &2884855; -- &2884855; -- &2884855;
+   -- &2884855; &3111497; &3111497; &3111497; &3111497; &2680103; &2680103; &2680103; &2680103; &2725464;
+   &2725464; &1024112; &1024112; -- &1079900; -- &1079900; &3585928; &3585928; -- &549488; -- &549488; -- &1119584;
+   -- &1119584; &2619752; &2619752; -- &2108549; -- &2108549; -- &2118186; -- &2118186; -- &3859737; -- &3859737;
+   -- &1399561; -- &1399561; -- &3277672; -- &3277672; &1757237; &1757237; -- &19422; -- &19422; &4010497; &4010497;
+   &280005; &280005; &2706023; &95776; &3077325; &3530437; -- &1661693; -- &3592148; -- &2537516; &3915439;
+   -- &3861115; -- &3043716; &3574422; -- &2867647; &3539968; -- &300467; &2348700; -- &539299; -- &1699267;
+   -- &1643818; &3505694; -- &3821735; &3507263; -- &2140649; -- &1600420; &3699596; &811944; &531354; &954230;
+   &3881043; &3900724; -- &2556880; &2071892; -- &2797779; -- &3930395; -- &3677745; -- &1452451; &2176455;
+   -- &1257611; -- &4083598; -- &3190144; -- &3632928; &3412210; &2147896; -- &2967645; -- &411027; -- &671102;
+   -- &22981; -- &381987; &1852771; -- &3343383; &508951; &44288; &904516; -- &3724342; &1653064; &2389356;
+   &759969; &189548; &3159746; -- &2409325; &1315589; &1285669; -- &812732; -- &3019102; -- &3628969; -- &1528703;
+   -- &3041255; &3475950; -- &1585221; &1939314; -- &1000202; -- &3157330; &126922; -- &983419; &2715295;
+   -- &3693493; -- &2477047; -- &1228525; -- &1308169; &1349076; -- &1430430; &264944; &3097992; -- &1100098;
+   &3958618; -- &8578; -- &3249728; -- &210977; -- &1316856; -- &3553272; -- &1851402; -- &177440; &1341330;
+   -- &1584928; -- &1439742; -- &3881060; &3839961; &2091667; -- &3342478; &266997; -- &3520352; &900702;
+   &495491; -- &655327; -- &3556995; &342297; &3437287; &2842341; &4055324; -- &3767016; -- &2994039; -- &1333058;
+   -- &451100; -- &1279661; &1500165; -- &542412; -- &2584293; -- &2013608; &1957272; -- &3183426; &810149;
+   -- &3038916; &2213111; -- &426683; -- &1667432; -- &2939036; &183443; -- &554416; &3937738; &3407706;
+   &2244091; &2434439; -- &3759364; &1859098; -- &1613174; -- &3122442; -- &525098; &286988; -- &3342277;
+   &2691481; &1247620; &1250494; &1869119; &1237275; &1312455; &1917081; &777191; -- &2831860; -- &3724270;
+   &2432395; &3369112; &162844; &1652634; &3523897; -- &975884; &1723600; -- &1104333; -- &2235985; -- &976891;
+   &3919660; &1400424; &2316500; -- &2446433; -- &1235728; -- &1197226; &909542; -- &43260; &2031748; -- &768622;
+   -- &2437823; &1735879; -- &2590150; &2486353; &2635921; &1903435; -- &3318210; &3306115; -- &2546312;
+   &2235880; -- &1671176; &594136; &2454455; &185531; &1616392; -- &3694233; &3866901; &1717735; -- &1803090;
+   -- &260646; -- &420899; &1612842; -- &48306; -- &846154; &3817976; -- &3562462; &3513181; -- &3193378;
+   &819034; -- &522500; &3207046; -- &3595838; &4108315; &203044; &1265009; &1595974; -- &3548272; -- &1050970;
+   -- &1430225; -- &1962642; -- &1374803; &3406031; -- &1846953; -- &3776993; -- &164721; -- &1207385; &3014001;
+   -- &1799107; &269760; &472078; &1910376; -- &3833893; -- &2286327; -- &3545687; -- &1362209; &1976782
+   ]`;;
+
+(* ------------------------------------------------------------------------- *)
+(* Correctness proof.                                                        *)
+(* ------------------------------------------------------------------------- *)
+
+(***
+ *** Currently, there is a discrepency when compiling the asmb on x86 machines vs Arm
+ *** As such, the produced mldsa_ntt_tmc has different lengths. When on ARM 0x3049
+ *** when on x86 0x3079.
+ ***)
+
+let MLDSA_NTT_CORRECT = prove
+  (`!a zetas (zetas_list:int32 list) x pc.
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc,0x3079) (a, 1024) /\
+    nonoverlapping (word pc,0x3079) (zetas, 2496) /\
+    nonoverlapping (a, 1024) (zetas, 2496)
+    ==> ensures x86
+          (\s. bytes_loaded s (word pc) (BUTLAST mldsa_ntt_tmc) /\
+              read RIP s = word pc /\
+              C_ARGUMENTS [a; zetas] s /\
+              wordlist_from_memory(zetas,624) s = MAP (iword: int -> 32 word) mldsa_complete_qdata /\
+              (!i. i < 256 ==> abs(ival(x i)) <= &8380416) /\
+              !i. i < 256
+                  ==> read(memory :> bytes32(word_add a (word(4 * i)))) s =
+                      x i)
+          (\s. read RIP s = word(pc + 0x3078) /\
+              (!i. i < 256
+                        ==> let zi =
+                      read(memory :> bytes32(word_add a (word(4 * i)))) s in
+                      (ival zi == mldsa_forward_ntt (ival o x) i) (mod &8380417) /\
+                      abs(ival zi) <= &42035261))
+          (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+          MAYCHANGE [ZMM0; ZMM1; ZMM4; ZMM5; ZMM6; ZMM7; ZMM8; ZMM9; ZMM10; ZMM11; ZMM12; ZMM13; ZMM14; ZMM15] ,,
+          MAYCHANGE [RAX] ,, MAYCHANGE SOME_FLAGS ,,
+          MAYCHANGE [memory :> bytes(a,1024)])`,
+
+(*** Setup - introduce variables and break down assumptions ***)
+  MAP_EVERY X_GEN_TAC
+   [`a:int64`; `zetas:int64`; `zetas_list:int32 list`; `x:num->int32`; `pc:num`] THEN
+  REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
+              NONOVERLAPPING_CLAUSES; ALL] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+(*** Pull out the bounds assumption since we don't need to expand it
+ *** until much later, and it keeps things a bit smaller and simpler
+ ***)
+
+  GLOBALIZE_PRECONDITION_TAC THEN
+
+(*** But do expand all the input[i] = x i assumptions ***)
+
+  CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
+  CONV_TAC NUM_REDUCE_CONV THEN
+  REPEAT STRIP_TAC THEN
+
+  REWRITE_TAC [SOME_FLAGS; fst MLDSA_NTT_TMC_EXEC] THEN
+
+  GHOST_INTRO_TAC `init_ymm0:int256` `read YMM0` THEN
+  GHOST_INTRO_TAC `init_ymm1:int256` `read YMM1` THEN
+  GHOST_INTRO_TAC `init_ymm2:int256` `read YMM2` THEN
+
+  ENSURES_INIT_TAC "s0" THEN
+
+(*** First restructure all the loads from the a pointer ***)
+
+  MP_TAC(end_itlist CONJ (map (fun n ->
+    READ_MEMORY_MERGE_CONV 3 (subst[mk_small_numeral(32*n),`n:num`]
+      `read (memory :> bytes256(word_add a (word n))) s0`)) (0--31))) THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN
+  DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes32 a) s = x`] THEN
+  CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
+
+(*** Expand the qdata table ***)
+
+  FIRST_X_ASSUM(MP_TAC o CONV_RULE (LAND_CONV WORDLIST_FROM_MEMORY_CONV)) THEN
+  REWRITE_TAC[mldsa_complete_qdata; MAP; CONS_11] THEN
+  STRIP_TAC THEN
+
+(*** Restructure zeta entries, as before but with WORD_REDUCE_CONV to simplify ***)
+
+  MP_TAC(end_itlist CONJ (map (fun n ->
+    READ_MEMORY_MERGE_CONV 3 (subst[mk_small_numeral(32*n),`n:num`]
+      `read (memory :> bytes256(word_add zetas (word n))) s0`)) (0--77))) THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN
+  DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes32 a) s = x`] THEN
+  CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
+
+(*** We've thrown away some of the 32-bit words that are used in
+ *** broadcast instructions. We could have written a more refined
+ *** alternative to DISCARD_MATCHING_ASSUMPTIONS above.
+ *** But here we just recreate them: select the two memory
+ *** assumptions we want to break apart, then split them up.
+ ***)
+
+  FIRST_ASSUM(MP_TAC o check
+   (can (term_match [] `read (memory :> bytes256 (word_add zetas (word 128))) s0 = xxx`) o concl)) THEN
+  FIRST_ASSUM(MP_TAC o check
+   (can (term_match [] `read (memory :> bytes256 (word_add zetas (word 1312))) s0 = xxx`) o concl)) THEN
+  REPLICATE_TAC 2
+   (CONV_TAC(LAND_CONV(READ_MEMORY_SPLIT_CONV 3)) THEN
+    CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC) THEN
+
+(*** Do the entire simulation (very slow!) ****)
+
+  MAP_EVERY (fun n -> X86_STEPS_TAC MLDSA_NTT_TMC_EXEC [n] THEN
+                      SIMD_SIMPLIFY_TAC[mldsa_montmul; WORD_ADD_MLDSA_MONTMUL;
+                      WORD_ADD_MLDSA_MONTMUL_ALT; WORD_SUB_MLDSA_MONTMUL])
+        (1--2337) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+
+(**** Reverse the restructuring by splitting the 256-bit words up ***)
+
+  REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
+    CONV_RULE(SIMD_SIMPLIFY_CONV[]) o
+    CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
+    check (can (term_match [] `read qqq s:int256 = xxx`) o concl))) THEN
+
+(*** Expand the cases in the conclusion (leave the let-terms for now)***)
+
+  CONV_TAC EXPAND_CASES_CONV THEN
+  CONV_TAC(ONCE_DEPTH_CONV NUM_MULT_CONV) THEN
+  REWRITE_TAC[INT_ABS_BOUNDS; WORD_ADD_0] THEN
+
+(*** Rewrite with assumptions then throw them away ***)
+
+  ASM_REWRITE_TAC[] THEN DISCARD_STATE_TAC "s2337" THEN
+
+(*** Remove one other non-arithmetical oddity ***)
+
+  REWRITE_TAC[WORD_BLAST `word_subword (x:int64) (0,64) = x`] THEN
+  REWRITE_TAC[WORD_BLAST
+   `word_subword (word_ushr (word_join (h:int32) (l:int32):int64) 32) (0,32) =
+    h`] THEN
+
+(*** Try splitting into 256 subgoals and applying CONGBOUND ***)
+
+  CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
+  REWRITE_TAC[GSYM CONJ_ASSOC] THEN
+  REPEAT(GEN_REWRITE_TAC I
+   [TAUT `p /\ q /\ r /\ s <=> (p /\ q /\ r) /\ s`] THEN CONJ_TAC) THEN
+  FIRST_X_ASSUM(MP_TAC o CONV_RULE EXPAND_CASES_CONV) THEN
+  POP_ASSUM_LIST(K ALL_TAC) THEN
+  DISCH_THEN(fun aboth ->
+    W(MP_TAC o GEN_CONGBOUND_RULE (CONJUNCTS aboth) o
+      rand o lhand o rator o lhand o snd)) THEN
+  (MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
+   [REWRITE_TAC[INVERSE_MOD_CONV `inverse_mod 8380417 4294967296`] THEN
+    MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
+    CONV_TAC(ONCE_DEPTH_CONV MLDSA_FORWARD_NTT_CONV) THEN
+    REWRITE_TAC[GSYM INT_REM_EQ; o_THM] THEN CONV_TAC INT_REM_DOWN_CONV THEN
+    REWRITE_TAC[INT_REM_EQ] THEN
+    REWRITE_TAC[REAL_INT_CONGRUENCE; INT_OF_NUM_EQ; ARITH_EQ] THEN
+    REWRITE_TAC[GSYM REAL_OF_INT_CLAUSES] THEN
+    CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN REAL_INTEGER_TAC;
+    MATCH_MP_TAC(INT_ARITH
+     `l':int <= l /\ u <= u'
+      ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
+    CONV_TAC INT_REDUCE_CONV]));;
+
+(* ------------------------------------------------------------------------- *)
+(* Subroutine correctness theorems.                                          *)
+(* ------------------------------------------------------------------------- *)
+
+let MLDSA_NTT_NOIBT_SUBROUTINE_CORRECT = prove
+ (`!a zetas (zetas_list:int32 list) x pc stackpointer returnaddress.
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc,LENGTH mldsa_ntt_tmc) (a, 1024) /\
+    nonoverlapping (word pc,LENGTH mldsa_ntt_tmc) (zetas, 2496) /\
+    nonoverlapping (a, 1024) (zetas, 2496) /\
+    nonoverlapping (stackpointer,8) (a, 1024) /\
+    nonoverlapping (stackpointer,8) (zetas, 2496)
+    ==> ensures x86
+          (\s. bytes_loaded s (word pc) mldsa_ntt_tmc /\
+              read RIP s = word pc /\
+              read RSP s = stackpointer /\
+              read (memory :> bytes64 stackpointer) s = returnaddress /\
+              C_ARGUMENTS [a; zetas] s /\
+              wordlist_from_memory(zetas,624) s = MAP (iword: int -> 32 word) mldsa_complete_qdata /\
+              (!i. i < 256 ==> abs(ival(x i)) <= &8380416) /\
+              !i. i < 256
+                  ==> read(memory :> bytes32(word_add a (word(4 * i)))) s =
+                      x i)
+          (\s. read RIP s = returnaddress /\
+              read RSP s = word_add stackpointer (word 8) /\
+              (!i. i < 256
+                        ==> let zi =
+                      read(memory :> bytes32(word_add a (word(4 * i)))) s in
+                      (ival zi == mldsa_forward_ntt (ival o x) i) (mod &8380417) /\
+                      abs(ival zi) <= &42035261))
+          (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+          MAYCHANGE [memory :> bytes(a,1024)])`,
+  let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
+  CONV_TAC TWEAK_CONV THEN
+  X86_PROMOTE_RETURN_NOSTACK_TAC mldsa_ntt_tmc (CONV_RULE TWEAK_CONV MLDSA_NTT_CORRECT));;
+
+let MLDSA_NTT_SUBROUTINE_CORRECT = prove
+ (`!a zetas (zetas_list:int32 list) x pc stackpointer returnaddress.
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc,LENGTH mldsa_ntt_mc) (a, 1024) /\
+    nonoverlapping (word pc,LENGTH mldsa_ntt_mc) (zetas, 2496) /\
+    nonoverlapping (a, 1024) (zetas, 2496) /\
+    nonoverlapping (stackpointer,8) (a, 1024) /\
+    nonoverlapping (stackpointer,8) (zetas, 2496)
+    ==> ensures x86
+          (\s. bytes_loaded s (word pc) mldsa_ntt_mc /\
+              read RIP s = word pc /\
+              read RSP s = stackpointer /\
+              read (memory :> bytes64 stackpointer) s = returnaddress /\
+              C_ARGUMENTS [a; zetas] s /\
+              wordlist_from_memory(zetas,624) s = MAP (iword: int -> 32 word) mldsa_complete_qdata /\
+              (!i. i < 256 ==> abs(ival(x i)) <= &8380416) /\
+              !i. i < 256
+                  ==> read(memory :> bytes32(word_add a (word(4 * i)))) s =
+                      x i)
+          (\s. read RIP s = returnaddress /\
+              read RSP s = word_add stackpointer (word 8) /\
+              (!i. i < 256
+                        ==> let zi =
+                      read(memory :> bytes32(word_add a (word(4 * i)))) s in
+                      (ival zi == mldsa_forward_ntt (ival o x) i) (mod &8380417) /\
+                      abs(ival zi) <= &42035261))
+          (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+          MAYCHANGE [memory :> bytes(a,1024)])`,
+  let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
+  CONV_TAC TWEAK_CONV THEN
+  MATCH_ACCEPT_TAC(ADD_IBT_RULE
+  (CONV_RULE TWEAK_CONV MLDSA_NTT_NOIBT_SUBROUTINE_CORRECT)));;

--- a/proofs/hol_light/x86_64/proofs/mldsa_specs.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_specs.ml
@@ -1,0 +1,597 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+(* ========================================================================= *)
+(* Common specifications and tactics for ML-DSA, mainly related to the NTT.  *)
+(* ========================================================================= *)
+
+needs "Library/words.ml";;
+needs "Library/isum.ml";;
+
+(* ------------------------------------------------------------------------- *)
+(* The pure forms of forward and inverse NTT with no reordering.             *)
+(* ------------------------------------------------------------------------- *)
+
+let pure_forward_ntt_mldsa = define
+ `pure_forward_ntt_mldsa f k =
+    isum (0..127) (\j. f(2 * j + k MOD 2) *
+                       &1753 pow ((2 * k DIV 2 + 1) * j))
+    rem &8380417`;;
+
+(* ------------------------------------------------------------------------- *)
+(* Bit-reversing order as used in the standard/default order.                *)
+(* ------------------------------------------------------------------------- *)
+
+let bitreverse8 = define
+ `bitreverse8(n) = val(word_reversefields 1 (word n:8 word))`;;
+
+(* ------------------------------------------------------------------------- *)
+(* AVX2-optimized ordering for ML-DSA NTT (swaps bit fields then reverses)   *)
+(* ------------------------------------------------------------------------- *)
+
+let avx2_ntt_order = define
+ `avx2_ntt_order i = 
+    bitreverse8(64 * (i DIV 64) + ((i MOD 64) DIV 8) + 8 * (i MOD 8))`;;
+
+(* ------------------------------------------------------------------------- *)
+(* Conversion of each element of an array to Montgomery form with B = 2^16.  *)
+(* ------------------------------------------------------------------------- *)
+
+let tomont_8380417 = define
+ `tomont_8380417 (a:num->int) = \i. (&2 pow 32 * a i) rem &8380417`;;
+
+(* ------------------------------------------------------------------------- *)
+(* The precise specs of the actual x86 code.                                 *)
+(* ------------------------------------------------------------------------- *)
+
+let mldsa_forward_ntt = define
+ `mldsa_forward_ntt f k =
+    isum (0..255) (\j. f j * &1753 pow ((2 * avx2_ntt_order k + 1) * j))
+    rem &8380417`;;
+
+(* ------------------------------------------------------------------------- *)
+(* Show how these relate to the "pure" ones.                                 *)
+(* ------------------------------------------------------------------------- *)
+
+let MLDSA_FORWARD_NTT = prove
+ (`mldsa_forward_ntt f k = 
+   isum (0..255) (\j. f j * &1753 pow ((2 * avx2_ntt_order k + 1) * j)) rem &8380417`,
+  REWRITE_TAC[mldsa_forward_ntt]);;
+
+(* ------------------------------------------------------------------------- *)
+(* Explicit computation rules to evaluate mod-8380417 powers less naively.   *)
+(* ------------------------------------------------------------------------- *)
+
+let BITREVERSE8_CLAUSES = end_itlist CONJ (map
+ (GEN_REWRITE_CONV I [bitreverse8] THENC DEPTH_CONV WORD_NUM_RED_CONV)
+ (map (curry mk_comb `bitreverse8` o mk_small_numeral) (0--255)));;
+
+let AVX2_NTT_ORDER_CLAUSES = end_itlist CONJ (map
+ (GEN_REWRITE_CONV I [avx2_ntt_order] THENC DEPTH_CONV WORD_NUM_RED_CONV THENC
+  GEN_REWRITE_CONV I [BITREVERSE8_CLAUSES])
+ (map (curry mk_comb `avx2_ntt_order` o mk_small_numeral) (0--255)));;
+
+let MLDSA_FORWARD_NTT_ALT = prove
+ (`mldsa_forward_ntt f k =
+   isum (0..255)
+        (\j. f j *
+             (&1753 pow ((2 * avx2_ntt_order k + 1) * j)) rem &8380417)
+    rem &8380417`,
+  REWRITE_TAC[mldsa_forward_ntt] THEN MATCH_MP_TAC
+   (REWRITE_RULE[] (ISPEC
+      `(\x y. x rem &8380417 = y rem &8380417)` ISUM_RELATED)) THEN
+  REWRITE_TAC[INT_REM_EQ; FINITE_NUMSEG; INT_CONG_ADD] THEN
+  X_GEN_TAC `i:num` THEN DISCH_TAC THEN
+  REWRITE_TAC[GSYM INT_OF_NUM_REM; GSYM INT_OF_NUM_CLAUSES;
+              GSYM INT_REM_EQ] THEN
+  CONV_TAC INT_REM_DOWN_CONV THEN
+  AP_THM_TAC THEN AP_TERM_TAC THEN CONV_TAC INT_ARITH);;
+
+let MLDSA_FORWARD_NTT_CONV =
+  GEN_REWRITE_CONV I [MLDSA_FORWARD_NTT_ALT] THENC
+  LAND_CONV EXPAND_ISUM_CONV THENC
+  DEPTH_CONV NUM_RED_CONV THENC
+  GEN_REWRITE_CONV ONCE_DEPTH_CONV [AVX2_NTT_ORDER_CLAUSES] THENC
+  DEPTH_CONV NUM_RED_CONV THENC
+  GEN_REWRITE_CONV DEPTH_CONV [INT_OF_NUM_POW; INT_OF_NUM_REM] THENC
+  ONCE_DEPTH_CONV EXP_MOD_CONV THENC INT_REDUCE_CONV;;
+
+(* ------------------------------------------------------------------------- *)
+(* Abbreviate the Barrett reduction and multiplication and Montgomery        *)
+(* reduction patterns in the code.                                           *)
+(* ------------------------------------------------------------------------- *)
+
+let mldsa_barred = define
+ `(mldsa_barred:int32->int32) x =
+  word_sub x
+   (word_mul
+    (word_ishr (word_add x (word 4194304)) 23)
+    (word 8380417))`;;
+
+let mldsa_montred = define
+   `(mldsa_montred:int64->int32) x =
+    word_subword
+     (word_add
+       (word_mul ((word_sx:int32->int64)
+                    (word_mul (word_subword x (0,32)) (word 4236238847)))
+                 (word 8380417))
+       x)
+     (32,32)`;;
+
+let mldsa_montmul = define
+ `mldsa_montmul (a:int64,b:int64) (x:int32) =
+  word_sub
+  (word_subword (word_mul (word_sx (x:int32)) a:int64) (32,32):int32)
+  (word_subword
+    (word_mul (word_sx
+      (word_subword (word_mul (word_sx (x:int32)) b:int64) (0,32):int32))
+      (word 8380417:int64))
+    (32,32))`;;
+
+let WORD_ADD_MLDSA_MONTMUL = prove
+ (`word_add y (mldsa_montmul (a,b) x) =
+   word_sub (word_add
+    (word_subword (word_mul (word_sx (x:int32)) a:int64) (32,32):int32)
+    y)
+  (word_subword
+    (word_mul (word_sx
+      (word_subword (word_mul (word_sx (x:int32)) b:int64) (0,32):int32))
+      (word 8380417:int64))
+    (32,32))`,
+  REWRITE_TAC[mldsa_montmul] THEN CONV_TAC WORD_RULE);;
+
+let WORD_SUB_MLDSA_MONTMUL = prove
+ (`word_sub y (mldsa_montmul (a,b) x) =
+  word_add (word_sub y
+        (word_subword (word_mul (word_sx (x:int32)) a:int64) (32,32):int32))
+    (word_subword
+    (word_mul (word_sx
+      (word_subword (word_mul (word_sx (x:int32)) b:int64) (0,32):int32))
+      (word 8380417:int64))
+    (32,32))`,
+  REWRITE_TAC[mldsa_montmul] THEN CONV_TAC WORD_RULE);;
+
+let WORD_ADD_MLDSA_MONTMUL_ALT = prove
+ (`word_add y (mldsa_montmul (a,b) x) =
+   word_sub (word_add y
+    (word_subword (word_mul (word_sx (x:int32)) a:int64) (32,32):int32))
+  (word_subword
+    (word_mul (word_sx
+      (word_subword (word_mul (word_sx (x:int32)) b:int64) (0,32):int32))
+      (word 8380417:int64))
+    (32,32))`,
+  REWRITE_TAC[mldsa_montmul] THEN CONV_TAC WORD_RULE);;
+
+(* ------------------------------------------------------------------------- *)
+(* From |- (x == y) (mod m) /\ P   to   |- (x == y) (mod n) /\ P             *)
+(* ------------------------------------------------------------------------- *)
+
+let WEAKEN_INTCONG_RULE =
+  let prule = (MATCH_MP o prove)
+   (`(x:int == y) (mod m) ==> !n. m rem n = &0 ==> (x == y) (mod n)`,
+    REWRITE_TAC[INT_REM_EQ_0] THEN INTEGER_TAC)
+  and conv = GEN_REWRITE_CONV I [INT_REM_ZERO; INT_REM_REFL] ORELSEC
+             INT_REM_CONV
+  and zth = REFL `&0:int` in
+  let lrule n th =
+    let th1 = SPEC (mk_intconst n) (prule th) in
+    let th2 = LAND_CONV conv (lhand(concl th1)) in
+    MP th1 (EQ_MP (SYM th2) zth) in
+  fun n th ->
+    let th1,th2 = CONJ_PAIR th in
+    CONJ (lrule n th1) th2;;
+
+(* ------------------------------------------------------------------------- *)
+(* Unify modulus and conjoin a pair of (x == y) (mod m) /\ P thoerems.       *)
+(* ------------------------------------------------------------------------- *)
+
+let UNIFY_INTCONG_RULE th1 th2 =
+  let p1 = dest_intconst (rand(rand(lhand(concl th1))))
+  and p2 = dest_intconst (rand(rand(lhand(concl th2)))) in
+  let d = gcd_num p1 p2 in
+  CONJ (WEAKEN_INTCONG_RULE d th1) (WEAKEN_INTCONG_RULE d th2);;
+
+(* ------------------------------------------------------------------------- *)
+(* Process list of inequality into standard congbounds for atomic terms.     *)
+(* ------------------------------------------------------------------------- *)
+
+let DIMINDEX_INT_REDUCE_CONV =
+  DEPTH_CONV(WORD_NUM_RED_CONV ORELSEC DIMINDEX_CONV) THENC
+  INT_REDUCE_CONV;;
+
+let PROCESS_BOUND_ASSUMPTIONS =
+  let cth = prove
+   (`(ival x <= b <=>
+      --(&2 pow (dimindex(:N) - 1)) <= ival x /\ ival x <= b) /\
+     (b <= ival x <=>
+      b <= ival x /\ ival x <= &2 pow (dimindex(:N) - 1) - &1) /\
+     (ival(x:N word) > b <=>
+      b + &1 <= ival x /\ ival x <= &2 pow (dimindex(:N) - 1) - &1) /\
+     (b > ival(x:N word) <=>
+      --(&2 pow (dimindex(:N) - 1)) <= ival x /\ ival x <= b - &1) /\
+     (ival(x:N word) >= b <=>
+      b <= ival x /\ ival x <= &2 pow (dimindex(:N) - 1) - &1) /\
+     (b >= ival(x:N word) <=>
+      --(&2 pow (dimindex(:N) - 1)) <= ival x /\ ival x <= b) /\
+     (ival(x:N word) < b <=>
+      --(&2 pow (dimindex(:N) - 1)) <= ival x /\ ival x <= b - &1) /\
+     (b < ival(x:N word) <=>
+     b + &1 <= ival x /\ ival x <= &2 pow (dimindex(:N) - 1) - &1) /\
+     (abs(ival(x:N word)) <= b <=>
+      --b <= ival x /\ ival x <= b) /\
+     (abs(ival(x:N word)) < b <=>
+      &1 - b <= ival x /\ ival x <= b - &1)`,
+    REWRITE_TAC[IVAL_BOUND; INT_ARITH `x:int <= y - &1 <=> x < y`] THEN
+    INT_ARITH_TAC)
+  and pth = prove
+   (`!l u (x:N word).
+          l <= ival x /\ ival x <= u
+          ==> (ival x == ival x) (mod &0) /\ l <= ival x /\ ival x <= u`,
+    REPEAT STRIP_TAC THEN ASM_REWRITE_TAC[] THEN INTEGER_TAC) in
+  let rule =
+    MATCH_MP pth o
+    CONV_RULE (BINOP2_CONV (LAND_CONV DIMINDEX_INT_REDUCE_CONV)
+                           (RAND_CONV DIMINDEX_INT_REDUCE_CONV)) o
+    GEN_REWRITE_RULE I [cth] in
+  let rec process lfn ths =
+    match ths with
+      [] -> lfn
+    | th::oths ->
+          let lfn' =
+            try let th' = rule th in
+                let tm = rand(concl th') in
+                if is_intconst (rand(rand tm)) && is_intconst (lhand(lhand tm))
+                then (rand(lhand(rand tm)) |-> th') lfn
+                else lfn
+            with Failure _ -> lfn in
+          process lfn' oths in
+  process undefined;;
+
+(* ------------------------------------------------------------------------- *)
+(* Congruence-and-bound propagation, just recursion on the expression tree.  *)
+(* ------------------------------------------------------------------------- *)
+
+let CONGBOUND_CONST = prove
+ (`!(x:N word) n.
+        ival x = n
+        ==> (ival x == n) (mod &0) /\ n <= ival x /\ ival x <= n`,
+  REPEAT STRIP_TAC THEN ASM_REWRITE_TAC[INT_LE_REFL] THEN INTEGER_TAC);;
+
+let CONGBOUND_ATOM = prove
+ (`!x:N word. (ival x == ival x) (mod &0) /\
+              --(&2 pow (dimindex(:N) - 1)) <= ival x /\
+              ival x <= &2 pow (dimindex(:N) - 1) - &1`,
+  GEN_TAC THEN REWRITE_TAC[INT_ARITH `x:int <= y - &1 <=> x < y`] THEN
+  REWRITE_TAC[IVAL_BOUND] THEN INTEGER_TAC);;
+
+let CONGBOUND_ATOM_GEN = prove
+ (`!x:N word. abs(ival x) <= n
+              ==> (ival x == ival x) (mod &0) /\
+                  --n <= ival x /\ ival x <= n`,
+  REWRITE_TAC[INTEGER_RULE `(x:int == x) (mod n)`] THEN INT_ARITH_TAC);;
+
+let CONGBOUND_IWORD = prove
+ (`!x. ((x == x') (mod p) /\ l <= x /\ x <= u)
+       ==> --(&2 pow (dimindex(:N) - 1)) <= l /\
+           u <= &2 pow (dimindex(:N) - 1) - &1
+           ==> (ival(iword x:N word) == x') (mod p) /\
+               l <= ival(iword x:N word) /\ ival(iword x:N word) <= u`,
+  GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN REWRITE_TAC[word_sx] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) IVAL_IWORD o
+    lhand o rand o rand o snd) THEN
+  ANTS_TAC THENL [ASM_INT_ARITH_TAC; DISCH_THEN SUBST1_TAC] THEN
+  ASM_REWRITE_TAC[]);;
+
+let CONGBOUND_WORD_SX = prove
+ (`!x:M word.
+        ((ival x == x') (mod p) /\ l <= ival x /\ ival x <= u)
+        ==> --(&2 pow (dimindex(:N) - 1)) <= l /\
+            u <= &2 pow (dimindex(:N) - 1) - &1
+            ==> (ival(word_sx x:N word) == x') (mod p) /\
+                l <= ival(word_sx x:N word) /\ ival(word_sx x:N word) <= u`,
+  REWRITE_TAC[word_sx; CONGBOUND_IWORD]);;
+
+let CONGBOUND_WORD_ADD = prove
+ (`!x y:N word.
+        ((ival x == x') (mod p) /\ lx <= ival x /\ ival x <= ux) /\
+        ((ival y == y') (mod p) /\ ly <= ival y /\ ival y <= uy)
+        ==> --(&2 pow (dimindex(:N) - 1)) <= lx + ly /\
+            ux + uy <= &2 pow (dimindex(:N) - 1) - &1
+            ==> (ival(word_add x y) == x' + y') (mod p) /\
+                lx + ly <= ival(word_add x y) /\
+                ival(word_add x y) <= ux + uy`,
+  REPEAT GEN_TAC THEN REWRITE_TAC[WORD_ADD_IMODULAR; imodular] THEN
+  STRIP_TAC THEN STRIP_TAC THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_IMP] CONGBOUND_IWORD) THEN
+  ASM_SIMP_TAC[INT_CONG_ADD] THEN ASM_INT_ARITH_TAC);;
+
+let CONGBOUND_WORD_SUB = prove
+ (`!x y:N word.
+        ((ival x == x') (mod p) /\ lx <= ival x /\ ival x <= ux) /\
+        ((ival y == y') (mod p) /\ ly <= ival y /\ ival y <= uy)
+        ==> --(&2 pow (dimindex(:N) - 1)) <= lx - uy /\
+            ux - ly <= &2 pow (dimindex(:N) - 1) - &1
+            ==> (ival(word_sub x y) == x' - y') (mod p) /\
+                lx - uy <= ival(word_sub x y) /\
+                ival(word_sub x y) <= ux - ly`,
+  REPEAT GEN_TAC THEN REWRITE_TAC[WORD_SUB_IMODULAR; imodular] THEN
+  STRIP_TAC THEN STRIP_TAC THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_IMP] CONGBOUND_IWORD) THEN
+  ASM_SIMP_TAC[INT_CONG_SUB] THEN ASM_INT_ARITH_TAC);;
+
+let CONGBOUND_WORD_MUL = prove
+ (`!x y:N word.
+        ((ival x == x') (mod p) /\ lx <= ival x /\ ival x <= ux) /\
+        ((ival y == y') (mod p) /\ ly <= ival y /\ ival y <= uy)
+        ==> --(&2 pow (dimindex(:N) - 1))
+            <= min (lx * ly) (min (lx * uy) (min (ux * ly) (ux * uy))) /\
+            max (lx * ly) (max (lx * uy) (max (ux * ly) (ux * uy)))
+            <= &2 pow (dimindex(:N) - 1) - &1
+            ==> (ival(word_mul x y) == x' * y') (mod p) /\
+                min (lx * ly) (min (lx * uy) (min (ux * ly) (ux * uy)))
+                <= ival(word_mul x y) /\
+                ival(word_mul x y)
+                <= max (lx * ly) (max (lx * uy) (max (ux * ly) (ux * uy)))`,
+  let lemma = prove
+     (`l:int <= x /\ x <= u
+       ==> !a. a * l <= a * x /\ a * x <= a * u \/
+               a * u <= a * x /\ a * x <= a * l`,
+      MESON_TAC[INT_LE_NEGTOTAL; INT_LE_LMUL;
+                INT_ARITH `a * x:int <= a * y <=> --a * y <= --a * x`]) in
+  REPEAT GEN_TAC THEN
+  DISCH_THEN(CONJUNCTS_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
+  DISCH_THEN(ASSUME_TAC o SPEC `ival(x:N word)` o MATCH_MP lemma) THEN
+  DISCH_THEN(MP_TAC o MATCH_MP lemma) THEN DISCH_THEN(fun th ->
+        ASSUME_TAC(SPEC `ly:int` th) THEN ASSUME_TAC(SPEC `uy:int` th)) THEN
+  REWRITE_TAC[WORD_MUL_IMODULAR; imodular] THEN STRIP_TAC THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_IMP] CONGBOUND_IWORD) THEN
+  ASM_SIMP_TAC[INT_CONG_MUL] THEN ASM_INT_ARITH_TAC);;
+
+let MONTRED_MLDSA_LEMMA = prove
+ (`!x. &2 pow 32 * ival(mldsa_montred x) =
+       ival(word_add
+         (word_mul (word_sx(iword(ival x * &4236238847):int32)) (word 8380417)) x)`,
+  GEN_TAC THEN REWRITE_TAC[mldsa_montred] THEN REWRITE_TAC[WORD_BLAST
+   `word_subword (x:int64) (0,32):int32 = word_sx x`] THEN
+  REWRITE_TAC[IWORD_INT_MUL; GSYM word_sx; GSYM WORD_IWORD] THEN
+  REWRITE_TAC[WORD_BLAST `(word_sx:int64->int32) x = word_zx x`] THEN
+  CONV_TAC INT_REDUCE_CONV THEN MATCH_MP_TAC(BITBLAST_RULE
+   `word_and x (word 4294967295):int64 = word 0
+    ==> &4294967296 * ival(word_subword x (32,32):int32) = ival x`) THEN
+  REWRITE_TAC[BITBLAST_RULE
+   `word_and x (word 4294967295):int64 = word 0 <=> word_zx x:int32 = word 0`] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) WORD_ZX_ADD o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_32; DIMINDEX_64; ARITH] THEN DISCH_THEN SUBST1_TAC THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) WORD_ZX_MUL o lhand o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_32; DIMINDEX_64; ARITH] THEN DISCH_THEN SUBST1_TAC THEN
+  REWRITE_TAC[WORD_BLAST `word_zx(word_sx (x:int32):int64) = x`] THEN
+  REWRITE_TAC[GSYM VAL_EQ_0; VAL_WORD_ADD; VAL_WORD_MUL; VAL_WORD] THEN
+  CONV_TAC MOD_DOWN_CONV THEN REWRITE_TAC[GSYM DIVIDES_MOD; DIMINDEX_32] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN MATCH_MP_TAC(NUMBER_RULE
+   `(a * b + 1 == 0) (mod d) ==> d divides ((x * a) * b + x)`) THEN
+  REWRITE_TAC[CONG] THEN ARITH_TAC);;
+
+let CONGBOUND_MLDSA_MONTRED = prove
+ (`!a a' l u.
+      (ival a == a') (mod &8380417) /\ l <= ival a /\ ival a <= u
+      ==> --(&9205375228383854592) <= l /\ u <= &9205375228392235008
+          ==> (ival(mldsa_montred a) == &(inverse_mod 8380417 4294967296) * a')
+              (mod &8380417) /\
+              (l - &17996808470921216) div &2 pow 32 <= ival(mldsa_montred a) /\
+              ival(mldsa_montred a) <= &1 + (u + &17996808462540799) div &2 pow 32`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN
+  CONV_TAC NUM_REDUCE_CONV THEN CONV_TAC(ONCE_DEPTH_CONV INVERSE_MOD_CONV) THEN
+  MP_TAC(SPECL [`&(inverse_mod 8380417 4294967296):int`; `(&2:int) pow 32`; `&8380417:int`] (INTEGER_RULE
+   `!d e n:int. (e * d == &1) (mod n)
+                ==> !x y. ((x == d * y) (mod n) <=> (e * x == y) (mod n))`)) THEN
+  CONV_TAC(ONCE_DEPTH_CONV INVERSE_MOD_CONV) THEN
+  ANTS_TAC THENL
+   [REWRITE_TAC[GSYM INT_REM_EQ] THEN CONV_TAC INT_REDUCE_CONV;
+    DISCH_THEN(fun th -> REWRITE_TAC[th])] THEN
+  ONCE_REWRITE_TAC[INT_ARITH
+   `l:int <= x <=> &2 pow 32 * l <= &2 pow 32 * x`] THEN
+  REWRITE_TAC[MONTRED_MLDSA_LEMMA] THEN
+  REWRITE_TAC[WORD_RULE
+   `word_add (word_mul a b) c = iword(ival a * ival b + ival c)`] THEN
+  ASM_SIMP_TAC[IVAL_WORD_SX; DIMINDEX_32; DIMINDEX_64; ARITH] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) IVAL_IWORD o
+   lhand o rator o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_64] THEN CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN
+  ANTS_TAC THENL
+   [SUBGOAL_THEN
+     `--(&9205375228383854592) <= ival(a:int64) /\
+      ival(a:int64) <= &9205375228392235008`
+    MP_TAC THENL [ASM_INT_ARITH_TAC; ALL_TAC] THEN
+    POP_ASSUM_LIST(K ALL_TAC) THEN STRIP_TAC THEN
+    ASM BOUNDER_TAC[];
+    DISCH_THEN SUBST1_TAC] THEN
+  ASM_REWRITE_TAC[INTEGER_RULE
+   `(a * p + x:int == y) (mod p) <=> (x == y) (mod p)`] THEN
+  CONJ_TAC THENL
+   [FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP (INT_ARITH
+     `l:int <= a ==> x - l <= p ==> x <= p + a`)) THEN
+    TRANS_TAC INT_LE_TRANS `--(&2 pow 31) *  &8380417:int` THEN
+    CONJ_TAC THENL [ASM_INT_ARITH_TAC; BOUNDER_TAC[]];
+    FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP (INT_ARITH
+     `a:int <= u ==> x <= p - u ==> x + a <= p`)) THEN
+    TRANS_TAC INT_LE_TRANS `(&2 pow 31 - &1) *  &8380417:int` THEN
+    CONJ_TAC THENL [BOUNDER_TAC[]; ASM_INT_ARITH_TAC]]);;
+
+let CONGBOUND_MLDSA_BARRED = prove
+ (`!a a' l u.
+        ((ival a == a') (mod &8380417) /\ l <= ival a /\ ival a <= u)
+        ==> u <= &0x7fbfffff
+            ==> (ival(mldsa_barred a) == a') (mod &8380417) /\
+                --(&6283009) <= ival(mldsa_barred a) /\
+                ival(mldsa_barred a) <= &6283008`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN
+  MP_TAC(ISPEC `a:int32` (BITBLAST_RULE
+     `!a:int32.
+        let ML_DSA_Q = &8380417 in
+        let t = word_ishr (word_add a (word 4194304)) 23 in
+        let r = word_sub a (word_mul t (word 8380417)) in
+        ival(a) < &0x7fc00000
+        ==> ival(a) - ML_DSA_Q * ival t = ival r /\
+            --(&6283009) <= ival r /\ ival r <= &6283008`)) THEN
+  CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
+  ASM_REWRITE_TAC[GSYM mldsa_barred] THEN
+  ANTS_TAC THENL [ASM_INT_ARITH_TAC; ALL_TAC] THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[GSYM th]) THEN
+  ASM_REWRITE_TAC[INTEGER_RULE
+   `(x - p * q:int == y) (mod p) <=> (x == y) (mod p)`]);;
+
+let CONGBOUND_MLDSA_MONTMUL = prove
+ (`!x x' lx ux.
+       ((ival x == x') (mod &8380417) /\ lx <= ival x /\ ival x <= ux)
+       ==> !a b. --(&2147483648) <= ival a /\
+                 ival a <= &2147483647 /\
+                 (&8380417 * ival b) rem &4294967296 = ival a rem &4294967296
+                 ==> (ival(mldsa_montmul (a,b) x) ==
+                     &(inverse_mod 8380417 4294967296) * ival a * x')
+                     (mod &8380417) /\
+                     (min (ival a * lx) (ival a * ux) - &17996808462540799)
+                     div &4294967296 <= ival(mldsa_montmul (a,b) x) /\
+                     ival(mldsa_montmul (a,b) x) <=
+                     (max (ival a * lx) (ival a * ux) + &17996812765888511)
+                     div &2 pow 32`,
+  let lemma = prove
+   (`l:int <= x /\ x <= u
+     ==> !a. a * l <= a * x /\ a * x <= a * u \/
+             a * u <= a * x /\ a * x <= a * l`,
+    MESON_TAC[INT_LE_NEGTOTAL; INT_LE_LMUL;
+              INT_ARITH `a * x:int <= a * y <=> --a * y <= --a * x`])
+  and ilemma = prove
+   (`!x:int64. ival(word_subword x (32,32):int32) = ival x div &2 pow 32`,
+    REWRITE_TAC[GSYM DIMINDEX_16; GSYM IVAL_WORD_ISHR] THEN
+    GEN_TAC THEN REWRITE_TAC[DIMINDEX_16] THEN BITBLAST_TAC) in
+  let mainlemma = prove
+   (`!x:int64 y:int64.
+          (ival x == ival y) (mod (&2 pow 32))
+          ==> &2 pow 32 *
+              ival(word_sub (word_subword x (32,32))
+                            (word_subword y (32,32)):int32) =
+              ival(word_sub x y)`,
+    REPEAT STRIP_TAC THEN MATCH_MP_TAC(INT_ARITH
+     `b rem &2 pow 32 = &0 /\ a = &2 pow 32 * b div &2 pow 32 ==> a = b`) THEN
+    CONJ_TAC THENL
+     [REWRITE_TAC[WORD_SUB_IMODULAR; imodular; INT_REM_EQ_0] THEN
+      SIMP_TAC[INT_DIVIDES_IVAL_IWORD; DIMINDEX_64; ARITH] THEN
+      POP_ASSUM MP_TAC THEN CONV_TAC INTEGER_RULE;
+      AP_TERM_TAC THEN REWRITE_TAC[GSYM ilemma] THEN AP_TERM_TAC] THEN
+    FIRST_X_ASSUM(MP_TAC o GEN_REWRITE_RULE I [GSYM INT_REM_EQ]) THEN
+    SIMP_TAC[INT_REM_IVAL; DIMINDEX_16; DIMINDEX_64; ARITH] THEN
+    BITBLAST_TAC) in
+  REPEAT GEN_TAC THEN DISCH_TAC THEN REPEAT GEN_TAC THEN STRIP_TAC THEN
+  CONV_TAC NUM_REDUCE_CONV THEN CONV_TAC(ONCE_DEPTH_CONV INVERSE_MOD_CONV) THEN
+  MP_TAC(SPECL [`&8265825:int`; `(&2:int) pow 32`; `&8380417:int`] (INTEGER_RULE
+ `!d e n:int. (e * d == &1) (mod n)
+              ==> !x y. ((x == d * y) (mod n) <=> (e * x == y) (mod n))`)) THEN
+  ANTS_TAC THENL
+   [REWRITE_TAC[GSYM INT_REM_EQ] THEN INT_ARITH_TAC;
+    DISCH_THEN(fun th -> REWRITE_TAC[th])] THEN
+  ONCE_REWRITE_TAC[INT_ARITH
+   `l:int <= x <=> &2 pow 32 * l <= &2 pow 32 * x`] THEN
+  REWRITE_TAC[mldsa_montmul] THEN
+  REWRITE_TAC[WORD_MUL_IMODULAR; imodular] THEN
+  SIMP_TAC[IVAL_WORD_SX; DIMINDEX_32; DIMINDEX_64; ARITH] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) mainlemma o
+   lhand o rator o lhand o snd) THEN
+  ANTS_TAC THENL
+   [SIMP_TAC[GSYM INT_REM_EQ; INT_REM_IVAL_IWORD; DIMINDEX_64; ARITH] THEN
+    ONCE_REWRITE_TAC[GSYM INT_MUL_REM] THEN
+    SIMP_TAC[GSYM VAL_IVAL_REM; GSYM DIMINDEX_32] THEN
+    SIMP_TAC[WORD_SUBWORD_EQUAL_WORD_ZX_POS0; DIMINDEX_32; DIMINDEX_64;
+             VAL_WORD_ZX_GEN; ARITH_LE; ARITH_LT] THEN
+    ONCE_REWRITE_TAC[ARITH_RULE `32 = MIN 64 32`] THEN
+    REWRITE_TAC[GSYM MOD_MOD_EXP_MIN] THEN
+    REWRITE_TAC[GSYM INT_OF_NUM_REM; GSYM INT_OF_NUM_CLAUSES] THEN
+    REWRITE_TAC[REWRITE_RULE[GSYM INT_REM_EQ; DIMINDEX_64]
+     (INST_TYPE [`:64`,`:N`] VAL_IWORD_CONG)] THEN
+    REWRITE_TAC[INT_REM_REM_POW_MIN] THEN CONV_TAC NUM_REDUCE_CONV THEN
+    CONV_TAC INT_REM_DOWN_CONV THEN
+    REWRITE_TAC[GSYM INT_MUL_ASSOC] THEN
+    ONCE_REWRITE_TAC[GSYM INT_MUL_REM] THEN
+    SIMP_TAC[GSYM VAL_IVAL_REM; GSYM DIMINDEX_32] THEN
+    REWRITE_TAC[DIMINDEX_32] THEN CONV_TAC INT_REM_DOWN_CONV THEN
+    ONCE_REWRITE_TAC[GSYM INT_MUL_REM] THEN
+    AP_THM_TAC THEN AP_TERM_TAC THEN AP_TERM_TAC THEN
+    CONV_TAC INT_REDUCE_CONV THEN ASM_REWRITE_TAC[INT_MUL_SYM];
+    DISCH_THEN SUBST1_TAC THEN REWRITE_TAC[GSYM IWORD_INT_SUB]] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) IVAL_IWORD o
+    lhand o rator o lhand o snd) THEN
+  ANTS_TAC THENL
+   [REWRITE_TAC[DIMINDEX_64; ARITH] THEN ASM BOUNDER_TAC[];
+    DISCH_THEN SUBST1_TAC] THEN
+  ASM_SIMP_TAC[INTEGER_RULE
+   `(x:int == x') (mod p) ==> (x * a - q * p == a * x') (mod p)`] THEN
+  REWRITE_TAC[GSYM(INT_REDUCE_CONV `(&2:int) pow 32`)] THEN
+  MATCH_MP_TAC(INT_ARITH
+  `(l <= p /\ p <= u) /\ (&4294967295 - c <= q /\ q <= b)
+   ==> &2 pow 32 * (l - b) div &2 pow 32 <= p - q /\
+       p - q <= &2 pow 32 * (u + c) div &2 pow 32`) THEN
+  CONJ_TAC THENL [ALL_TAC; BOUNDER_TAC[]] THEN
+  FIRST_X_ASSUM(MP_TAC o SPEC `ival(a:int64)` o
+    MATCH_MP lemma o CONJUNCT2) THEN
+  INT_ARITH_TAC);;
+
+let CONCL_BOUNDS_RULE =
+  CONV_RULE(BINOP2_CONV
+          (LAND_CONV(RAND_CONV DIMINDEX_INT_REDUCE_CONV))
+          (BINOP2_CONV
+           (LAND_CONV DIMINDEX_INT_REDUCE_CONV)
+           (RAND_CONV DIMINDEX_INT_REDUCE_CONV)));;
+
+let SIDE_ELIM_RULE th =
+  MP th (EQT_ELIM(DIMINDEX_INT_REDUCE_CONV(lhand(concl th))));;
+
+let GEN_CONGBOUND_RULE aboths =
+  let lfn = PROCESS_BOUND_ASSUMPTIONS aboths in
+  let rec rule tm =
+    try apply lfn tm with Failure _ ->
+    match tm with
+      Comb(Const("word",_),n) when is_numeral n ->
+        let th1 = ISPEC tm CONGBOUND_CONST in
+        let th2 = WORD_RED_CONV(lhand(lhand(snd(strip_forall(concl th1))))) in
+        MATCH_MP th1 th2
+    | Comb(Const("iword",_),n) when is_intconst n ->
+        let th0 = WORD_IWORD_CONV tm in
+        let th1 = ISPEC (rand(concl th0)) CONGBOUND_CONST in
+        let th2 = WORD_RED_CONV(lhand(lhand(snd(strip_forall(concl th1))))) in
+        SUBS[SYM th0] (MATCH_MP th1 th2)
+    | Comb(Const("mldsa_montred",_),t) ->
+        let th1 = WEAKEN_INTCONG_RULE (num 8380417) (rule t) in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE(MATCH_MP CONGBOUND_MLDSA_MONTRED th1))
+    | Comb(Const("mldsa_barred",_),t) ->
+        let th1 = WEAKEN_INTCONG_RULE (num 8380417) (rule t) in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE(MATCH_MP CONGBOUND_MLDSA_BARRED th1))
+    | Comb(Comb(Const("mldsa_montmul",_),ab),t) ->
+        let atm,btm = dest_pair ab and th0 = rule t in
+        let th0' = WEAKEN_INTCONG_RULE (num 8380417) th0 in
+        let th1 = SPECL [atm;btm] (MATCH_MP CONGBOUND_MLDSA_MONTMUL th0') in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
+    | Comb(Const("word_sx",_),t) ->
+        let th0 = rule t in
+        let tyin = type_match
+         (type_of(rator(rand(lhand(funpow 4 rand (snd(dest_forall
+            (concl CONGBOUND_WORD_SX)))))))) (type_of(rator tm)) [] in
+        let th1 = MATCH_MP (INST_TYPE tyin CONGBOUND_WORD_SX) th0 in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
+    | Comb(Comb(Const("word_add",_),ltm),rtm) ->
+        let lth = rule ltm and rth = rule rtm in
+        let th1 = MATCH_MP CONGBOUND_WORD_ADD (UNIFY_INTCONG_RULE lth rth) in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
+    | Comb(Comb(Const("word_sub",_),ltm),rtm) ->
+        let lth = rule ltm and rth = rule rtm in
+        let th1 = MATCH_MP CONGBOUND_WORD_SUB (UNIFY_INTCONG_RULE lth rth) in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
+    | Comb(Comb(Const("word_mul",_),ltm),rtm) ->
+        let lth = rule ltm and rth = rule rtm in
+        let th1 = MATCH_MP CONGBOUND_WORD_MUL (UNIFY_INTCONG_RULE lth rth) in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
+    | _ -> CONCL_BOUNDS_RULE(ISPEC tm CONGBOUND_ATOM) in
+  rule;;
+
+let CONGBOUND_RULE = GEN_CONGBOUND_RULE [];;

--- a/proofs/hol_light/x86_64/proofs/mldsa_utils.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_utils.ml
@@ -1,0 +1,92 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+(* ------------------------------------------------------------------------- *)
+(* Some convenient proof tools.                                              *)
+(* ------------------------------------------------------------------------- *)
+
+let READ_MEMORY_MERGE_CONV =
+  let baseconv =
+    GEN_REWRITE_CONV I [READ_MEMORY_BYTESIZED_SPLIT] THENC
+    LAND_CONV(LAND_CONV(RAND_CONV(RAND_CONV
+     (TRY_CONV(GEN_REWRITE_CONV I [GSYM WORD_ADD_ASSOC] THENC
+               RAND_CONV WORD_ADD_CONV))))) in
+  let rec conv n tm =
+    if n = 0 then REFL tm else
+    (baseconv THENC BINOP_CONV (conv(n - 1))) tm in
+  conv;;
+
+let READ_MEMORY_SPLIT_CONV =
+  let baseconv =
+    GEN_REWRITE_CONV I [READ_MEMORY_BYTESIZED_UNSPLIT] THENC
+    BINOP_CONV(LAND_CONV(LAND_CONV(RAND_CONV(RAND_CONV
+     (TRY_CONV(GEN_REWRITE_CONV I [GSYM WORD_ADD_ASSOC] THENC
+               RAND_CONV WORD_ADD_CONV)))))) in
+  let rec conv n tm =
+    if n = 0 then REFL tm else
+    (baseconv THENC BINOP_CONV (conv(n - 1))) tm in
+  conv;;
+
+let SIMD_SIMPLIFY_CONV unfold_defs =
+  TOP_DEPTH_CONV
+   (REWR_CONV WORD_SUBWORD_AND ORELSEC WORD_SIMPLE_SUBWORD_CONV) THENC
+  DEPTH_CONV WORD_NUM_RED_CONV THENC
+  REWRITE_CONV (map GSYM unfold_defs);;
+
+let SIMD_SIMPLIFY_TAC unfold_defs =
+  let arm_simdable = can (term_match [] `read X (s:armstate):int128 = whatever`) in
+  let x86_simdable = can (term_match [] `read X (s:x86state):int256 = whatever`) in
+  let simdable tm = arm_simdable tm || x86_simdable tm in
+  TRY(FIRST_X_ASSUM
+   (ASSUME_TAC o
+    CONV_RULE(RAND_CONV (SIMD_SIMPLIFY_CONV unfold_defs)) o
+    check (simdable o concl)));;
+
+let MEMORY_128_FROM_16_TAC =
+  let a_tm = `a:int64` and n_tm = `n:num` and i64_ty = `:int64`
+  and pat = `read (memory :> bytes128(word_add a (word n))) s0` in
+  fun v n ->
+    let pat' = subst[mk_var(v,i64_ty),a_tm] pat in
+    let f i =
+      let itm = mk_small_numeral(16*i) in
+      READ_MEMORY_MERGE_CONV 3 (subst[itm,n_tm] pat') in
+    MP_TAC(end_itlist CONJ (map f (0--(n-1))));;
+
+(* This tactic repeated calls `f n with monotonically increasing values of n
+   until the target PC matches one of the assumptions.
+
+   The goal must be of the form `ensure arm ...`. Clauses constraining the PC
+   must be of the form `read PC some_state = some_value`. *)
+let MAP_UNTIL_TARGET_PC f n = fun (asl, w) ->
+  let is_pc_condition = can (term_match [] `read PC some_state = some_value`) in
+  (* We assume that the goal has the form
+     `ensure arm (\s. ... /\ read PC s = some_value /\ ...)` *)
+  let extract_target_pc_from_goal goal =
+    let _, insts, _ = term_match [] `eventually arm (\s'. P) some_state` goal in
+    insts
+      |> rev_assoc `P: bool`
+      |> conjuncts
+      |> find is_pc_condition in
+  (* Find PC-constraining assumption from the list of all assumptions. *)
+  let extract_pc_assumption asl =
+    try Some (find (is_pc_condition o concl o snd) asl |> snd |> concl) with find -> None in
+  (* Check if there is an assumption constraining the PC to the target PC *)
+  let has_matching_pc_assumption asl target_pc =
+    match extract_pc_assumption asl with
+     | None -> false
+     | Some(asm) -> can (term_match [`returnaddress: 64 word`; `pc: num`] target_pc) asm in
+  let target_pc = extract_target_pc_from_goal w in
+  (* ALL_TAC if we reached the target PC, NO_TAC otherwise, so
+     TARGET_PC_REACHED_TAC target_pc ORELSE SOME_OTHER_TACTIC
+     is effectively `if !(target_pc_reached) SOME_OTHER_TACTIC` *)
+  let TARGET_PC_REACHED_TAC target_pc = fun (asl, w) ->
+    if has_matching_pc_assumption asl target_pc then
+      ALL_TAC (asl, w)
+    else
+      NO_TAC (asl, w) in
+  let rec core n (asl, w) =
+    (TARGET_PC_REACHED_TAC target_pc ORELSE (f n THEN core (n + 1))) (asl, w)
+  in
+    core n (asl, w);;

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -28,6 +28,7 @@ _RE_DEFINED = re.compile(r"defined\(([^)]+)\)")
 _RE_MARKDOWN_CITE = re.compile(r"\[\^(?P<id>\w+)\]")
 _RE_C_CITE = re.compile(r"@\[(?P<id>\w+)")
 _RE_MACRO_CHECK = re.compile(r"[^_]((?:MLD_|MLDSA_)\w+)(.*)$", re.M)
+_RE_BYTECODE_START = re.compile(r"=== bytecode start: mldsa/([^/\s]+?)\.o")
 _RE_DEFINE = re.compile(r"^\s*#define\s+(\w+)")
 
 # File cache: {filename: {"content": str, "original": str, "force_format": bool}}
@@ -1717,6 +1718,31 @@ def update_via_simpasm(
     update_file(outfile_full, new_contents)
 
 
+def gen_hol_light_asm_file(job):
+    infile, outfile, indir, cflags = job
+    update_via_simpasm(
+        f"{indir}/{infile}",
+        "proofs/hol_light/x86_64/mldsa",
+        outfile=outfile,
+        cflags=cflags,
+        preserve_header=False,
+    )
+
+
+def gen_hol_light_asm():
+    joblist = [
+        (
+            "ntt.S",
+            "mldsa_ntt.S",
+            "dev/x86_64/src",
+            "-Imldsa/src/native/x86_64/src/ -mavx2 -mbmi2 -msse4 -fcf-protection=full",
+        ),
+    ]
+
+    with ThreadPoolExecutor() as executor:
+        _ = list(executor.map(partial(gen_hol_light_asm_file), joblist))
+
+
 def update_via_copy(infile_full, outfile_full, transform=None):
     status_update("copy", f"{infile_full} -> {outfile_full}")
 
@@ -2421,6 +2447,78 @@ def gen_citations():
     gen_bib_file(bibliography)
 
 
+def extract_bytecode_from_output(output_text):
+    """Convert output of proofs/hol_light/x86_64/proofs/dump_bytecode.native
+    into a dictionary mapping function names to byte code strings."""
+    bytecode_dict = {}
+
+    lines = output_text.split("\n")
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        match = _RE_BYTECODE_START.search(line)
+        if match:
+            filename = match.group(1)
+
+            # Collect bytecode until end marker
+            bytecode_lines = []
+            i += 1
+            while i < len(lines) and "==== bytecode end" not in lines[i]:
+                bytecode_lines.append(lines[i])
+                i += 1
+
+            bytecode = "\n".join(bytecode_lines).strip()
+            bytecode_dict[filename] = bytecode
+        i += 1
+
+    return bytecode_dict
+
+
+def update_bytecode_in_proof_script(filepath, bytecode):
+    content = read_file(filepath)
+
+    # Check if markers exist
+    start_marker = "(*** BYTECODE START ***)"
+    end_marker = "(*** BYTECODE END ***)"
+
+    if start_marker not in content or end_marker not in content:
+        raise Exception(f"Could not find BYTECODE START/END markers in {filepath}")
+
+    # Replace content between markers
+    pattern = rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}"
+    replacement = f"{start_marker}\n{bytecode}\n{end_marker}"
+
+    updated_content = re.sub(pattern, replacement, content, flags=re.DOTALL)
+
+    update_file(filepath, updated_content)
+
+
+def update_hol_light_bytecode():
+    """Update HOL Light proof files with bytecode from make dump_bytecode."""
+    status_update(
+        "HOL Light bytecode",
+        "Running make dump_bytecode ... (this may take a few minutes)",
+    )
+
+    # Run make to get bytecode output
+    result = subprocess.run(
+        ["make", "-C", "proofs/hol_light/x86_64", "dump_bytecode"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output_text = result.stdout
+
+    # Extract bytecode
+    bytecode_dict = extract_bytecode_from_output(output_text)
+
+    # Update each .ml file
+    for obj_name, bytecode in bytecode_dict.items():
+        ml_file = "proofs/hol_light/x86_64/proofs/" + obj_name + ".ml"
+        update_bytecode_in_proof_script(ml_file, bytecode)
+
+
 def gen_test_config(config_path, config_spec, default_config_content):
     """Generate a config file by modifying the default config."""
     status_update("test configs", config_path)
@@ -2554,6 +2652,9 @@ def _main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("--dry-run", default=False, action="store_true")
+    parser.add_argument(
+        "--update-hol-light-bytecode", default=False, action="store_true"
+    )
     parser.add_argument("--aarch64-clean", default=True, action="store_true")
     parser.add_argument("--no-simplify", default=False, action="store_true")
     parser.add_argument("--force-cross", default=False, action="store_true")
@@ -2583,6 +2684,10 @@ def _main():
     gen_avx2_rej_uniform_table()
     high_level_status("Generated zeta and lookup tables")
 
+    if platform.machine().lower() not in ["arm64", "aarch64"]:
+        gen_hol_light_asm()
+        high_level_status("Generated HOL Light assembly")
+
     synchronize_backends(
         clean=args.aarch64_clean,
         no_simplify=args.no_simplify,
@@ -2602,6 +2707,10 @@ def _main():
         x86_64_syntax=args.x86_64_syntax,
     )
     high_level_status("Completed final backend synchronization")
+
+    if args.update_hol_light_bytecode:
+        update_hol_light_bytecode()
+        high_level_status("Updated HOL Light bytecode")
 
     gen_monolithic_source_file()
     high_level_status("Generated monolithic source files")

--- a/scripts/tests
+++ b/scripts/tests
@@ -854,6 +854,62 @@ class Tests:
 
         self.check_fail()
 
+    def hol_light(self):
+
+        def list_proofs():
+            cmd_str = ["./proofs/hol_light/x86_64/list_proofs.sh"]
+            p = subprocess.run(cmd_str, capture_output=True, universal_newlines=False)
+            proofs = filter(lambda s: s.strip() != "", p.stdout.decode().split("\n"))
+            return list(proofs)
+
+        if self.args.list_functions:
+            for p in list_proofs():
+                print(p)
+            exit(0)
+
+        def run_hol_light_single_step(proofs):
+            num_proofs = len(proofs)
+            for i, func in enumerate(proofs):
+                log = logger(f"HOL_LIGHT ({i+1}/{num_proofs})", None, None, None)
+                log.info(f"Starting HOL-Light proof for {func}")
+                start = time.time()
+                proof_bin = f"mldsa/{func}.native"
+                proof_target = f"mldsa/{func}.correct"
+                proof_dir = "proofs/hol_light/x86_64"
+                # Remove intermediate proof files to force-rerun
+                try:
+                    os.remove(os.path.join(proof_dir, proof_bin))
+                    os.remove(os.path.join(proof_dir, proof_target))
+                except FileNotFoundError:
+                    pass
+                p = subprocess.run(
+                    [
+                        "make",
+                        f"mldsa/{func}.correct",
+                    ]
+                    + self.make_j(),
+                    cwd="proofs/hol_light/x86_64",
+                    env=os.environ.copy(),
+                    capture_output=(self.args.verbose is False),
+                )
+
+                end = time.time()
+                dur = int(end - start)
+                if p.returncode != 0:
+                    log.error(f"   FAILED (after {dur}s)")
+                    if p.stderr is not None:
+                        log.error(p.stderr.decode())
+                    self.fail(f"HOL-Light proof for {func}")
+                else:
+                    log.info(f"   SUCCESS (after {dur}s)")
+
+        proofs = list_proofs()
+        if self.args.proof is not None:
+            proofs = self.args.proof
+
+        run_hol_light_single_step(proofs)
+        self.check_fail()
+
 
 #
 # Command line interface
@@ -1149,6 +1205,29 @@ def cli():
         default=False,
     )
 
+    # hol_light arguments
+    hol_light_parser = cmd_subparsers.add_parser(
+        "hol_light",
+        help="Run the HOL Light proofs for x86_64 assembly functions",
+        parents=[common_parser],
+    )
+
+    hol_light_parser.add_argument(
+        "-p",
+        "--proof",
+        nargs="+",
+        help="Space separated list of functions for which to run the HOL Light proofs.",
+        default=None,
+    )
+
+    hol_light_parser.add_argument(
+        "-l",
+        "--list-functions",
+        help="Don't run any proofs, but list all functions for which HOL Light proofs are available",
+        action="store_true",
+        default=False,
+    )
+
     # func arguments
     func_parser = cmd_subparsers.add_parser(
         "func",
@@ -1199,6 +1278,8 @@ def cli():
         Tests(args).bench()
     elif args.cmd == "cbmc":
         Tests(args).cbmc()
+    elif args.cmd == "hol_light":
+        Tests(args).hol_light()
     elif args.cmd == "func":
         Tests(args).func()
     elif args.cmd == "kat":


### PR DESCRIPTION
- Resolves https://github.com/pq-code-package/mldsa-native/issues/338
- Resolves https://github.com/pq-code-package/mldsa-native/issues/646
- Resolves https://github.com/pq-code-package/mldsa-native/issues/645
- Resolves https://github.com/pq-code-package/mldsa-native/issues/647

This PR includes:

- An update to s2n-bignum version to support proofs
- Addition of `list_proofs.sh`, `build-proof.sh`, `dump_bytecode.ml` utilities
- Addition of `mldsa-specs.ml` and `mldsa-utils.ml` to support HOL-Light proofs
- Addition of first HOL-Light proof for ML-DSA x86 AVX2 NTT in `mldsa_ntt.ml`
- Addition of `hol_light` to `scripts/tests` to wrap and run proofs
- READMEs for usage descriptions
- Autogen updated to use `dump_bytecode.ml` by the argument `--update-hol-light-bytecode` and `--dry-run` to check/update
- Autogen HOL-Light assembly files `gen_hol_light_asm_file` and `gen_hol_light_asm`
- 3 New CI jobs for HOL-light proofs

See the added [proofs/hol_light/x86_64/README.md](https://github.com/pq-code-package/mldsa-native/blob/fd1787ad8c412b8f651d01433689d43d83f47c4e/proofs/hol_light/x86_64/README.md) for details. 

Running `make -C proofs/hol_light/x86_64` produces an `mldsa_ntt.correct` file that ends in the following:
```
Running time: 18147.000000 sec, Start unixtime: 1762547981.000000, End unixtime: 1762566128.000000
```
(~5hour on my test EC2 m5.2xlarge, Successful in 249m in CI).

#### Discussion
There is an issue where the x86 bytecode generated on clang ARM Mac is different to that when compiled on a gcc Linux. The clang compiler performs some optimization of instructions by switching the source operands of `VPADDD` etc. to get a shorter encoding. This means the `define_assert_from_elf` check will fail when compiled on clang ARM Mac, as the proof is set with the machine code as compiled on gcc Linux (I do have proofs for both). We will have the same issue in mlkem-native when the x86 proofs arrive. So looking for opinions on (1) being okay with the x86 proofs not working on clang ARM Mac environments (2) fix the selective swapping of source operands to `VPADDD` to "optimise" the instructions down to the shorter size on gcc Linux, so both compile consistently (3) adding both proof types... likely all but (1) is out of scope of this PR -- just keeping notes.
