### PR TITLE
native chknorm: 0/0xFFFFFFFF -> 0/1 

### DIFF
--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -136,7 +136,7 @@ static MLD_INLINE void mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   mld_poly_use_hint_88_asm(b, a, h);
 }
 
-static MLD_INLINE uint32_t mld_poly_chknorm_native(const int32_t *a, int32_t B)
+static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_asm(a, B);
 }

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -83,7 +83,7 @@ void mld_poly_use_hint_32_asm(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_asm(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_asm MLD_NAMESPACE(poly_chknorm_asm)
-uint32_t mld_poly_chknorm_asm(const int32_t *a, int32_t B);
+int mld_poly_chknorm_asm(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_asm MLD_NAMESPACE(polyz_unpack_17_asm)
 void mld_polyz_unpack_17_asm(int32_t *r, const uint8_t *buf,

--- a/dev/aarch64_clean/src/poly_chknorm_asm.S
+++ b/dev/aarch64_clean/src/poly_chknorm_asm.S
@@ -48,9 +48,10 @@ poly_chknorm_loop:
         subs count, count, #1
         bne poly_chknorm_loop
 
-        // Return 0xffffffff if any of the 4 lanes is 0xffffffff
+        // Return 1 if any of the 4 lanes is 0xffffffff
         umaxv s21, flags.4s
         fmov w0, s21
+        and w0, w0, #1
 
         ret
 

--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -143,7 +143,7 @@ static MLD_INLINE void mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                             (const __m256i *)h);
 }
 
-static MLD_INLINE uint32_t mld_poly_chknorm_native(const int32_t *a, int32_t B)
+static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_avx2((const __m256i *)a, B);
 }

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -70,7 +70,7 @@ void mld_poly_use_hint_32_avx2(__m256i *b, const __m256i *a, const __m256i *h);
 void mld_poly_use_hint_88_avx2(__m256i *b, const __m256i *a, const __m256i *h);
 
 #define mld_poly_chknorm_avx2 MLD_NAMESPACE(mld_poly_chknorm_avx2)
-uint32_t mld_poly_chknorm_avx2(const __m256i *a, int32_t B);
+int mld_poly_chknorm_avx2(const __m256i *a, int32_t B);
 
 #define mld_polyz_unpack_17_avx2 MLD_NAMESPACE(mld_polyz_unpack_17_avx2)
 void mld_polyz_unpack_17_avx2(__m256i *r, const uint8_t *a);

--- a/dev/x86_64/src/poly_chknorm_avx2.c
+++ b/dev/x86_64/src/poly_chknorm_avx2.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include "arith_native_x86_64.h"
 
-uint32_t mld_poly_chknorm_avx2(const __m256i *a, int32_t B)
+int mld_poly_chknorm_avx2(const __m256i *a, int32_t B)
 {
   unsigned int i;
   __m256i f, t;
@@ -41,7 +41,7 @@ uint32_t mld_poly_chknorm_avx2(const __m256i *a, int32_t B)
     t = _mm256_or_si256(t, f);
   }
 
-  return (uint32_t)(_mm256_testz_si256(t, t) - 1);
+  return 1 - _mm256_testz_si256(t, t);
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/mldsa/src/native/aarch64/meta.h
+++ b/mldsa/src/native/aarch64/meta.h
@@ -136,7 +136,7 @@ static MLD_INLINE void mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   mld_poly_use_hint_88_asm(b, a, h);
 }
 
-static MLD_INLINE uint32_t mld_poly_chknorm_native(const int32_t *a, int32_t B)
+static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_asm(a, B);
 }

