### PR TITLE
Make: add compiler and host platform feature detection

### DIFF
--- a/.github/actions/ct-test/action.yml
+++ b/.github/actions/ct-test/action.yml
@@ -46,4 +46,5 @@ runs:
           # It may increase run-time of the valgrind tests.
           # TODO: Check with future versions of valgrind if this is still needed (both 3.24 and 3.25 fail without)
           # TODO: Check if this is still needed once the poly_chknorm intrinsics implementation is replaced by assembly
-          tests func --exec-wrapper="valgrind --vex-guest-max-insns=55 --error-exitcode=1 ${{ inputs.valgrind_flags }}" --cflags="-DMLD_CONFIG_CT_TESTING_ENABLED -DNTESTS=5 ${{ inputs.cflags }}"
+          # Disable the AArch64 SHA3 extension as it's not yet supported by valgrind
+          MK_COMPILER_SUPPORTS_SHA3=0 tests func --exec-wrapper="valgrind --vex-guest-max-insns=55 --error-exitcode=1 ${{ inputs.valgrind_flags }}" --cflags="-DMLD_CONFIG_CT_TESTING_ENABLED -DNTESTS=5 ${{ inputs.cflags }}"

--- a/test/mk/auto.mk
+++ b/test/mk/auto.mk
@@ -2,37 +2,115 @@
 # Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-# Automatically detect system architecture and set preprocessor etc accordingly
+# Automatically detect system architecture and set preprocessor flags accordingly
+# This file detects host CPU capabilities and combines them with compiler support
+# to enable optimal compilation flags.
+
+ifndef _AUTO_MK
+_AUTO_MK :=
+
+# Helper function to check if host CPU supports a feature
+# Usage: $(call check_host_feature,feature_pattern,source_command)
+define check_host_feature
+$(shell $(2) 2>/dev/null | grep -q "$(1)" && echo 1 || echo 0)
+endef
+
+# x86_64 architecture detection
+ifeq ($(ARCH),x86_64)
+
+# Host CPU feature detection for x86_64
 ifeq ($(HOST_PLATFORM),Linux-x86_64)
-ifeq ($(CROSS_PREFIX),)
-	CFLAGS += -mavx2 -mbmi2 -mpopcnt -maes
-	CFLAGS += -DMLD_FORCE_X86_64
-else ifneq ($(findstring aarch64_be, $(CROSS_PREFIX)),)
-	CFLAGS += -DMLD_FORCE_AARCH64_EB
-else ifneq ($(findstring aarch64, $(CROSS_PREFIX)),)
-	CFLAGS += -DMLD_FORCE_AARCH64
+# Linux: Use /proc/cpuinfo
+MK_HOST_SUPPORTS_AVX2 := $(call check_host_feature,avx2,cat /proc/cpuinfo)
+MK_HOST_SUPPORTS_SSE2 := $(call check_host_feature,sse2,cat /proc/cpuinfo)
+MK_HOST_SUPPORTS_BMI2 := $(call check_host_feature,bmi2,cat /proc/cpuinfo)
+else ifeq ($(HOST_PLATFORM),Darwin-x86_64)
+# macOS: Use sysctl
+MK_HOST_SUPPORTS_AVX2 := $(call check_host_feature,AVX2,sysctl -n machdep.cpu.leaf7_features)
+MK_HOST_SUPPORTS_SSE2 := $(call check_host_feature,SSE2,sysctl -n machdep.cpu.features)
+MK_HOST_SUPPORTS_BMI2 := $(call check_host_feature,BMI2,sysctl -n machdep.cpu.leaf7_features)
+else ifneq ($(CROSS_PREFIX),)
+# Cross-compilation: assume all features are supported
+MK_HOST_SUPPORTS_AVX2 := 1
+MK_HOST_SUPPORTS_SSE2 := 1
+MK_HOST_SUPPORTS_BMI2 := 1
 else
+# Other platforms: assume no support
+MK_HOST_SUPPORTS_AVX2 := 0
+MK_HOST_SUPPORTS_SSE2 := 0
+MK_HOST_SUPPORTS_BMI2 := 0
+endif # HOST_PLATFORM x86_64
 
-endif
+endif # x86_64
 
-# linux aarch64
-else ifeq ($(HOST_PLATFORM),Linux-aarch64)
-ifeq ($(CROSS_PREFIX),)
-	CFLAGS += -DMLD_FORCE_AARCH64
-else ifneq ($(findstring x86_64, $(CROSS_PREFIX)),)
-	CFLAGS += -mavx2 -mbmi2 -mpopcnt -maes
-	CFLAGS += -DMLD_FORCE_X86_64
-else
-endif
+# AArch64 architecture detection
+ifeq ($(ARCH),aarch64)
 
