### PR TITLE
Standardize on signed integers in quantifiers and loops.

### DIFF
--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -32,6 +32,7 @@
 
 
 #if !defined(__ASSEMBLER__)
+#include <stddef.h>
 #include "../api.h"
 #include "src/arith_native_aarch64.h"
 
@@ -49,9 +50,8 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
-static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
-                                             const uint8_t *buf,
-                                             unsigned buflen)
+static MLD_INLINE int mld_rej_uniform_native(int32_t *r, int len,
+                                             const uint8_t *buf, int buflen)
 {
   if (len != MLDSA_N ||
       buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
@@ -59,15 +59,15 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
     return MLD_NATIVE_FUNC_FALLBACK;
   }
 
-  /* Safety: outlen is at most MLDSA_N, hence, this cast is safe. */
+  /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)mld_rej_uniform_asm(r, buf, buflen, mld_rej_uniform_table);
 }
 
-static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
   if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
   {
@@ -82,16 +82,16 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta2_asm(r, buf, buflen, mld_rej_uniform_eta_table);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }
 
-static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
   if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
   {
@@ -106,7 +106,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta4_asm(r, buf, buflen, mld_rej_uniform_eta_table);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -56,16 +56,16 @@ void mld_ntt_asm(int32_t *, const int32_t *, const int32_t *);
 void mld_intt_asm(int32_t *, const int32_t *, const int32_t *);
 
 #define mld_rej_uniform_asm MLD_NAMESPACE(rej_uniform_asm)
-uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, unsigned buflen,
+uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
                              const uint8_t *table);
 
 #define mld_rej_uniform_eta2_asm MLD_NAMESPACE(rej_uniform_eta2_asm)
-unsigned mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf,
-                                  unsigned buflen, const uint8_t *table);
+int32_t mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
+                                 const uint8_t *table);
 
 #define mld_rej_uniform_eta4_asm MLD_NAMESPACE(rej_uniform_eta4_asm)
-unsigned mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf,
-                                  unsigned buflen, const uint8_t *table);
+int32_t mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
+                                 const uint8_t *table);
 
 #define mld_poly_decompose_32_asm MLD_NAMESPACE(poly_decompose_32_asm)
 void mld_poly_decompose_32_asm(int32_t *a1, int32_t *a0, const int32_t *a);

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -32,6 +32,7 @@
 
 
 #if !defined(__ASSEMBLER__)
+#include <stddef.h>
 #include "../api.h"
 #include "src/arith_native_aarch64.h"
 
@@ -49,9 +50,8 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
-static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
-                                             const uint8_t *buf,
-                                             unsigned buflen)
+static MLD_INLINE int mld_rej_uniform_native(int32_t *r, int len,
+                                             const uint8_t *buf, int buflen)
 {
   if (len != MLDSA_N ||
       buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
@@ -59,15 +59,15 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
     return MLD_NATIVE_FUNC_FALLBACK;
   }
 
-  /* Safety: outlen is at most MLDSA_N, hence, this cast is safe. */
+  /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)mld_rej_uniform_asm(r, buf, buflen, mld_rej_uniform_table);
 }
 
-static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
   if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
   {
@@ -82,16 +82,16 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta2_asm(r, buf, buflen, mld_rej_uniform_eta_table);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }
 
-static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
   if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
   {
@@ -106,7 +106,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta4_asm(r, buf, buflen, mld_rej_uniform_eta_table);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -56,16 +56,16 @@ void mld_ntt_asm(int32_t *, const int32_t *, const int32_t *);
 void mld_intt_asm(int32_t *, const int32_t *, const int32_t *);
 
 #define mld_rej_uniform_asm MLD_NAMESPACE(rej_uniform_asm)
-uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, unsigned buflen,
+uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
                              const uint8_t *table);
 
 #define mld_rej_uniform_eta2_asm MLD_NAMESPACE(rej_uniform_eta2_asm)
-unsigned mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf,
-                                  unsigned buflen, const uint8_t *table);
+int32_t mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
+                                 const uint8_t *table);
 
 #define mld_rej_uniform_eta4_asm MLD_NAMESPACE(rej_uniform_eta4_asm)
-unsigned mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf,
-                                  unsigned buflen, const uint8_t *table);
+int32_t mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
+                                 const uint8_t *table);
 
 #define mld_poly_decompose_32_asm MLD_NAMESPACE(poly_decompose_32_asm)
 void mld_poly_decompose_32_asm(int32_t *a1, int32_t *a0, const int32_t *a);

--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -31,6 +31,7 @@
 #define MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7
 
 #if !defined(__ASSEMBLER__)
+#include <stddef.h>
 #include <string.h>
 #include "../../common.h"
 #include "../api.h"
@@ -64,9 +65,8 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
-static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
-                                             const uint8_t *buf,
-                                             unsigned buflen)
+static MLD_INLINE int mld_rej_uniform_native(int32_t *r, int len,
+                                             const uint8_t *buf, int buflen)
 {
   /* AVX2 implementation assumes specific buffer lengths */
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
@@ -79,11 +79,11 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_avx2(r, buf);
 }
 
-static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AVX2 implementation assumes specific buffer lengths */
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN)
@@ -100,16 +100,16 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta2_avx2(r, buf);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }
 
-static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AVX2 implementation assumes specific buffer lengths */
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN)
@@ -126,7 +126,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta4_avx2(r, buf);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -43,15 +43,15 @@ void mld_invntt_avx2(__m256i *r, const __m256i *mld_qdata);
 void mld_nttunpack_avx2(__m256i *r);
 
 #define mld_rej_uniform_avx2 MLD_NAMESPACE(mld_rej_uniform_avx2)
-unsigned mld_rej_uniform_avx2(int32_t *r,
-                              const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN]);
+int32_t mld_rej_uniform_avx2(int32_t *r,
+                             const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN]);
 
 #define mld_rej_uniform_eta2_avx2 MLD_NAMESPACE(mld_rej_uniform_eta2_avx2)
-unsigned mld_rej_uniform_eta2_avx2(
+int32_t mld_rej_uniform_eta2_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN]);
 
 #define mld_rej_uniform_eta4_avx2 MLD_NAMESPACE(mld_rej_uniform_eta4_avx2)
-unsigned mld_rej_uniform_eta4_avx2(
+int32_t mld_rej_uniform_eta4_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN]);
 
 #define mld_poly_decompose_32_avx2 MLD_NAMESPACE(mld_poly_decompose_32_avx2)

--- a/dev/x86_64/src/rej_uniform_avx2.c
+++ b/dev/x86_64/src/rej_uniform_avx2.c
@@ -36,8 +36,8 @@
  *            frontend to perform the unintuitive padding.
  */
 
-unsigned int mld_rej_uniform_avx2(
-    int32_t *MLD_RESTRICT r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN])
+int32_t mld_rej_uniform_avx2(int32_t *MLD_RESTRICT r,
+                             const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN])
 {
   unsigned int ctr, pos;
   uint32_t good;
@@ -116,7 +116,7 @@ unsigned int mld_rej_uniform_avx2(
     }
   }
 
-  return ctr;
+  return (int32_t)ctr;
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/dev/x86_64/src/rej_uniform_eta2_avx2.c
+++ b/dev/x86_64/src/rej_uniform_eta2_avx2.c
@@ -35,7 +35,7 @@
  *            rej_eta_avx and supports multiple values for ETA via preprocessor
  *            conditionals. We move the conditionals to the frontend.
  */
-unsigned int mld_rej_uniform_eta2_avx2(
+int32_t mld_rej_uniform_eta2_avx2(
     int32_t *MLD_RESTRICT r,
     const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN])
 {
@@ -139,7 +139,7 @@ unsigned int mld_rej_uniform_eta2_avx2(
     }
   }
 
-  return ctr;
+  return (int32_t)ctr;
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/dev/x86_64/src/rej_uniform_eta4_avx2.c
+++ b/dev/x86_64/src/rej_uniform_eta4_avx2.c
@@ -36,7 +36,7 @@
  *            conditionals. We move the conditionals to the frontend.
  */
 
-unsigned int mld_rej_uniform_eta4_avx2(
+int32_t mld_rej_uniform_eta4_avx2(
     int32_t *MLD_RESTRICT r,
     const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN])
 {
@@ -123,7 +123,7 @@ unsigned int mld_rej_uniform_eta4_avx2(
     }
   }
 