--- a/mldsa/src/native/aarch64/src/arith_native_aarch64.h
+++ b/mldsa/src/native/aarch64/src/arith_native_aarch64.h
@@ -83,7 +83,7 @@ void mld_poly_use_hint_32_asm(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_asm(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_asm MLD_NAMESPACE(poly_chknorm_asm)
-uint32_t mld_poly_chknorm_asm(const int32_t *a, int32_t B);
+int mld_poly_chknorm_asm(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_asm MLD_NAMESPACE(polyz_unpack_17_asm)
 void mld_polyz_unpack_17_asm(int32_t *r, const uint8_t *buf,

--- a/mldsa/src/native/aarch64/src/poly_chknorm_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_chknorm_asm.S
@@ -43,6 +43,7 @@ Lpoly_chknorm_loop:
         b.ne	Lpoly_chknorm_loop
         umaxv	s21, v21.4s
         fmov	w0, s21
+        and	w0, w0, #0x1
         ret
         .cfi_endproc
 

--- a/mldsa/src/native/api.h
+++ b/mldsa/src/native/api.h
@@ -264,10 +264,10 @@ static MLD_INLINE void mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
  * Arguments:   - const int32_t *a: pointer to polynomial
  *              - int32_t B: norm bound
  *
- * Returns 0 if the infinity norm is strictly smaller than B, and 0xFFFFFFFF
+ * Returns 0 if the infinity norm is strictly smaller than B, and 1
  * otherwise. B must not be larger than MLDSA_Q - REDUCE32_RANGE_MAX.
  **************************************************/
-static MLD_INLINE uint32_t mld_poly_chknorm_native(const int32_t *a, int32_t B);
+static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B);
 #endif /* MLD_USE_NATIVE_POLY_CHKNORM */
 
 #if defined(MLD_USE_NATIVE_POLYZ_UNPACK_17)

--- a/mldsa/src/native/x86_64/meta.h
+++ b/mldsa/src/native/x86_64/meta.h
@@ -143,7 +143,7 @@ static MLD_INLINE void mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                             (const __m256i *)h);
 }
 
-static MLD_INLINE uint32_t mld_poly_chknorm_native(const int32_t *a, int32_t B)
+static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_avx2((const __m256i *)a, B);
 }

--- a/mldsa/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mldsa/src/native/x86_64/src/arith_native_x86_64.h
@@ -70,7 +70,7 @@ void mld_poly_use_hint_32_avx2(__m256i *b, const __m256i *a, const __m256i *h);
 void mld_poly_use_hint_88_avx2(__m256i *b, const __m256i *a, const __m256i *h);
 
 #define mld_poly_chknorm_avx2 MLD_NAMESPACE(mld_poly_chknorm_avx2)
-uint32_t mld_poly_chknorm_avx2(const __m256i *a, int32_t B);
+int mld_poly_chknorm_avx2(const __m256i *a, int32_t B);
 
 #define mld_polyz_unpack_17_avx2 MLD_NAMESPACE(mld_polyz_unpack_17_avx2)
 void mld_polyz_unpack_17_avx2(__m256i *r, const uint8_t *a);

--- a/mldsa/src/native/x86_64/src/poly_chknorm_avx2.c
+++ b/mldsa/src/native/x86_64/src/poly_chknorm_avx2.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include "arith_native_x86_64.h"
 
-uint32_t mld_poly_chknorm_avx2(const __m256i *a, int32_t B)
+int mld_poly_chknorm_avx2(const __m256i *a, int32_t B)
 {
   unsigned int i;
   __m256i f, t;
@@ -41,7 +41,7 @@ uint32_t mld_poly_chknorm_avx2(const __m256i *a, int32_t B)
     t = _mm256_or_si256(t, f);
   }
 
-  return (uint32_t)(_mm256_testz_si256(t, t) - 1);
+  return 1 - _mm256_testz_si256(t, t);
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/mldsa/src/poly.c
+++ b/mldsa/src/poly.c
@@ -589,8 +589,11 @@ uint32_t mld_poly_chknorm(const mld_poly *a, int32_t B)
 #if defined(MLD_USE_NATIVE_POLY_CHKNORM)
   /* TODO: proof */
   mld_assert_bound(a->coeffs, MLDSA_N, -REDUCE32_RANGE_MAX, REDUCE32_RANGE_MAX);
-  return mld_poly_chknorm_native(a->coeffs, B);
-#else
+
+  /* The native backend returns 0 if all coeffs within the bound, 1 otherwise */
+  /* Convert to 0 / 0xFFFFFFFF here */
+  return 0U - (uint32_t)mld_poly_chknorm_native(a->coeffs, B);
+#else  /* MLD_USE_NATIVE_POLY_CHKNORM */
   unsigned int i;
   uint32_t t = 0;
   mld_assert_bound(a->coeffs, MLDSA_N, -REDUCE32_RANGE_MAX, REDUCE32_RANGE_MAX);


### PR DESCRIPTION
Previously the native chknorm functions would follow the C implementation,
i.e., return 0 if all coefficients are within bound and 0xFFFFFFFF otherwise.
This leads to problems with the run-time dispatch in
https://github.com/pq-code-package/mldsa-native/pull/607
as we want to use -1 to signal that the current platforms lacks the required
capabilities to run the native code, and we should fall back to the C
implementation.

This commit changes the backend API to return 1 in the failure mode.
This will allow to implement the run-time dispatch.