### PR TITLE
sign.c: zeroize buffers in all code paths

### DIFF
--- a/proofs/cbmc/crypto_sign_signature_internal/Makefile
+++ b/proofs/cbmc/crypto_sign_signature_internal/Makefile
@@ -33,7 +33,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
 CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 


### PR DESCRIPTION
In various functions in sign.c, the zeroization would only happen in case the function returned correctly. In the case of failure, there would be a shortcut that returns without zeroization.
This commit fixes that ensuring zeroization for all code paths.