-# darwin aarch64
+# Host CPU feature detection for AArch64
+ifeq ($(HOST_PLATFORM),Linux-aarch64)
+# Linux: Use /proc/cpuinfo (look for sha3 in Features line)
+MK_HOST_SUPPORTS_SHA3 := $(call check_host_feature,sha3,cat /proc/cpuinfo)
 else ifeq ($(HOST_PLATFORM),Darwin-arm64)
-ifeq ($(CROSS_PREFIX),)
-	CFLAGS += -DMLD_FORCE_AARCH64
-else ifneq ($(findstring x86_64, $(CROSS_PREFIX)),)
-	CFLAGS += -DMLD_FORCE_X86_64
-else ifneq ($(findstring aarch64, $(CROSS_PREFIX)),)
-	CFLAGS += -DMLD_FORCE_AARCH64
+# macOS: Use sysctl to check for SHA3 support
+MK_HOST_SUPPORTS_SHA3 := $(call check_host_feature,1,sysctl -n hw.optional.armv8_2_sha3)
+else ifneq ($(CROSS_PREFIX),)
+# Cross-compilation: assume all features are supported
+MK_HOST_SUPPORTS_SHA3 := 1
 else
+# Other platforms: assume no support
+MK_HOST_SUPPORTS_SHA3 := 0
+endif # HOST_PLATFORM aarch64
+
+endif # aarch64
+
+# Only apply CFLAGS modifications if AUTO=1
+ifeq ($(AUTO),1)
+
+# x86_64 CFLAGS configuration
+ifeq ($(ARCH),x86_64)
+CFLAGS += -DMLD_FORCE_X86_64
+
+# Add flags only if both compiler and host support the feature
+ifeq ($(MK_COMPILER_SUPPORTS_AVX2)$(MK_HOST_SUPPORTS_AVX2),11)
+CFLAGS += -mavx2
 endif
+
+ifeq ($(MK_COMPILER_SUPPORTS_BMI2)$(MK_HOST_SUPPORTS_BMI2),11)
+CFLAGS += -mbmi2
 endif
+endif # x86_64
+
+# AArch64 CFLAGS configuration
+ifeq ($(ARCH),aarch64)
+CFLAGS += -DMLD_FORCE_AARCH64
+
+# Add SHA3 flags only if both compiler and host support it
+ifeq ($(MK_COMPILER_SUPPORTS_SHA3)$(MK_HOST_SUPPORTS_SHA3),11)
+CFLAGS += -march=armv8.4-a+sha3
+endif
+endif # aarch64
+
+# AArch64 Big Endian CFLAGS configuration
+ifeq ($(ARCH),aarch64_be)
+CFLAGS += -DMLD_FORCE_AARCH64_EB
+endif # aarch64_be
+
+# RISC-V 64-bit CFLAGS configuration
+ifeq ($(ARCH),riscv64)
+CFLAGS += -DMLD_FORCE_RISCV64
+CFLAGS += -march=rv64gcv
+endif # riscv64
+
+# RISC-V 32-bit CFLAGS configuration
+ifeq ($(ARCH),riscv32)
+CFLAGS += -DMLD_FORCE_RISCV32
+endif # riscv32
+
+# PowerPC 64-bit Little Endian CFLAGS configuration
+ifeq ($(ARCH),powerpc64le)
+CFLAGS += -DMLD_FORCE_PPC64LE
+endif # powerpc64le
+
+endif # AUTO=1
+
+endif # _AUTO_MK

