### PR TITLE
sys.h: Detect little endian when compiling with MSVC

### DIFF
--- a/mldsa/src/sys.h
+++ b/mldsa/src/sys.h
@@ -22,6 +22,15 @@
 #error "__BYTE_ORDER__ defined, but don't recognize value."
 #endif
 #endif /* __BYTE_ORDER__ */
+
+/* MSVC does not define __BYTE_ORDER__. However, MSVC only supports
+ * little endian x86, x86_64, and AArch64. It is, hence, safe to assume
+ * little endian. */
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64) || \
+                          defined(_M_IX86) || defined(_M_ARM64))
+#define MLD_SYS_LITTLE_ENDIAN
+#endif
+
 #endif /* !MLD_SYS_LITTLE_ENDIAN && !MLD_SYS_BIG_ENDIAN */
 
 /* Check if we're running on an AArch64 little endian system. _M_ARM64 is set by


### PR DESCRIPTION
This commit adds detection for endianness with MSVC - MSVC does not define __BYTE_ORDER__, and, hence our current detection does not capture it.

MSVC currently supports 3 platforms: x86, x86_64, and AArch64 (AArch32 was recently removed in VS 2026 18.0)
See
https://learn.microsoft.com/en-us/cpp/overview/supported-platforms-visual-cpp

x86 and x86_64 are always little endian.
AArch64 can be either little endian or big endian, but MSVC/Windows only supports little endian:
https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions

For AArch32, I can't find explicit statements that MSVC was always limited to little endian, so I've commited that.

See
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros

- Resolves https://github.com/pq-code-package/mldsa-native/issues/620