### PR TITLE
Bump nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754028485,
-        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "lastModified": 1763334038,
+        "narHash": "sha256-LBVOyaH6NFzQ3X/c6vfMZ9k4SV2ofhpxeL9YnhHNJQQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
+        "rev": "4c8cdd5b1a630e8f72c9dd9bf582b1afb3127d2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I am currently facing an issue with gcc in our default nix development shell:

```
$ gcc --version
dyld[66234]: duplicate LC_RPATH '/nix/store/x1l4adm8r5vbbba33ma9mby5hj175dfw-libSystem-B/lib' in /nix/store/xmy0dqsra0h4ybqc7n2b5gji41r4sh5z-gcc-14.2.1.20250322/bin/gcc dyld[66234]: duplicate LC_RPATH '/nix/store/x1l4adm8r5vbbba33ma9mby5hj175dfw-libSystem-B/lib' Abort trap: 6
```

The problem goes away when updating nixpkgs (and it also updates gcc to 14.3.0):

$ gcc --version
gcc (GCC) 14.3.0

This commit bumps the nixplgs version to a recent version.