### PR TITLE
ACVP Client: Do not rely on truncated SHA512 support in hashlib

### DIFF
--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -158,9 +158,9 @@ def compute_hash(msg, alg):
     elif alg == "SHA2-512":
         return hashlib.sha512(msg_bytes).hexdigest()
     elif alg == "SHA2-512/224":
-        return hashlib.new("sha512_224", msg_bytes).hexdigest()
+        return hashlib.sha512(msg_bytes).digest()[:28].hex()
     elif alg == "SHA2-512/256":
-        return hashlib.new("sha512_256", msg_bytes).hexdigest()
+        return hashlib.sha512(msg_bytes).digest()[:32].hex()
     elif alg == "SHA3-224":
         return hashlib.sha3_224(msg_bytes).hexdigest()
     elif alg == "SHA3-256":


### PR DESCRIPTION
Python 3.7's hashlib does not have support for truncated SHA512 (hashlib.new("sha512_224", ...) and hashlib.new("sha512_256", ...). It seems it got added in 3.8, but the documentation does not mention it at all.

This commit removes the relying on both sha512_224 and sha512_256 support in hashlib, and instead just uses sha512 and performs the truncation afterwards.

- Resolves https://github.com/pq-code-package/mldsa-native/issues/719