-  return ctr;
+  return (int32_t)ctr;
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/mldsa/src/cbmc.h
+++ b/mldsa/src/cbmc.h
@@ -93,14 +93,14 @@
 #define forall(qvar, qvar_lb, qvar_ub, predicate)                 \
   __CPROVER_forall                                                \
   {                                                               \
-    unsigned qvar;                                                \
+    signed int qvar;                                              \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==> (predicate)   \
   }
 
 #define exists(qvar, qvar_lb, qvar_ub, predicate)         \
   __CPROVER_exists                                              \
   {                                                             \
-    unsigned qvar;                                              \
+    signed int qvar;                                            \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) && (predicate)  \
   }
 /* clang-format on */
@@ -119,7 +119,7 @@
                          value_lb, value_ub)                           \
   __CPROVER_forall                                                     \
   {                                                                    \
-    unsigned qvar;                                                     \
+    signed int qvar;                                                   \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
         (((int)(value_lb) <= ((array_var)[(qvar)])) &&		       \
          (((array_var)[(qvar)]) < (int)(value_ub)))		       \

--- a/mldsa/src/debug.c
+++ b/mldsa/src/debug.c
@@ -30,11 +30,11 @@ void mld_debug_check_assert(const char *file, int line, const int val)
 }
 
 void mld_debug_check_bounds(const char *file, int line, const int32_t *ptr,
-                            unsigned len, int64_t lower_bound_exclusive,
+                            int len, int64_t lower_bound_exclusive,
                             int64_t upper_bound_exclusive)
 {
   int err = 0;
-  unsigned i;
+  int i;
   for (i = 0; i < len; i++)
   {
     int32_t val = ptr[i];

--- a/mldsa/src/debug.h
+++ b/mldsa/src/debug.h
@@ -43,7 +43,7 @@ void mld_debug_check_assert(const char *file, int line, const int val);
  **************************************************/
 #define mld_debug_check_bounds MLD_NAMESPACE(mldsa_debug_check_bounds)
 void mld_debug_check_bounds(const char *file, int line, const int32_t *ptr,
-                            unsigned len, int64_t lower_bound_exclusive,
+                            int len, int64_t lower_bound_exclusive,
                             int64_t upper_bound_exclusive);
 
 /* Check assertion, calling exit() upon failure

--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -64,45 +64,44 @@ __contract__(
  * Description: Absorb step of Keccak; incremental.
  *
  * Arguments:   - uint64_t *s: pointer to Keccak state
- *              - unsigned int pos: position in current block to be absorbed
- *              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+ *              - int pos: position in current block to be absorbed
+ *              - int r: rate in bytes (e.g., 168 for SHAKE128)
  *              - const uint8_t *in: pointer to input to be absorbed into s
  *              - size_t inlen: length of input in bytes
  *
  * Returns new position pos in current block
  **************************************************/
-static unsigned int keccak_absorb(uint64_t s[MLD_KECCAK_LANES],
-                                  unsigned int pos, unsigned int r,
-                                  const uint8_t *in, size_t inlen)
+static int keccak_absorb(uint64_t s[MLD_KECCAK_LANES], int pos, int r,
+                         const uint8_t *in, size_t inlen)
 __contract__(
   requires(inlen <= MLD_MAX_BUFFER_SIZE)
-  requires(r < sizeof(uint64_t) * MLD_KECCAK_LANES)
-  requires(pos <= r)
+  requires(r >= 0 && r < sizeof(uint64_t) * MLD_KECCAK_LANES)
+  requires(pos >= 0 && pos <= r)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   requires(memory_no_alias(in, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
-  ensures(return_value < r))
+  ensures(return_value >= 0 && return_value < r))
 {
-  while (inlen >= r - pos)
+  while (inlen >= (size_t)r - (size_t)pos)
   __loop__(
     assigns(pos, in, inlen,
       memory_slice(s, sizeof(uint64_t) *  MLD_KECCAK_LANES))
+    invariant(pos >= 0 && pos <= r)
     invariant(inlen <= loop_entry(inlen))
-    invariant(pos <= r)
     invariant(in == loop_entry(in) + (loop_entry(inlen) - inlen)))
   {
     mld_keccakf1600_xor_bytes(s, in, pos, r - pos);
-    inlen -= r - pos;
+    inlen -= (size_t)r - (size_t)pos;
     in += r - pos;
     mld_keccakf1600_permute(s);
     pos = 0;
   }
-  /* Safety: At this point, inlen < r, so the truncation to unsigned is safe. */
-  mld_keccakf1600_xor_bytes(s, in, pos, (unsigned)inlen);
+  /* Safety: At this point, inlen < r, so the cast to int is safe. */
+  mld_keccakf1600_xor_bytes(s, in, pos, (int)inlen);
 
-  /* Safety: At this point, inlen < r and pos <= r so the truncation to unsigned
+  /* Safety: At this point, inlen < r and pos <= r so the cast to int
    * is safe. */
-  return (unsigned)(pos + inlen);
+  return pos + (int)inlen;
 }
 
 /*************************************************
@@ -111,15 +110,15 @@ __contract__(
  * Description: Finalize absorb step.
  *
  * Arguments:   - uint64_t *s: pointer to Keccak state
- *              - unsigned int pos: position in current block to be absorbed
- *              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+ *              - int pos: position in current block to be absorbed
+ *              - int r: rate in bytes (e.g., 168 for SHAKE128)
  *              - uint8_t p: domain separation byte
  **************************************************/
-static void keccak_finalize(uint64_t s[MLD_KECCAK_LANES], unsigned int pos,
-                            unsigned int r, uint8_t p)
+static void keccak_finalize(uint64_t s[MLD_KECCAK_LANES], int pos, int r,
+                            uint8_t p)
 __contract__(
-  requires(pos <= r && r < sizeof(uint64_t) * MLD_KECCAK_LANES)
-  requires((r / 8) >= 1)
+  requires(pos >= 0 && pos <= r && r < sizeof(uint64_t) * MLD_KECCAK_LANES)
+  requires(r >= 0 && (r / 8) >= 1)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
 )
@@ -139,28 +138,28 @@ __contract__(
  * Arguments:   - uint8_t *out: pointer to output data
  *              - size_t outlen: number of bytes to be squeezed (written to out)
  *              - uint64_t *s: pointer to input/output Keccak state
- *              - unsigned int pos: number of bytes in current block already
- *squeezed
- *              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+ *              - int pos: number of bytes in current block already squeezed
+ *              - int r: rate in bytes (e.g., 168 for SHAKE128)
  *
  * Returns new position pos in current block
  **************************************************/
-static unsigned int keccak_squeeze(uint8_t *out, size_t outlen,
-                                   uint64_t s[MLD_KECCAK_LANES],
-                                   unsigned int pos, unsigned int r)
+static int keccak_squeeze(uint8_t *out, size_t outlen,
+                          uint64_t s[MLD_KECCAK_LANES], int pos, int r)
 __contract__(
+  requires(pos >= 0 && pos <= r)
   requires((r == SHAKE128_RATE && pos <= SHAKE128_RATE) ||
            (r == SHAKE256_RATE && pos <= SHAKE256_RATE) ||
            (r == SHA3_512_RATE && pos <= SHA3_512_RATE))
+  requires(r >= 0)
   requires(outlen <= 8 * r /* somewhat arbitrary bound */)
   requires(memory_no_alias(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   requires(memory_no_alias(out, outlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   assigns(memory_slice(out, outlen))
-  ensures(return_value <= r))
+  ensures(return_value >= 0 && return_value <= r))
 {
-  unsigned int i;
-  size_t out_offset = 0;
+  int i;
+  int out_offset = 0;
 
   /* Reference: This code is re-factored from the reference implementation
    * to facilitate proof with CBMC and to improve readability.
@@ -168,14 +167,14 @@ __contract__(
    * Take a mutable copy of outlen to count down the number of bytes
    * still to squeeze. The initial value of outlen is needed for the CBMC
    * assigns() clauses. */
-  size_t bytes_to_go = outlen;
+  int bytes_to_go = (int)outlen;
 
   while (bytes_to_go > 0)
   __loop__(
     assigns(i, bytes_to_go, pos, out_offset, memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES), memory_slice(out, outlen))
-    invariant(bytes_to_go <= outlen)
-    invariant(out_offset == outlen - bytes_to_go)
-    invariant(pos <= r)
+    invariant(pos >= 0 && pos <= r)
+    invariant(bytes_to_go >= 0 && bytes_to_go <= outlen)
+    invariant(out_offset == (int)outlen - bytes_to_go)
   )
   {
     if (pos == r)
@@ -184,7 +183,7 @@ __contract__(
       pos = 0;
     }
     /* Safety: If bytes_to_go < r - pos, truncation to unsigned is safe. */
-    i = bytes_to_go < r - pos ? (unsigned)bytes_to_go : r - pos;
+    i = (bytes_to_go < r - pos) ? bytes_to_go : r - pos;
     mld_keccakf1600_extract_bytes(s, out + out_offset, pos, i);
     bytes_to_go -= i;
     pos += i;

--- a/mldsa/src/fips202/fips202.h
+++ b/mldsa/src/fips202/fips202.h
@@ -22,13 +22,13 @@
 typedef struct
 {
   uint64_t s[MLD_KECCAK_LANES];
-  unsigned int pos;
+  int pos;
 } mld_shake128ctx;
 
 typedef struct
 {
   uint64_t s[MLD_KECCAK_LANES];
-  unsigned int pos;
+  int pos;
 } mld_shake256ctx;
 
 #define mld_shake128_init MLD_NAMESPACE(shake128_init)
@@ -63,9 +63,9 @@ __contract__(
   requires(inlen <= MLD_MAX_BUFFER_SIZE)
   requires(memory_no_alias(state, sizeof(mld_shake128ctx)))
   requires(memory_no_alias(in, inlen))
-  requires(state->pos <= SHAKE128_RATE)
+  requires(state->pos >= 0 && state->pos <= SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(mld_shake128ctx)))
-  ensures(state->pos <= SHAKE128_RATE)
+  ensures(state->pos >= 0 && state->pos <= SHAKE128_RATE)
 );
 
 #define mld_shake128_finalize MLD_NAMESPACE(shake128_finalize)
@@ -79,9 +79,9 @@ __contract__(
 void mld_shake128_finalize(mld_shake128ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake128ctx)))
-  requires(state->pos <= SHAKE128_RATE)
+  requires(state->pos >= 0 && state->pos <= SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(mld_shake128ctx)))
-  ensures(state->pos <= SHAKE128_RATE)
+  ensures(state->pos >= 0 && state->pos <= SHAKE128_RATE)
 );
 
 #define mld_shake128_squeeze MLD_NAMESPACE(shake128_squeeze)
@@ -101,10 +101,10 @@ __contract__(
   requires(outlen <= 8 * SHAKE128_RATE /* somewhat arbitrary bound */)
   requires(memory_no_alias(state, sizeof(mld_shake128ctx)))
   requires(memory_no_alias(out, outlen))
-  requires(state->pos <= SHAKE128_RATE)
+  requires(state->pos >= 0 && state->pos <= SHAKE128_RATE)
   assigns(memory_slice(state, sizeof(mld_shake128ctx)))
   assigns(memory_slice(out, outlen))
-  ensures(state->pos <= SHAKE128_RATE)
+  ensures(state->pos >= 0 && state->pos <= SHAKE128_RATE)
 );
 
 #define mld_shake128_release MLD_NAMESPACE(shake128_release)
@@ -153,9 +153,9 @@ __contract__(
   requires(inlen <= MLD_MAX_BUFFER_SIZE)
   requires(memory_no_alias(state, sizeof(mld_shake256ctx)))
   requires(memory_no_alias(in, inlen))
-  requires(state->pos <= SHAKE256_RATE)
+  requires(state->pos >= 0 && state->pos <= SHAKE256_RATE)
   assigns(memory_slice(state, sizeof(mld_shake256ctx)))
-  ensures(state->pos <= SHAKE256_RATE)
+  ensures(state->pos >= 0 && state->pos <= SHAKE256_RATE)
 );
 
 #define mld_shake256_finalize MLD_NAMESPACE(shake256_finalize)
@@ -169,9 +169,9 @@ __contract__(
 void mld_shake256_finalize(mld_shake256ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake256ctx)))
-  requires(state->pos <= SHAKE256_RATE)
+  requires(state->pos >= 0 && state->pos <= SHAKE256_RATE)
   assigns(memory_slice(state, sizeof(mld_shake256ctx)))
-  ensures(state->pos <= SHAKE256_RATE)
+  ensures(state->pos >= 0 && state->pos <= SHAKE256_RATE)
 );
 
 #define mld_shake256_squeeze MLD_NAMESPACE(shake256_squeeze)
@@ -191,10 +191,10 @@ __contract__(
   requires(outlen <= 8 * SHAKE256_RATE /* somewhat arbitrary bound */)
   requires(memory_no_alias(state, sizeof(mld_shake256ctx)))
   requires(memory_no_alias(out, outlen))
-  requires(state->pos <= SHAKE256_RATE)
+  requires(state->pos >= 0 && state->pos <= SHAKE256_RATE)
   assigns(memory_slice(state, sizeof(mld_shake256ctx)))
   assigns(memory_slice(out, outlen))
-  ensures(state->pos <= SHAKE256_RATE)
+  ensures(state->pos >= 0 && state->pos <= SHAKE256_RATE)
 );
 
 #define mld_shake256_release MLD_NAMESPACE(shake256_release)

--- a/mldsa/src/fips202/keccakf1600.c
+++ b/mldsa/src/fips202/keccakf1600.c
@@ -37,20 +37,20 @@
 #define MLD_KECCAK_ROL(a, offset) ((a << offset) ^ (a >> (64 - offset)))
 
 void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
-                                   unsigned offset, unsigned length)
+                                   int offset, int length)
 {
-  unsigned i;
+  int i;
 #if defined(MLD_SYS_LITTLE_ENDIAN)
   uint8_t *state_ptr = (uint8_t *)state + offset;
   for (i = 0; i < length; i++)
-  __loop__(invariant(i <= length))
+  __loop__(invariant(i >= 0 && i <= length))
   {
     data[i] = state_ptr[i];
   }
 #else  /* MLD_SYS_LITTLE_ENDIAN */
   /* Portable version */
   for (i = 0; i < length; i++)
-  __loop__(invariant(i <= length))
+  __loop__(invariant(i >= 0 && i <= length))
   {
     data[i] = (state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07))) & 0xFF;
   }
