### PR TITLE
CI: Add cross tests for RVV

### DIFF
--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -152,7 +152,7 @@ runs:
           examples: ${{ inputs.examples }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
-      - name: Cross riscv64 Tests
+      - name: Cross riscv64 Tests (RVV, VLEN=128)
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
         uses: ./.github/actions/functest
         with:
@@ -164,7 +164,64 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
           ldflags: ${{ inputs.ldflags }}
           cross_prefix: riscv64-unknown-linux-gnu-
-          exec_wrapper: qemu-riscv64
+          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=128"
+          opt: ${{ inputs.opt }}
+          func: ${{ inputs.func }}
+          kat: ${{ inputs.kat }}
+          acvp: ${{ inputs.acvp }}
+          examples: ${{ inputs.examples }}
+          stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
+      - name: Cross riscv64 Tests (RVV, VLEN=256)
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
+        uses: ./.github/actions/functest
+        with:
+          nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
+          gh_token: ${{ inputs.gh_token }}
+          custom_shell: ${{ inputs.custom_shell }}
+          cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
+          cross_prefix: riscv64-unknown-linux-gnu-
+          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=256"
+          opt: ${{ inputs.opt }}
+          func: ${{ inputs.func }}
+          kat: ${{ inputs.kat }}
+          acvp: ${{ inputs.acvp }}
+          examples: ${{ inputs.examples }}
+          stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
+      - name: Cross riscv64 Tests (RVV, VLEN=512)
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
+        uses: ./.github/actions/functest
+        with:
+          nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
+          gh_token: ${{ inputs.gh_token }}
+          custom_shell: ${{ inputs.custom_shell }}
+          cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
+          cross_prefix: riscv64-unknown-linux-gnu-
+          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=512"
+          opt: ${{ inputs.opt }}
+          func: ${{ inputs.func }}
+          kat: ${{ inputs.kat }}
+          acvp: ${{ inputs.acvp }}
+          examples: ${{ inputs.examples }}
+          stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
+      - name: Cross riscv64 Tests (RVV, VLEN=1024)
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
+        uses: ./.github/actions/functest
+        with:
+          nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
+          gh_token: ${{ inputs.gh_token }}
+          custom_shell: ${{ inputs.custom_shell }}
+          cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
+          cross_prefix: riscv64-unknown-linux-gnu-
+          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=1024"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}


### PR DESCRIPTION
- Resolves: #625

- This PR replaces the existing RISC-V64 tests with multiple RVV RISC-V64 tests that use different VLEN values (128/256/512/1024).