### PR TITLE
Serial FIPS202: Do not declare mld_poly_uniform_gamma1_4x

### DIFF
--- a/mldsa/src/poly_kl.h
+++ b/mldsa/src/poly_kl.h
@@ -181,6 +181,7 @@ __contract__(
 );
 #endif /* MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 #define mld_poly_uniform_gamma1_4x MLD_NAMESPACE_KL(poly_uniform_gamma1_4x)
 /*************************************************
  * Name:        mld_poly_uniform_gamma1_4x
@@ -215,6 +216,7 @@ __contract__(
   ensures(array_bound(r2->coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1))
   ensures(array_bound(r3->coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1))
 );
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 #define mld_poly_challenge MLD_NAMESPACE_KL(poly_challenge)
 /*************************************************


### PR DESCRIPTION
When MLD_CONFIG_SERIAL_FIPS202_ONLY is set, we are not using or defining mld_poly_uniform_gamma1_4x. Hence, we should also not declare it. This commit fixes that.
Without this fix, on gets unused function warnings in a monobuild marking internal functions as static.