@@ -58,20 +58,20 @@ void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
 }
 
 void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
-                               unsigned offset, unsigned length)
+                               int offset, int length)
 {
-  unsigned i;
+  int i;
 #if defined(MLD_SYS_LITTLE_ENDIAN)
   uint8_t *state_ptr = (uint8_t *)state + offset;
   for (i = 0; i < length; i++)
-  __loop__(invariant(i <= length))
+  __loop__(invariant(i >= 0 && i <= length))
   {
     state_ptr[i] ^= data[i];
   }
 #else  /* MLD_SYS_LITTLE_ENDIAN */
   /* Portable version */
   for (i = 0; i < length; i++)
-  __loop__(invariant(i <= length))
+  __loop__(invariant(i >= 0 && i <= length))
   {
     state[(offset + i) >> 3] ^= (uint64_t)data[i]
                                 << (8 * ((offset + i) & 0x07));
@@ -81,8 +81,8 @@ void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
 
 void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
                                      unsigned char *data1, unsigned char *data2,
-                                     unsigned char *data3, unsigned offset,
-                                     unsigned length)
+                                     unsigned char *data3, int offset,
+                                     int length)
 {
   mld_keccakf1600_extract_bytes(state + MLD_KECCAK_LANES * 0, data0, offset,
                                 length);
@@ -97,8 +97,8 @@ void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
 void mld_keccakf1600x4_xor_bytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
-                                 const unsigned char *data3, unsigned offset,
-                                 unsigned length)
+                                 const unsigned char *data3, int offset,
+                                 int length)
 {
   mld_keccakf1600_xor_bytes(state + MLD_KECCAK_LANES * 0, data0, offset,
                             length);
@@ -140,7 +140,7 @@ static const uint64_t mld_KeccakF_RoundConstants[MLD_KECCAK_NROUNDS] = {
 
 static void mld_keccakf1600_permute_c(uint64_t *state)
 {
-  unsigned round;
+  int round;
 
   uint64_t Aba, Abe, Abi, Abo, Abu;
   uint64_t Aga, Age, Agi, Ago, Agu;
@@ -183,7 +183,7 @@ static void mld_keccakf1600_permute_c(uint64_t *state)
   Asu = state[24];
 
   for (round = 0; round < MLD_KECCAK_NROUNDS; round += 2)
-  __loop__(invariant(round <= MLD_KECCAK_NROUNDS && round % 2 == 0))
+  __loop__(invariant(round >= 0 && round <= MLD_KECCAK_NROUNDS && round % 2 == 0))
   {
     /* prepareTheta */
     BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;

--- a/mldsa/src/fips202/keccakf1600.h
+++ b/mldsa/src/fips202/keccakf1600.h
@@ -22,7 +22,7 @@
 
 #define mld_keccakf1600_extract_bytes MLD_NAMESPACE(keccakf1600_extract_bytes)
 void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
-                                   unsigned offset, unsigned length)
+                                   int offset, int length)
 __contract__(
     requires(0 <= offset && offset <= MLD_KECCAK_LANES * sizeof(uint64_t) &&
 	     0 <= length && length <= MLD_KECCAK_LANES * sizeof(uint64_t) - offset)
@@ -33,7 +33,7 @@ __contract__(
 
 #define mld_keccakf1600_xor_bytes MLD_NAMESPACE(keccakf1600_xor_bytes)
 void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
-                               unsigned offset, unsigned length)
+                               int offset, int length)
 __contract__(
     requires(0 <= offset && offset <= MLD_KECCAK_LANES * sizeof(uint64_t) &&
 	     0 <= length && length <= MLD_KECCAK_LANES * sizeof(uint64_t) - offset)
@@ -46,8 +46,8 @@ __contract__(
   MLD_NAMESPACE(keccakf1600x4_extract_bytes)
 void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
                                      unsigned char *data1, unsigned char *data2,
-                                     unsigned char *data3, unsigned offset,
-                                     unsigned length)
+                                     unsigned char *data3, int offset,
+                                     int length)
 __contract__(
     requires(0 <= offset && offset <= MLD_KECCAK_LANES * sizeof(uint64_t) &&
 	     0 <= length && length <= MLD_KECCAK_LANES * sizeof(uint64_t) - offset)
@@ -66,8 +66,8 @@ __contract__(
 void mld_keccakf1600x4_xor_bytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
-                                 const unsigned char *data3, unsigned offset,
-                                 unsigned length)
+                                 const unsigned char *data3, int offset,
+                                 int length)
 __contract__(
     requires(0 <= offset && offset <= MLD_KECCAK_LANES * sizeof(uint64_t) &&
 	     0 <= length && length <= MLD_KECCAK_LANES * sizeof(uint64_t) - offset)

--- a/mldsa/src/native/aarch64/meta.h
+++ b/mldsa/src/native/aarch64/meta.h
@@ -32,6 +32,7 @@
 
 
 #if !defined(__ASSEMBLER__)
+#include <stddef.h>
 #include "../api.h"
 #include "src/arith_native_aarch64.h"
 
@@ -49,9 +50,8 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
-static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
-                                             const uint8_t *buf,
-                                             unsigned buflen)
+static MLD_INLINE int mld_rej_uniform_native(int32_t *r, int len,
+                                             const uint8_t *buf, int buflen)
 {
   if (len != MLDSA_N ||
       buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
@@ -59,15 +59,15 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
     return MLD_NATIVE_FUNC_FALLBACK;
   }
 
-  /* Safety: outlen is at most MLDSA_N, hence, this cast is safe. */
+  /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)mld_rej_uniform_asm(r, buf, buflen, mld_rej_uniform_table);
 }
 
-static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
   if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
   {
@@ -82,16 +82,16 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta2_asm(r, buf, buflen, mld_rej_uniform_eta_table);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }
 
-static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
   if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
   {
@@ -106,7 +106,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta4_asm(r, buf, buflen, mld_rej_uniform_eta_table);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }

--- a/mldsa/src/native/aarch64/src/arith_native_aarch64.h
+++ b/mldsa/src/native/aarch64/src/arith_native_aarch64.h
@@ -56,16 +56,16 @@ void mld_ntt_asm(int32_t *, const int32_t *, const int32_t *);
 void mld_intt_asm(int32_t *, const int32_t *, const int32_t *);
 
 #define mld_rej_uniform_asm MLD_NAMESPACE(rej_uniform_asm)
-uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, unsigned buflen,
+uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
                              const uint8_t *table);
 
 #define mld_rej_uniform_eta2_asm MLD_NAMESPACE(rej_uniform_eta2_asm)
