### PR TITLE
Port: porting check-namespace from mlkem-native

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -89,6 +89,10 @@ runs:
               --ldflags="${{ inputs.ldflags }}" \
               --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v  ${{ inputs.bench_extra_args }}
+    - name: Check namespace
+      shell: ${{ env.SHELL }}
+      run: |
+        check-namespace
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
       with:

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -48,6 +48,9 @@ inputs:
   examples:
     description: Determine whether to run examples or not
     default: "true"
+  check_namespace:
+    description: Determine whether to check namespacing or not
+    default: "true"
   stack:
     description: Determine whether to run stack analysis or not
     default: "false"
@@ -101,7 +104,7 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v ${{ inputs.extra_args }}
+          ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v ${{ inputs.extra_args }}
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -45,6 +45,9 @@ inputs:
   examples:
     description: Determine whether to run examples or not
     default: "true"
+  check_namespace:
+    description: Determine whether to check namespacing or not
+    default: "true"
   stack:
     description: Determine whether to run stack analysis or not
     default: "false"
@@ -70,6 +73,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross x86_64 Tests
@@ -90,6 +94,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross aarch64 Tests
@@ -110,6 +115,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross ppc64le Tests
@@ -130,6 +136,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross aarch64_be Tests
@@ -150,6 +157,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv64 Tests (RVV, VLEN=128)
@@ -170,6 +178,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv64 Tests (RVV, VLEN=256)
@@ -189,6 +198,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv64 Tests (RVV, VLEN=512)
@@ -208,6 +218,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv64 Tests (RVV, VLEN=1024)
@@ -227,6 +238,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv32 Tests
@@ -247,6 +259,7 @@ runs:
           kat: ${{ inputs.kat }}
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
+          check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
           extra_args: ${{ inputs.extra_args }}
 

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: ./.github/actions/setup-os
       - name: tests func
         run: |
-          ./scripts/tests func
+          ./scripts/tests func --check-namespace
   quickcheck-acvp:
     strategy:
       fail-fast: false
@@ -161,7 +161,7 @@ jobs:
       - uses: ./.github/actions/setup-apt
       - name: tests func
         run: |
-          ./scripts/tests func --cflags="-std=c90"
+          ./scripts/tests func --cflags="-std=c90" --check-namespace
       - name: tests bench
         run: |
           ./scripts/tests bench -c NO --cflags="-std=c90"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
           compile_mode: native
           cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
           ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+          check_namespace: 'false'
   backend_tests:
     name: AArch64 FIPS202 backends (${{ matrix.backend }})
     strategy:
@@ -173,6 +174,7 @@ jobs:
           examples: 'false'
           cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
           ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+          check_namespace: 'false'
           extra_args: "--fips202-aarch64-backend ${{ matrix.backend }}"
   compiler_tests:
     name: Compiler tests  (${{ matrix.compiler.name }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
@@ -415,6 +417,7 @@ jobs:
           acvp: false
           examples: false
           stack: true
+          check_namespace: false
   config_variations:
     name: Non-standard configurations
     strategy:

--- a/scripts/check-namespace
+++ b/scripts/check-namespace
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright (c) The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# This scripts runs nm on the object files (excluding test objects) and checks that all exported
+# symbols are properly namespaced.
+# It assumes that object files are present under test/build/mldsa{44,65,87} and
+# test/build/fips202.
+
+# The checked namespaces are
+# PQCP_MLDSA_NATIVE_FIPS202_ for FIPS202 code
+# PQCP_MLDSA_NATIVE_MLDSA44_ for MLDSA44 code
+# PQCP_MLDSA_NATIVE_MLDSA65_ for MLDSA65 code
+# PQCP_MLDSA_NATIVE_MLDSA87_ for MLDSA87 code
+
+import subprocess
+import os
+
+
+def check_file(file_path, namespaces):
+    print("checking namespacing: {}".format(file_path))
+    command = ["nm", "-g", file_path]
+
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    result = result.stdout.decode("utf-8")
+    lines = result.strip().split("\n")
+    symbols = []
+    for line in lines:
+        if line.startswith("00"):
+            symbols.append(line)
+
+    def is_namespaced(symbol):
+        for namespace in namespaces:
+            if symbol.startswith(namespace) or symbol.startswith("_" + namespace):
+                return True
+        return False
+
+    non_namespaced = []
+    for symbolstr in symbols:
+        *_, symtype, symbol = symbolstr.split()
+        if symtype in "TDRS":
+            if is_namespaced(symbol) is False:
+                non_namespaced.append(symbol)
+
+    if len(non_namespaced) > 0:
+        print("Missing namespace literal from {}".format(namespaces))
+        for symbol in non_namespaced:
+            print("\tsymbol: {}".format(symbol))
+    assert not non_namespaced, "Literals with missing namespaces"
+
+
+def check_folder(folder, namespace):
+    checked = 0
+    # recursively go through folder and check all object files
+    for root, dirnames, filenames in os.walk(folder):
+        for filename in filenames:
+            if filename.endswith(".o"):
+                check_file(os.path.join(root, filename), namespace)
+                checked += 1
+    print("Checked {} files".format(checked))
+    assert checked > 0
+
+
+def make_mldsa_namespace(lvl):
+    return [f"PQCP_MLDSA_NATIVE_MLDSA{lvl}"]
+
+
+def run():
+    check_folder("test/build/mldsa44/mldsa", make_mldsa_namespace(44))
+    check_folder("test/build/mldsa65/mldsa", make_mldsa_namespace(65))
+    check_folder("test/build/mldsa87/mldsa", make_mldsa_namespace(87))
+
+
+if __name__ == "__main__":
+    os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+    run()

--- a/scripts/tests
+++ b/scripts/tests
@@ -577,6 +577,14 @@ class Tests:
     def func(self):
         def _func(opt):
             self._compile_schemes(TEST_TYPES.FUNC, opt)
+            if self.args.check_namespace is True:
+                p = subprocess.run(
+                    ["python3", "check-namespace"],
+                    stdout=subprocess.DEVNULL if not self.args.verbose else None,
+                    cwd="scripts",
+                )
+                if p.returncode != 0:
+                    self.fail(f"Namespacing failed for opt={opt}")
             if self.args.run:
                 self._run_schemes(TEST_TYPES.FUNC, opt)
 
@@ -743,6 +751,15 @@ class Tests:
                 self._compile_schemes(TEST_TYPES.ACVP, opt)
             if stack is True:
                 self._compile_schemes(TEST_TYPES.STACK, opt)
+
+            if self.args.check_namespace is True:
+                p = subprocess.run(
+                    ["python3", "check-namespace"],
+                    stdout=subprocess.DEVNULL if not self.args.verbose else None,
+                    cwd="scripts",
+                )
+                if p.returncode != 0:
+                    self.fail(f"Namespacing failed for opt={opt}")
 
             if self.args.run is False:
                 return
@@ -1022,6 +1039,13 @@ def cli():
         "all", help="Run all tests (except benchmark for now)", parents=[common_parser]
     )
 
+    all_parser.add_argument(
+        "--check-namespace",
+        help="Check namespacing of binaries",
+        action="store_true",
+        default=False,
+    )
+
     func_group = all_parser.add_mutually_exclusive_group()
     func_group.add_argument(
         "--func", action="store_true", dest="func", help="Run func test", default=True
@@ -1251,6 +1275,13 @@ def cli():
         "func",
         help="Run the functional tests for all parameter sets",
         parents=[common_parser],
+    )
+
+    func_parser.add_argument(
+        "--check-namespace",
+        help="Check namespacing of binaries",
+        action="store_true",
+        default=False,
     )
 
     # kat arguments


### PR DESCRIPTION
- This PR resolves: #687 

- This PR ported `check-namespace` from mlkem-native and add `check_namespace` check to the CI workflow.