--- a/test/mk/compiler.mk
+++ b/test/mk/compiler.mk
@@ -1,0 +1,75 @@
+# Copyright (c) The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Compiler feature detection for mldsa-native
+# This file detects whether the compiler supports various architectural features
+# used by mldsa-native through compile-time tests with C code containing inline assembly.
+#
+# Feature detection can be overridden by setting the corresponding variable on the command line:
+#   make MK_COMPILER_SUPPORTS_SHA3=0    # Disable SHA3 detection
+#   make MK_COMPILER_SUPPORTS_AVX2=0    # Disable AVX2 detection
+#   make MK_COMPILER_SUPPORTS_BMI2=0    # Disable BMI2 detection
+#   make MK_COMPILER_SUPPORTS_SSE2=0    # Disable SSE2 detection
+
+ifndef _COMPILER_MK
+_COMPILER_MK :=
+
+
+# Override ARCH for cross-compilation based on CROSS_PREFIX
+ifeq ($(CROSS_PREFIX),)
+ARCH := $(shell uname -m)
+# Normalize architecture names
+ifeq ($(ARCH),arm64)
+ARCH := aarch64
+endif
+else # CROSS_PREFIX
+ifneq ($(findstring x86_64, $(CROSS_PREFIX)),)
+ARCH := x86_64
+else ifneq ($(findstring aarch64_be, $(CROSS_PREFIX)),)
+ARCH := aarch64_be
+else ifneq ($(findstring aarch64, $(CROSS_PREFIX)),)
+ARCH := aarch64
+else ifneq ($(findstring riscv64, $(CROSS_PREFIX)),)
+ARCH := riscv64
+else ifneq ($(findstring riscv32, $(CROSS_PREFIX)),)
+ARCH := riscv32
+else ifneq ($(findstring powerpc64le, $(CROSS_PREFIX)),)
+ARCH := powerpc64le
+else ifneq ($(findstring arm-none-eabi-, $(CROSS_PREFIX)),)
+ARCH := arm
+else
+ifeq ($(AUTO),1)
+$(warning Unknown cross-compilation prefix $(CROSS_PREFIX), no automatic detection of CFLAGS.)
+ARCH := unknown
+endif
+endif
+endif # CROSS_PREFIX
+
+# x86_64 feature detection
+ifeq ($(ARCH),x86_64)
+
+# Test AVX2 support using C with inline assembly
+# Can be overridden by setting MK_COMPILER_SUPPORTS_AVX2=0/1 on command line
+MK_COMPILER_SUPPORTS_AVX2 ?= $(shell echo 'int main() { __asm__("vpxor %%ymm0, %%ymm1, %%ymm2" ::: "ymm0", "ymm1", "ymm2"); return 0; }' | $(CC) -mavx2 -x c - -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+
+# Test SSE2 support using C with inline assembly
+# Can be overridden by setting MK_COMPILER_SUPPORTS_SSE2=0/1 on command line
+MK_COMPILER_SUPPORTS_SSE2 ?= $(shell echo 'int main() { __asm__("pxor %%xmm0, %%xmm1" ::: "xmm0", "xmm1"); return 0; }' | $(CC) -msse2 -x c - -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+
+# Test BMI2 support using C with inline assembly
+# Can be overridden by setting MK_COMPILER_SUPPORTS_BMI2=0/1 on command line
+MK_COMPILER_SUPPORTS_BMI2 ?= $(shell echo 'int main() { __asm__("pdep %%eax, %%ebx, %%ecx" ::: "eax", "ebx", "ecx"); return 0; }' | $(CC) -mbmi2 -x c - -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+
+endif # x86_64
+
+# AArch64 feature detection
+ifeq ($(ARCH),aarch64)
+
+# Test SHA3 support (Armv8.4-a+SHA3) using C with inline assembly
+# Can be overridden by setting MK_COMPILER_SUPPORTS_SHA3=0/1 on command line
+MK_COMPILER_SUPPORTS_SHA3 ?= $(shell echo 'int main() { __asm__("eor3 v0.16b, v1.16b, v2.16b, v3.16b" ::: "v0", "v1", "v2", "v3"); return 0; }' | $(CC) -march=armv8.4-a+sha3 -x c - -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+
+endif # aarch64
+
+endif # _COMPILER_MK

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -89,13 +89,8 @@ $(1)_FROM_ENV := $$($(1))
 endef
 $(foreach var,$(RETAINED_VARS),$(eval $(call CAPTURE_VAR,$(var))))
 
-AUTO ?= 1
 CYCLES ?=
 OPT ?= 1
-
-ifeq ($(AUTO),1)
-include test/mk/auto.mk
-endif
 
 BUILD_DIR ?= test/build
 


### PR DESCRIPTION
This commit extends the Makefiles to check both compiler and host CPU
capabilities when setting architecture flags with AUTO=1.

- Adds test/mk/compiler.mk for compile-time compiler feature detection
  (AVX2, BMI2, SSE2 for x86_64; SHA3 for AArch64)
- test/mk/auto.mk detects host CPU features and only enables
  flags when both compiler AND host support them
- Adds host_info target to display feature detection status
- Adds workaround for valgrind SHA3 incompatibility by allowing
  MK_COMPILER_SUPPORTS_SHA3=0 override on command line
- Updated .github/actions/ct-test/action.yml to disable SHA3 for
  valgrind constant-time tests

Adapted from mlkem-native commit 9da1ccd668c5c956b9c367e048a3df611dd9473
introduced in pr [#1146](https://github.com/pq-code-package/mlkem-native/pull/1146)

Fixes: https://github.com/pq-code-package/mldsa-native/issues/601

Signed-off-by: Andreas Hatziiliou <andreas.hatziiliou@savoirfairelinux.com>