-unsigned mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf,
-                                  unsigned buflen, const uint8_t *table);
+int32_t mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
+                                 const uint8_t *table);
 
 #define mld_rej_uniform_eta4_asm MLD_NAMESPACE(rej_uniform_eta4_asm)
-unsigned mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf,
-                                  unsigned buflen, const uint8_t *table);
+int32_t mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf, int32_t buflen,
+                                 const uint8_t *table);
 
 #define mld_poly_decompose_32_asm MLD_NAMESPACE(poly_decompose_32_asm)
 void mld_poly_decompose_32_asm(int32_t *a1, int32_t *a0, const int32_t *a);

--- a/mldsa/src/native/api.h
+++ b/mldsa/src/native/api.h
@@ -122,19 +122,18 @@ static MLD_INLINE int mld_intt_native(int32_t p[MLDSA_N]);
  *              uniform random integers in [0, MLDSA_Q-1]
  *
  * Arguments:   - int32_t *r:          pointer to output buffer
- *              - unsigned len:        requested number of 32-bit integers
+ *              - int len:             requested number of 32-bit integers
  *                                     (uniform mod q).
  *              - const uint8_t *buf:  pointer to input buffer
  *                                     (assumed to be uniform random bytes)
- *              - unsigned buflen:     length of input buffer in bytes.
+ *              - int buflen:          length of input buffer in bytes.
  *
  * Return -1 if the native implementation does not support the input
  * lengths. Otherwise, returns non-negative number of sampled 32-bit integers
  * (at most len).
  **************************************************/
-static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
-                                             const uint8_t *buf,
-                                             unsigned buflen);
+static MLD_INLINE int mld_rej_uniform_native(int32_t *r, int len,
+                                             const uint8_t *buf, int buflen);
 #endif /* MLD_USE_NATIVE_REJ_UNIFORM */
 
 #if defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA2)
@@ -145,19 +144,19 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
  *              uniform random integers in [-2,+2].
  *
  * Arguments:   - int32_t *r:          pointer to output buffer
- *              - unsigned len:        requested number of 32-bit integers
+ *              - int len:             requested number of 32-bit integers
  *                                     (uniform in [-2, +2]).
  *              - const uint8_t *buf:  pointer to input buffer
  *                                     (assumed to be uniform random bytes)
- *              - unsigned buflen:     length of input buffer in bytes.
+ *              - int buflen:          length of input buffer in bytes.
  *
  * Return -1 if the native implementation does not support the input
  *lengths. Otherwise, returns non-negative number of sampled 32-bit integers
  *(at most len).
  **************************************************/
-static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen);
+                                                  int buflen);
 #endif /* MLD_USE_NATIVE_REJ_UNIFORM_ETA2 */
 
 #if defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA4)
@@ -168,19 +167,19 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
  *              uniform random integers in [-4,+4].
  *
  * Arguments:   - int32_t *r:          pointer to output buffer
- *              - unsigned len:        requested number of 32-bit integers
+ *              - int len:             requested number of 32-bit integers
  *                                     (uniform in [-4, +4]).
  *              - const uint8_t *buf:  pointer to input buffer
  *                                     (assumed to be uniform random bytes)
- *              - unsigned buflen:     length of input buffer in bytes.
+ *              - int buflen:          length of input buffer in bytes.
  *
  * Return -1 if the native implementation does not support the input
  *lengths. Otherwise, returns non-negative number of sampled 32-bit integers
  *(at most len).
  **************************************************/
-static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen);
+                                                  int buflen);
 #endif /* MLD_USE_NATIVE_REJ_UNIFORM_ETA4 */
 
 #if defined(MLD_USE_NATIVE_POLY_DECOMPOSE_32)

--- a/mldsa/src/native/x86_64/meta.h
+++ b/mldsa/src/native/x86_64/meta.h
@@ -31,6 +31,7 @@
 #define MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7
 
 #if !defined(__ASSEMBLER__)
+#include <stddef.h>
 #include <string.h>
 #include "../../common.h"
 #include "../api.h"
