### PR TITLE
nix: Only run build_nix_cache CI in main branch

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,7 +49,7 @@ jobs:
 
   build_nix_cache:
     needs: [ check_modified_files ]
-    if: ${{ needs.check_modified_files.outputs.run_needed == '1' }}
+    if: ${{ needs.check_modified_files.outputs.run_needed == '1' && github.ref == 'refs/heads/main' }}
     permissions:
       actions: 'write'
       contents: 'read'
@@ -65,7 +65,7 @@ jobs:
         with:
           cache: true
           verbose: true
-          save_cache: ${{ github.ref == 'refs/heads/main' }}
+          save_cache: true
           devShell: ci
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
b4209badf3bb948a626dbfde8e5e789f947323d2 changed the nix CI to only store the cache in the main branch to stop PRs from evicting our cache entries from main.
However, with that commit PRs changing the nix setup are still running the build_nix_cache CI, but discarding the result in the end. That is not useful and wastes significant CI time. This commit changes this to only run the build_nix_cache workflow in the main branch.