### PR TITLE
Port: add --aarch64-fips202-backend to tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,27 @@ jobs:
           compile_mode: native
           cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
           ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+  backend_tests:
+    name: AArch64 FIPS202 backends (${{ matrix.backend }})
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [x1_scalar, x1_v84a, x2_v84a, x4_v8a_scalar, x4_v8a_v84a_scalar]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: build + test
+        uses: ./.github/actions/multi-functest
+        with:
+          nix-shell: 'ci'
+          nix-cache: 'false'
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: 'native'
+          opt: 'opt'
+          examples: 'false'
+          cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+          ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+          extra_args: "--fips202-aarch64-backend ${{ matrix.backend }}"
   compiler_tests:
     name: Compiler tests  (${{ matrix.compiler.name }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
     strategy:

--- a/scripts/tests
+++ b/scripts/tests
@@ -407,6 +407,18 @@ class Tests:
         if test_type.is_example() and self.args.cross_prefix != "":
             cflags += " -static"
 
+        # Add FIPS202 backend selection if specified and this is an OPT build
+        if self.args.fips202_aarch64_backend != "auto" and opt is True:
+            # Make sure we're forcing AArch64 architecture
+            if not " -DMLD_FORCE_AARCH64" in cflags:
+                cflags += " -DMLD_FORCE_AARCH64"
+
+            # Enable native backend for FIPS202
+            cflags += " -DMLD_CONFIG_USE_NATIVE_BACKEND_FIPS202"
+
+            # Specify the backend file
+            cflags += f' -DMLD_CONFIG_FIPS202_BACKEND_FILE=\\"fips202/native/aarch64/{self.args.fips202_aarch64_backend}.h\\"'
+
         env_update = {}
         if cflags != "":
             env_update["CFLAGS"] = cflags
@@ -892,6 +904,21 @@ def cli():
         choices=["ALL", "OPT", "NO_OPT"],
         type=str.upper,
         default="ALL",
+    )
+
+    common_parser.add_argument(
+        "--fips202-aarch64-backend",
+        help="Select FIPS202 AArch64 backend",
+        choices=[
+            "auto",
+            "x1_scalar",
+            "x1_v84a",
+            "x2_v84a",
+            "x4_v8a_scalar",
+            "x4_v8a_v84a_scalar",
+        ],
+        default="auto",
+        type=str,
     )
 
     # --run / --no-run


### PR DESCRIPTION
- Resolves: #621 

- This PR is ported from mlkem-native PR #1106.

- This PR adds the `--aarch64-fips202-backend` option to the `tests` scripts, allowing the FIPS202 backend to be specified directly as an input parameter, this makes testing different FIPS202 AArch64 backends easier, also adds `backend_tests` to the CI workflow.