@@ -64,9 +65,8 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
-static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
-                                             const uint8_t *buf,
-                                             unsigned buflen)
+static MLD_INLINE int mld_rej_uniform_native(int32_t *r, int len,
+                                             const uint8_t *buf, int buflen)
 {
   /* AVX2 implementation assumes specific buffer lengths */
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
@@ -79,11 +79,11 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_avx2(r, buf);
 }
 
-static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AVX2 implementation assumes specific buffer lengths */
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN)
@@ -100,16 +100,16 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta2_avx2(r, buf);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }
 
-static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
+static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, int len,
                                                   const uint8_t *buf,
-                                                  unsigned buflen)
+                                                  int buflen)
 {
-  unsigned int outlen;
+  int32_t outlen;
   /* AVX2 implementation assumes specific buffer lengths */
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN)
@@ -126,7 +126,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
    */
   MLD_CT_TESTING_DECLASSIFY(buf, buflen);
   outlen = mld_rej_uniform_eta4_avx2(r, buf);
-  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * outlen);
+  MLD_CT_TESTING_SECRET(r, sizeof(int32_t) * (size_t)outlen);
   /* Safety: outlen is at most MLDSA_N and, hence, this cast is safe. */
   return (int)outlen;
 }

--- a/mldsa/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mldsa/src/native/x86_64/src/arith_native_x86_64.h
@@ -43,15 +43,15 @@ void mld_invntt_avx2(__m256i *r, const __m256i *mld_qdata);
 void mld_nttunpack_avx2(__m256i *r);
 
 #define mld_rej_uniform_avx2 MLD_NAMESPACE(mld_rej_uniform_avx2)
-unsigned mld_rej_uniform_avx2(int32_t *r,
-                              const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN]);
+int32_t mld_rej_uniform_avx2(int32_t *r,
+                             const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN]);
 
 #define mld_rej_uniform_eta2_avx2 MLD_NAMESPACE(mld_rej_uniform_eta2_avx2)
-unsigned mld_rej_uniform_eta2_avx2(
+int32_t mld_rej_uniform_eta2_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN]);
 
 #define mld_rej_uniform_eta4_avx2 MLD_NAMESPACE(mld_rej_uniform_eta4_avx2)
-unsigned mld_rej_uniform_eta4_avx2(
+int32_t mld_rej_uniform_eta4_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN]);
 
 #define mld_poly_decompose_32_avx2 MLD_NAMESPACE(mld_poly_decompose_32_avx2)

--- a/mldsa/src/native/x86_64/src/rej_uniform_avx2.c
+++ b/mldsa/src/native/x86_64/src/rej_uniform_avx2.c
@@ -36,8 +36,8 @@
  *            frontend to perform the unintuitive padding.
  */
 
-unsigned int mld_rej_uniform_avx2(
-    int32_t *MLD_RESTRICT r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN])
+int32_t mld_rej_uniform_avx2(int32_t *MLD_RESTRICT r,
+                             const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN])
 {
   unsigned int ctr, pos;
   uint32_t good;
@@ -116,7 +116,7 @@ unsigned int mld_rej_uniform_avx2(
     }
   }
 
-  return ctr;
+  return (int32_t)ctr;
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/mldsa/src/native/x86_64/src/rej_uniform_eta2_avx2.c
+++ b/mldsa/src/native/x86_64/src/rej_uniform_eta2_avx2.c
@@ -35,7 +35,7 @@
  *            rej_eta_avx and supports multiple values for ETA via preprocessor
  *            conditionals. We move the conditionals to the frontend.
  */
-unsigned int mld_rej_uniform_eta2_avx2(
+int32_t mld_rej_uniform_eta2_avx2(
     int32_t *MLD_RESTRICT r,
     const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN])
 {
@@ -139,7 +139,7 @@ unsigned int mld_rej_uniform_eta2_avx2(
     }
   }
 
-  return ctr;
+  return (int32_t)ctr;
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/mldsa/src/native/x86_64/src/rej_uniform_eta4_avx2.c
+++ b/mldsa/src/native/x86_64/src/rej_uniform_eta4_avx2.c
@@ -36,7 +36,7 @@
  *            conditionals. We move the conditionals to the frontend.
  */
 
-unsigned int mld_rej_uniform_eta4_avx2(
+int32_t mld_rej_uniform_eta4_avx2(
     int32_t *MLD_RESTRICT r,
     const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN])
 {
@@ -123,7 +123,7 @@ unsigned int mld_rej_uniform_eta4_avx2(
     }
   }
 
-  return ctr;
+  return (int32_t)ctr;
 }
 
 #else /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \

