### PR TITLE
ACVP: Update to v1.1.0.41

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -69,7 +69,7 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
-        acvp-version: [v1.1.0.38, v1.1.0.39, v1.1.0.40]
+        acvp-version: [v1.1.0.39, v1.1.0.40, v1.1.0.41]
         exclude:
           - {external: true,
              target: {

--- a/README.md
+++ b/README.md
@@ -92,18 +92,18 @@ You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP 
 # Using the tests script
 ./scripts/tests acvp
 # Using a specific ACVP release
-./scripts/tests acvp --version v1.1.0.40
+./scripts/tests acvp --version v1.1.0.41
 
 # Using the ACVP client directly
 python3 ./test/acvp_client.py
-python3 ./test/acvp_client.py --version v1.1.0.40
+python3 ./test/acvp_client.py --version v1.1.0.41
 
 # Using specific ACVP test vector files (downloaded from the ACVP-Server)
 # python3 ./test/acvp_client.py -p {PROMPT}.json -e {EXPECTED_RESULT}.json
 # For example, assuming you have run the above
 python3 ./test/acvp_client.py \
-  -p ./test/.acvp-data/v1.1.0.40/files/ML-DSA-sigVer-FIPS204/prompt.json \
-  -e ./test/.acvp-data/v1.1.0.40/files/ML-DSA-sigVer-FIPS204/expectedResults.json
+  -p ./test/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/prompt.json \
+  -e ./test/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/expectedResults.json
 ```
 
 ## Benchmarking

--- a/scripts/tests
+++ b/scripts/tests
@@ -1085,8 +1085,8 @@ def cli():
     )
     acvp_parser.add_argument(
         "--version",
-        default="v1.1.0.40",
-        help="ACVP test vector version (default: v1.1.0.40)",
+        default="v1.1.0.41",
+        help="ACVP test vector version (default: v1.1.0.41)",
     )
 
     # examples arguments

--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -22,7 +22,7 @@ exec_prefix = os.environ.get("EXEC_WRAPPER", "")
 exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
 
-def download_acvp_files(version="v1.1.0.40"):
+def download_acvp_files(version):
     """Download ACVP test files for the specified version if not present."""
     base_url = f"https://raw.githubusercontent.com/usnistgov/ACVP-Server/{version}/gen-val/json-files"
 
@@ -78,7 +78,7 @@ def loadAcvpData(prompt, expectedResults):
     return (prompt, promptData, expectedResults, expectedResultsData)
 
 
-def loadDefaultAcvpData(version="v1.1.0.40"):
+def loadDefaultAcvpData(version):
     data_dir = f"test/.acvp-data/{version}/files"
     acvp_jsons_for_version = [
         (
@@ -418,7 +418,7 @@ def runTest(data, output):
     info("ALL GOOD!")
 
 
-def test(prompt, expected, output, version="v1.1.0.40"):
+def test(prompt, expected, output, version):
     assert (
         prompt is not None or output is None
     ), "cannot produce output if there is no input"
@@ -453,8 +453,8 @@ parser.add_argument(
 parser.add_argument(
     "--version",
     "-v",
-    default="v1.1.0.40",
-    help="ACVP test vector version (default: v1.1.0.40)",
+    default="v1.1.0.41",
+    help="ACVP test vector version (default: v1.1.0.41)",
 )
 args = parser.parse_args()
 


### PR DESCRIPTION
Update to the recently released ACVP testvectors v1.1.0.41: https://github.com/usnistgov/ACVP-Server/releases/tag/v1.1.0.41

No changes have been made to the ML-DSA testvectors.