### PR TITLE
Replace `/bin/bash` by `/usr/bin/env bash`

### DIFF
--- a/META.sh
+++ b/META.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) The mlkem-native project authors
 # Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 	size_44 size_65 size_87 size \
 	run_size_44 run_size_65 run_size_87 run_size
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := build
 
 all: build

--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -88,7 +88,7 @@ CBMC_STARTER_KIT_VERSION = CBMC starter kit 2.11
 # results that are hard to explain.  Dependency handling in this
 # Makefile.common may not be perfect.
 
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 
 default: report
 


### PR DESCRIPTION
NOTE: Similar patch for mlkem-native: https://github.com/pq-code-package/mlkem-native/pull/1295

The mldsa-native package fails to build on NixOS, because NixOS does not provide `/bin/bash` by default.

On NixOS, the recommended approach is to use `/usr/bin/env bash` because this makes it easier to install different versions of `bash` on the same system. (By letting `PATH` decide which binary to execute.) Note that `/usr/bin/env bash` is also the recommended approach on MacOS to use a newer `bash` version than the system-provided one.

I see that `/usr/bin/env bash` and `/usr/bin/env python3` are already used in 15 locations (see for example: [proofs/cbmc/list_proofs.sh](https://github.com/pq-code-package/mldsa-native/blob/main/proofs/cbmc/list_proofs.sh)). Therefore, I'm proposing to replace the remaining instances of `/bin/bash` to `/usr/bin/env bash`. So, this change not only fixes builds on NixOS, but is also more consistent.