--- a/mldsa/src/packing.c
+++ b/mldsa/src/packing.c
@@ -20,13 +20,13 @@ MLD_INTERNAL_API
 void mld_pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
                  const uint8_t rho[MLDSA_SEEDBYTES], const mld_polyveck *t1)
 {
-  unsigned int i;
+  int i;
 
   mld_memcpy(pk, rho, MLDSA_SEEDBYTES);
   for (i = 0; i < MLDSA_K; ++i)
   __loop__(
     assigns(i, memory_slice(pk, CRYPTO_PUBLICKEYBYTES))
-    invariant(i <= MLDSA_K)
+    invariant(i >= 0 && i <= MLDSA_K)
   )
   {
     mld_polyt1_pack(pk + MLDSA_SEEDBYTES + i * MLDSA_POLYT1_PACKEDBYTES,
@@ -38,7 +38,7 @@ MLD_INTERNAL_API
 void mld_unpack_pk(uint8_t rho[MLDSA_SEEDBYTES], mld_polyveck *t1,
                    const uint8_t pk[CRYPTO_PUBLICKEYBYTES])
 {
-  unsigned int i;
+  int i;
 
   mld_memcpy(rho, pk, MLDSA_SEEDBYTES);
   pk += MLDSA_SEEDBYTES;
@@ -101,9 +101,9 @@ void mld_unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
 MLD_INTERNAL_API
 void mld_pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
                   const mld_polyvecl *z, const mld_polyveck *h,
-                  const unsigned int number_of_hints)
+                  const int number_of_hints)
 {
-  unsigned int i, j, k;
+  int i, j, k;
 
   mld_memcpy(sig, c, MLDSA_CTILDEBYTES);
   sig += MLDSA_CTILDEBYTES;
@@ -133,8 +133,8 @@ void mld_pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
   for (i = 0; i < MLDSA_K; ++i)
   __loop__(
     assigns(i, j, k, memory_slice(sig, MLDSA_POLYVECH_PACKEDBYTES))
-    invariant(i <= MLDSA_K)
-    invariant(k <= number_of_hints)
+    invariant(i >= 0 && i <= MLDSA_K)
+    invariant(k >= 0 && k <= number_of_hints)
     invariant(number_of_hints <= MLDSA_OMEGA)
   )
   {
@@ -143,10 +143,10 @@ void mld_pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
     for (j = 0; j < MLDSA_N; ++j)
     __loop__(
       assigns(j, k, memory_slice(sig, MLDSA_POLYVECH_PACKEDBYTES))
-      invariant(i <= MLDSA_K)
-      invariant(j <= MLDSA_N)
-      invariant(k <= number_of_hints)
-      invariant(number_of_hints <= MLDSA_OMEGA)
+      invariant(i >= 0 && i <= MLDSA_K)
+      invariant(j >= 0 && j <= MLDSA_N)
+      invariant(k >= 0 && k <= number_of_hints)
+      invariant(number_of_hints >= 0 && number_of_hints <= MLDSA_OMEGA)
     )
     {
       /* The reference implementation implicitly relies on the total */
@@ -192,8 +192,8 @@ __contract__(
   ensures(return_value >= 0 && return_value <= 1)
 )
 {
-  unsigned int i, j;
-  unsigned int old_hint_count;
+  int i;
+  unsigned int j, old_hint_count;
 
   /* Set all coefficients of all polynomials to 0.    */
   /* Only those that are actually non-zero hints will */
@@ -203,7 +203,7 @@ __contract__(
   old_hint_count = 0;
   for (i = 0; i < MLDSA_K; ++i)
   __loop__(
-    invariant(i <= MLDSA_K)
+    invariant(i >= 0 && i <= MLDSA_K)
     /* Maintain the post-condition */
     invariant(forall(k1, 0, MLDSA_K, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
   )

--- a/mldsa/src/packing.h
+++ b/mldsa/src/packing.h
@@ -80,8 +80,7 @@ __contract__(
  *                                   MLDSA_SEEDBYTES
  *              - const mld_polyvecl *z: pointer to vector z
  *              - const mld_polyveck *h: pointer to hint vector h
- *              - const unsigned int number_of_hints: total
- *                                   hints in *h
+ *              - const int number_of_hints: total hints in *h
  *
  * Note that the number_of_hints argument is not present
  * in the reference implementation. It is added here to ease
@@ -90,7 +89,7 @@ __contract__(
 MLD_INTERNAL_API
 void mld_pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[MLDSA_CTILDEBYTES],
                   const mld_polyvecl *z, const mld_polyveck *h,
-                  const unsigned int number_of_hints)
+                  const int number_of_hints)
 __contract__(
   requires(memory_no_alias(sig, CRYPTO_BYTES))
   requires(memory_no_alias(c, MLDSA_CTILDEBYTES))
@@ -100,7 +99,7 @@ __contract__(
     array_bound(z->vec[k0].coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1)))
   requires(forall(k1, 0, MLDSA_K,
     array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
-  requires(number_of_hints <= MLDSA_OMEGA)
+  requires(number_of_hints >= 0 && number_of_hints <= MLDSA_OMEGA)
   assigns(memory_slice(sig, CRYPTO_BYTES))
 );
 

--- a/mldsa/src/poly.c
+++ b/mldsa/src/poly.c
@@ -358,7 +358,9 @@ __contract__(
 static int mld_rej_uniform(int32_t *a, int target, int offset,
                            const uint8_t *buf, int buflen)
 __contract__(
+  requires(offset >= 0)
   requires(offset <= target && target <= MLDSA_N)
+  requires(buflen >= 0)
   requires(buflen <= (POLY_UNIFORM_NBLOCKS * STREAM128_BLOCKBYTES) && buflen % 3 == 0)
   requires(memory_no_alias(a, sizeof(int32_t) * target))
   requires(memory_no_alias(buf, buflen))

--- a/mldsa/src/poly.c
+++ b/mldsa/src/poly.c
@@ -288,10 +288,8 @@ void mld_poly_power2round(mld_poly *a1, mld_poly *a0, const mld_poly *a)
  *              in that it adds the offset and always expects the base of the
  *              target buffer. This avoids shifting the buffer base in the
  *              caller, which appears tricky to reason about. */
-MLD_STATIC_TESTABLE unsigned int mld_rej_uniform_c(int32_t *a, int target,
-                                                   int offset,
-                                                   const uint8_t *buf,
-                                                   int buflen)
+MLD_STATIC_TESTABLE int mld_rej_uniform_c(int32_t *a, int target, int offset,
+                                          const uint8_t *buf, int buflen)
 __contract__(
   requires(target >= 0 && target <= MLDSA_N)
   requires(offset >= 0 && offset <= target)
@@ -357,9 +355,8 @@ __contract__(
  *              in that it adds the offset and always expects the base of the
  *              target buffer. This avoids shifting the buffer base in the
  *              caller, which appears tricky to reason about. */
-static unsigned int mld_rej_uniform(int32_t *a, unsigned int target,
-                                    unsigned int offset, const uint8_t *buf,
-                                    unsigned int buflen)
+static int mld_rej_uniform(int32_t *a, int target, int offset,
+                           const uint8_t *buf, int buflen)
 __contract__(
   requires(offset <= target && target <= MLDSA_N)
   requires(buflen <= (POLY_UNIFORM_NBLOCKS * STREAM128_BLOCKBYTES) && buflen % 3 == 0)
@@ -380,9 +377,8 @@ __contract__(
     ret = mld_rej_uniform_native(a, target, buf, buflen);
     if (ret != MLD_NATIVE_FUNC_FALLBACK)
     {
-      unsigned res = (unsigned)ret;
-      mld_assert_bound(a, res, 0, MLDSA_Q);
-      return res;
+      mld_assert_bound(a, ret, 0, MLDSA_Q);
+      return ret;
     }
   }
 #endif /* MLD_USE_NATIVE_REJ_UNIFORM */

--- a/mldsa/src/poly_kl.c
+++ b/mldsa/src/poly_kl.c
@@ -302,7 +302,9 @@ __contract__(
 static int mld_rej_eta(int32_t *a, int target, int offset, const uint8_t *buf,
                        int buflen)
 __contract__(
+  requires(offset >= 0)
   requires(offset <= target && target <= MLDSA_N)
+  requires(buflen >= 0)
   requires(buflen <= (POLY_UNIFORM_ETA_NBLOCKS * STREAM256_BLOCKBYTES))
   requires(memory_no_alias(a, sizeof(int32_t) * target))
   requires(memory_no_alias(buf, buflen))

--- a/mldsa/src/poly_kl.c
+++ b/mldsa/src/poly_kl.c
@@ -243,39 +243,7 @@ __contract__(
   int t_valid;
   uint32_t t0, t1;
   mld_assert_abs_bound(a, offset, MLDSA_ETA + 1);
-
-/* TODO: CBMC proof based on mld_rej_uniform_eta2_native */
-#if MLDSA_ETA == 2 && defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA2)
-  if (offset == 0)
-  {
-    int ret;
-    ret = mld_rej_uniform_eta2_native(a, target, buf, buflen);
-    if (ret != MLD_NATIVE_FUNC_FALLBACK)
-    {
-      int res = ret;
-      mld_assert_abs_bound(a, res, MLDSA_ETA + 1);
-      return res;
-    }
-  }
-/* TODO: CBMC proof based on mld_rej_uniform_eta4_native */
-#elif MLDSA_ETA == 4 && defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA4)
-  if (offset == 0)
-  {
-    int ret;
-    ret = mld_rej_uniform_eta4_native(a, target, buf, buflen);
-    if (ret != MLD_NATIVE_FUNC_FALLBACK)
-    {
-      int res = ret;
-      mld_assert_abs_bound(a, res, MLDSA_ETA + 1);
-      return res;
-    }
-  }
-#endif /* !(MLDSA_ETA == 2 && MLD_USE_NATIVE_REJ_UNIFORM_ETA2) && MLDSA_ETA == \
-          4 && MLD_USE_NATIVE_REJ_UNIFORM_ETA4 */
-
-  >>>>>>>
-      7060123f(Standardize on signed integers in quantifiers and loops.)ctr =
-      offset;
+  ctr = offset;
   pos = 0;
   while (ctr < target && pos < buflen)
   __loop__(
@@ -331,9 +299,8 @@ __contract__(
   return ctr;
 }
 
-static unsigned int mld_rej_eta(int32_t *a, unsigned int target,
-                                unsigned int offset, const uint8_t *buf,
-                                unsigned int buflen)
+static int mld_rej_eta(int32_t *a, int target, int offset, const uint8_t *buf,
+                       int buflen)
 __contract__(
   requires(offset <= target && target <= MLDSA_N)
   requires(buflen <= (POLY_UNIFORM_ETA_NBLOCKS * STREAM256_BLOCKBYTES))
@@ -354,9 +321,8 @@ __contract__(
     ret = mld_rej_uniform_eta2_native(a, target, buf, buflen);
     if (ret != MLD_NATIVE_FUNC_FALLBACK)
     {
-      unsigned res = (unsigned)ret;
-      mld_assert_abs_bound(a, res, MLDSA_ETA + 1);
-      return res;
+      mld_assert_abs_bound(a, ret, MLDSA_ETA + 1);
+      return ret;
     }
   }
 /* TODO: CBMC proof based on mld_rej_uniform_eta4_native */
@@ -368,9 +334,8 @@ __contract__(
     ret = mld_rej_uniform_eta4_native(a, target, buf, buflen);
     if (ret != MLD_NATIVE_FUNC_FALLBACK)
     {
-      unsigned res = (unsigned)ret;
-      mld_assert_abs_bound(a, res, MLDSA_ETA + 1);
-      return res;
+      mld_assert_abs_bound(a, ret, MLDSA_ETA + 1);
+      return ret;
     }
   }
 #endif /* !(MLDSA_ETA == 2 && MLD_USE_NATIVE_REJ_UNIFORM_ETA2) && MLDSA_ETA == \

--- a/mldsa/src/poly_kl.h
+++ b/mldsa/src/poly_kl.h
@@ -55,14 +55,13 @@ __contract__(
  * Returns number of 1 bits.
  **************************************************/
 MLD_INTERNAL_API
-unsigned int mld_poly_make_hint(mld_poly *h, const mld_poly *a0,
-                                const mld_poly *a1)
+int mld_poly_make_hint(mld_poly *h, const mld_poly *a0, const mld_poly *a1)
 __contract__(
   requires(memory_no_alias(h,  sizeof(mld_poly)))
   requires(memory_no_alias(a0, sizeof(mld_poly)))
   requires(memory_no_alias(a1, sizeof(mld_poly)))
   assigns(memory_slice(h, sizeof(mld_poly)))
-  ensures(return_value <= MLDSA_N)
+  ensures(return_value >= 0 && return_value <= MLDSA_N)
   ensures(array_bound(h->coeffs, 0, MLDSA_N, 0, 2))
 );
 

--- a/mldsa/src/polyvec.h
+++ b/mldsa/src/polyvec.h
@@ -508,14 +508,14 @@ __contract__(
  * Returns number of 1 bits.
  **************************************************/
 MLD_INTERNAL_API
-unsigned int mld_polyveck_make_hint(mld_polyveck *h, const mld_polyveck *v0,
-                                    const mld_polyveck *v1)
+int mld_polyveck_make_hint(mld_polyveck *h, const mld_polyveck *v0,
+                           const mld_polyveck *v1)
 __contract__(
   requires(memory_no_alias(h,  sizeof(mld_polyveck)))
   requires(memory_no_alias(v0, sizeof(mld_polyveck)))
   requires(memory_no_alias(v1, sizeof(mld_polyveck)))
   assigns(memory_slice(h, sizeof(mld_polyveck)))
-  ensures(return_value <= MLDSA_N * MLDSA_K)
+  ensures(return_value >= 0 && return_value <= MLDSA_N * MLDSA_K)
   ensures(forall(k1, 0, MLDSA_K, array_bound(h->vec[k1].coeffs, 0, MLDSA_N, 0, 2)))
 );
 

--- a/mldsa/src/rounding.h
+++ b/mldsa/src/rounding.h
@@ -157,7 +157,7 @@ __contract__(
  *
  * Returns 1 if overflow, 0 otherwise
  **************************************************/
-static MLD_INLINE unsigned int mld_make_hint(int32_t a0, int32_t a1)
+static MLD_INLINE int mld_make_hint(int32_t a0, int32_t a1)
 __contract__(
   ensures(return_value >= 0 && return_value <= 1)
 )

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -445,7 +445,7 @@ __contract__(
 )
 {
   MLD_ALIGN uint8_t challenge_bytes[MLDSA_CTILDEBYTES];
-  unsigned int n;
+  int n;
   mld_polyvecl y, z;
   mld_polyveck w, w1, w0, h;
   mld_poly cp;
@@ -782,7 +782,7 @@ int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
                                 const uint8_t pk[CRYPTO_PUBLICKEYBYTES],
                                 int externalmu)
 {
-  unsigned int i;
+  int i;
   int res;
   MLD_ALIGN uint8_t buf[MLDSA_K * MLDSA_POLYW1_PACKEDBYTES];
   MLD_ALIGN uint8_t rho[MLDSA_SEEDBYTES];
@@ -864,7 +864,7 @@ int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen,
   MLD_CT_TESTING_DECLASSIFY(c2, sizeof(c2));
   for (i = 0; i < MLDSA_CTILDEBYTES; ++i)
   __loop__(
-    invariant(i <= MLDSA_CTILDEBYTES)
+    invariant(i >= 0 && i <= MLDSA_CTILDEBYTES)
   )
   {
     if (c[i] != c2[i])

--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -26,7 +26,8 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+# Bitwuzla has been found to be more efficient on this function
+CBMCFLAGS=--bitwuzla --slice-formula
 
 FUNCTION_NAME = mld_invntt_layer
 

--- a/proofs/cbmc/invntt_layer/invntt_layer_harness.c
+++ b/proofs/cbmc/invntt_layer/invntt_layer_harness.c
@@ -4,11 +4,11 @@
 #include <stdint.h>
 #include "params.h"
 
-void mld_invntt_layer(int32_t r[MLDSA_N], unsigned layer);
+void mld_invntt_layer(int32_t r[MLDSA_N], int layer);
 
 void harness(void)
 {
   int32_t *r;
-  unsigned layer;
+  int layer;
   mld_invntt_layer(r, layer);
 }

--- a/proofs/cbmc/keccak_absorb/keccak_absorb_harness.c
+++ b/proofs/cbmc/keccak_absorb/keccak_absorb_harness.c
@@ -3,18 +3,16 @@
 
 #include "fips202/fips202.h"
 
-extern unsigned int keccak_absorb(uint64_t s[MLD_KECCAK_LANES],
-                                  unsigned int pos, unsigned int r,
-                                  const uint8_t *in, size_t inlen);
+extern int keccak_absorb(uint64_t s[MLD_KECCAK_LANES], int pos, int r,
+                         const uint8_t *in, size_t inlen);
 
 void harness(void)
 {
   uint64_t *s;
-  unsigned int pos;
-  const unsigned int r;
+  int pos, r, r2;
   const uint8_t *in;
   size_t inlen;
   uint8_t p;
 
-  keccak_absorb(s, pos, r, in, inlen);
+  r2 = keccak_absorb(s, pos, r, in, inlen);
 }

--- a/proofs/cbmc/keccak_absorb_once_x4/keccak_absorb_once_x4_harness.c
+++ b/proofs/cbmc/keccak_absorb_once_x4/keccak_absorb_once_x4_harness.c
@@ -9,14 +9,14 @@
 #include <string.h>
 
 
-void mld_keccak_absorb_once_x4(uint64_t *s, uint32_t r, const uint8_t *in0,
+void mld_keccak_absorb_once_x4(uint64_t *s, int r, const uint8_t *in0,
                                const uint8_t *in1, const uint8_t *in2,
                                const uint8_t *in3, size_t inlen, uint8_t p);
 
 void harness(void)
 {
   uint64_t *s;
-  uint32_t r;
+  int r;
   const uint8_t *in0, *in1, *in2, *in3;
   size_t inlen;
   uint8_t p;

--- a/proofs/cbmc/keccak_finalize/keccak_finalize_harness.c
+++ b/proofs/cbmc/keccak_finalize/keccak_finalize_harness.c
@@ -3,13 +3,13 @@
 
 #include "fips202/fips202.h"
 
-extern void keccak_finalize(uint64_t s[MLD_KECCAK_LANES], unsigned int pos,
-                            unsigned int r, uint8_t p);
+extern void keccak_finalize(uint64_t s[MLD_KECCAK_LANES], int pos, int r,
+                            uint8_t p);
 
 void harness(void)
 {
   uint64_t *s;
-  unsigned int pos, r;
+  int pos, r;
   uint8_t p;
 
   keccak_finalize(s, pos, r, p);

--- a/proofs/cbmc/keccak_squeeze/keccak_squeeze_harness.c
+++ b/proofs/cbmc/keccak_squeeze/keccak_squeeze_harness.c
@@ -3,16 +3,15 @@
 
 #include "fips202/fips202.h"
 
-static unsigned int keccak_squeeze(uint8_t *out, size_t outlen,
-                                   uint64_t s[MLD_KECCAK_LANES],
-                                   unsigned int pos, unsigned int r);
+static int keccak_squeeze(uint8_t *out, size_t outlen,
+                          uint64_t s[MLD_KECCAK_LANES], int pos, int r);
 
 void harness(void)
 {
   uint8_t *out;
   size_t outlen;
   uint64_t *s;
-  unsigned int pos, r;
+  int pos, r, r2;
 
-  keccak_squeeze(out, outlen, s, pos, r);
+  r2 = keccak_squeeze(out, outlen, s, pos, r);
 }

--- a/proofs/cbmc/keccak_squeezeblocks_x4/keccak_squeezeblocks_x4_harness.c
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/keccak_squeezeblocks_x4_harness.c
@@ -11,13 +11,13 @@
 
 void mld_keccak_squeezeblocks_x4(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                                  uint8_t *out3, size_t nblocks, uint64_t *s,
-                                 uint32_t r);
+                                 int r);
 
 void harness(void)
 {
   uint8_t *out0, out1, out2, out3;
   size_t nblocks;
   uint64_t *s;
-  uint32_t r;
+  int r;
   mld_keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, s, r);
 }

--- a/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
@@ -9,7 +9,7 @@ void harness(void)
 {
   uint64_t *state;
   unsigned char *data;
-  unsigned offset;
-  unsigned length;
+  int offset;
+  int length;
   mld_keccakf1600_extract_bytes(state, data, offset, length);
 }

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
@@ -9,7 +9,7 @@ void harness(void)
 {
   uint64_t *state;
   unsigned char *data;
-  unsigned offset;
-  unsigned length;
+  int offset;
+  int length;
   mld_keccakf1600_extract_bytes(state, data, offset, length);
 }

--- a/proofs/cbmc/keccakf1600_xor_bytes/keccakf1600_xor_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600_xor_bytes/keccakf1600_xor_bytes_harness.c
@@ -9,7 +9,7 @@ void harness(void)
 {
   uint64_t *state;
   const unsigned char *data;
-  unsigned offset;
-  unsigned length;
+  int offset;
+  int length;
   mld_keccakf1600_xor_bytes(state, data, offset, length);
 }

--- a/proofs/cbmc/keccakf1600_xor_bytes_BE/keccakf1600_xor_bytes_be_harness.c
+++ b/proofs/cbmc/keccakf1600_xor_bytes_BE/keccakf1600_xor_bytes_be_harness.c
@@ -9,7 +9,7 @@ void harness(void)
 {
   uint64_t *state;
   const unsigned char *data;
-  unsigned offset;
-  unsigned length;
+  int offset;
+  int length;
   mld_keccakf1600_xor_bytes(state, data, offset, length);
 }

--- a/proofs/cbmc/keccakf1600x4_extract_bytes/keccakf1600x4_extract_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600x4_extract_bytes/keccakf1600x4_extract_bytes_harness.c
@@ -9,8 +9,8 @@ void harness(void)
 {
   uint64_t *state;
   unsigned char *data0, *data1, *data2, *data3;
-  unsigned offset;
-  unsigned length;
+  int offset;
+  int length;
   mld_keccakf1600x4_extract_bytes(state, data0, data1, data2, data3, offset,
                                   length);
 }

--- a/proofs/cbmc/keccakf1600x4_xor_bytes/keccakf1600x4_xor_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600x4_xor_bytes/keccakf1600x4_xor_bytes_harness.c
@@ -9,8 +9,8 @@ void harness(void)
 {
   uint64_t *state;
   const unsigned char *data0, *data1, *data2, *data3;
-  unsigned offset;
-  unsigned length;
+  int offset;
+  int length;
   mld_keccakf1600x4_xor_bytes(state, data0, data1, data2, data3, offset,
                               length);
 }

--- a/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
+++ b/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
@@ -4,13 +4,13 @@
 #include <stdint.h>
 #include "params.h"
 
-void mld_ntt_butterfly_block(int32_t r[MLDSA_N], int32_t zeta, unsigned start,
-                             unsigned len, unsigned bound);
+void mld_ntt_butterfly_block(int32_t r[MLDSA_N], int32_t zeta, const int start,
+                             const int len, const int bound);
 
 void harness(void)
 {
   int32_t *r, zeta;
-  unsigned start, len;
-  unsigned bound;
+  int start, len;
+  int bound;
   mld_ntt_butterfly_block(r, zeta, start, len, bound);
 }

--- a/proofs/cbmc/ntt_layer/ntt_layer_harness.c
+++ b/proofs/cbmc/ntt_layer/ntt_layer_harness.c
@@ -4,11 +4,11 @@
 #include <stdint.h>
 #include "params.h"
 
-void mld_ntt_layer(int32_t r[MLDSA_N], unsigned layer);
+void mld_ntt_layer(int32_t r[MLDSA_N], const int layer);
 
 void harness(void)
 {
   int32_t *r;
-  unsigned layer;
+  int layer;
   mld_ntt_layer(r, layer);
 }

--- a/proofs/cbmc/pack_sig/pack_sig_harness.c
+++ b/proofs/cbmc/pack_sig/pack_sig_harness.c
@@ -9,6 +9,6 @@ void harness(void)
   uint8_t *a, *b;
   mld_polyveck *h;
   mld_polyvecl *z;
-  unsigned int nh;
+  int nh;
   mld_pack_sig(a, b, z, h, nh);
 }

--- a/proofs/cbmc/polyvecl_add/Makefile
+++ b/proofs/cbmc/polyvecl_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2 --slice-formula
 
 FUNCTION_NAME = polyvecl_add
 

--- a/proofs/cbmc/rej_eta/rej_eta_harness.c
+++ b/proofs/cbmc/rej_eta/rej_eta_harness.c
@@ -3,17 +3,14 @@
 
 #include "poly.h"
 
-static unsigned int mld_rej_eta(int32_t *a, unsigned int target,
-                                unsigned int offset, const uint8_t *buf,
-                                unsigned int buflen);
+static int mld_rej_eta(int32_t *a, int target, int offset, const uint8_t *buf,
+                       int buflen);
 
 void harness(void)
 {
   int32_t *a;
-  unsigned int target;
-  unsigned int offset;
+  int target, offset, buflen, r;
   const uint8_t *buf;
-  unsigned int buflen;
 
-  mld_rej_eta(a, target, offset, buf, buflen);
+  r = mld_rej_eta(a, target, offset, buf, buflen);
 }

--- a/proofs/cbmc/rej_eta_c/rej_eta_c_harness.c
+++ b/proofs/cbmc/rej_eta_c/rej_eta_c_harness.c
@@ -4,17 +4,16 @@
 #include "poly.h"
 
 #define mld_rej_eta_c MLD_ADD_PARAM_SET(mld_rej_eta_c)
-static unsigned int mld_rej_eta_c(int32_t *a, unsigned int target,
-                                  unsigned int offset, const uint8_t *buf,
-                                  unsigned int buflen);
+static int mld_rej_eta_c(int32_t *a, int target, int offset, const uint8_t *buf,
+                         int buflen);
 
 void harness(void)
 {
   int32_t *a;
-  unsigned int target;
-  unsigned int offset;
+  int target;
+  int offset;
   const uint8_t *buf;
-  unsigned int buflen;
+  int buflen;
 
   mld_rej_eta_c(a, target, offset, buf, buflen);
 }

--- a/proofs/cbmc/rej_uniform/rej_uniform_harness.c
+++ b/proofs/cbmc/rej_uniform/rej_uniform_harness.c
@@ -3,17 +3,14 @@
 
 #include "poly.h"
 
-static unsigned int mld_rej_uniform(int32_t *a, unsigned int target,
-                                    unsigned int offset, const uint8_t *buf,
-                                    unsigned int buflen);
+static int mld_rej_uniform(int32_t *a, int target, int offset,
+                           const uint8_t *buf, int buflen);
 
 void harness(void)
 {
   int32_t *a;
-  unsigned int target;
-  unsigned int offset;
+  int target, offset, buflen, r;
   const uint8_t *buf;
-  unsigned int buflen;
 
-  mld_rej_uniform(a, target, offset, buf, buflen);
+  r = mld_rej_uniform(a, target, offset, buf, buflen);
 }

--- a/proofs/cbmc/rej_uniform_c/rej_uniform_c_harness.c
+++ b/proofs/cbmc/rej_uniform_c/rej_uniform_c_harness.c
@@ -3,17 +3,16 @@
 
 #include "poly.h"
 
-static unsigned int mld_rej_uniform_c(int32_t *a, unsigned int target,
-                                      unsigned int offset, const uint8_t *buf,
-                                      unsigned int buflen);
+static int mld_rej_uniform_c(int32_t *a, int target, int offset,
+                             const uint8_t *buf, int buflen);
 
 void harness(void)
 {
   int32_t *a;
-  unsigned int target;
-  unsigned int offset;
+  int target;
+  int offset;
   const uint8_t *buf;
-  unsigned int buflen;
+  int buflen;
 
   mld_rej_uniform_c(a, target, offset, buf, buflen);
 }


### PR DESCRIPTION
Conjecture: it is better for proof performance and stability to use signed "int" types for quantifiers, loop indexing expressions, for loop counters. This PR implements this change to gain data on its impact on proof and runtime performance.

Specifically, use signed "int" for:
1. for loop counters
2. quantified expressions
3. variables and struct fields that count or index into arrays
4. formal parameters for array indexes, offsets and counts

Additionally, strengthen pre-conditions on polyvecl_add() and polyveck_add() to stabilize proof of those functions for all parameter sets.

Opening a PR here to get Benchmark results.