### PR TITLE
Switch mld_polymat to struct wrapper

### DIFF
--- a/mldsa/mldsa_native.S
+++ b/mldsa/mldsa_native.S
@@ -259,6 +259,7 @@
 #undef mld_polyz_unpack
 /* mldsa/src/polyvec.h */
 #undef MLD_POLYVEC_H
+#undef mld_polymat
 #undef mld_polyvec_matrix_expand
 #undef mld_polyvec_matrix_pointwise_montgomery
 #undef mld_polyveck

--- a/mldsa/mldsa_native.c
+++ b/mldsa/mldsa_native.c
@@ -256,6 +256,7 @@
 #undef mld_polyz_unpack
 /* mldsa/src/polyvec.h */
 #undef MLD_POLYVEC_H
+#undef mld_polymat
 #undef mld_polyvec_matrix_expand
 #undef mld_polyvec_matrix_pointwise_montgomery
 #undef mld_polyveck

--- a/proofs/cbmc/attempt_signature_generation/attempt_signature_generation_harness.c
+++ b/proofs/cbmc/attempt_signature_generation/attempt_signature_generation_harness.c
@@ -3,10 +3,12 @@
 
 #include "sign.h"
 
-int mld_attempt_signature_generation(
-    uint8_t *sig, const uint8_t *mu, const uint8_t rhoprime[MLDSA_CRHBYTES],
-    uint16_t nonce, const mld_polyvecl mat[MLDSA_K], const mld_polyvecl *s1,
-    const mld_polyveck *s2, const mld_polyveck *t0);
+int mld_attempt_signature_generation(uint8_t *sig, const uint8_t *mu,
+                                     const uint8_t rhoprime[MLDSA_CRHBYTES],
+                                     uint16_t nonce, mld_polymat *mat,
+                                     const mld_polyvecl *s1,
+                                     const mld_polyveck *s2,
+                                     const mld_polyveck *t0);
 
 void harness(void)
 {
@@ -14,7 +16,7 @@ void harness(void)
   uint8_t *mu;
   uint8_t *rhoprime;
   uint16_t nonce;
-  mld_polyvecl *mat;
+  mld_polymat *mat;
   mld_polyvecl *s1;
   mld_polyveck *s2;
   mld_polyveck *t0;

--- a/proofs/cbmc/polymat_permute_bitrev_to_custom/polymat_permute_bitrev_to_custom_harness.c
+++ b/proofs/cbmc/polymat_permute_bitrev_to_custom/polymat_permute_bitrev_to_custom_harness.c
@@ -3,10 +3,10 @@
 
 #include "polyvec.h"
 
-void mld_polymat_permute_bitrev_to_custom(mld_polyvecl mat[MLDSA_K]);
+void mld_polymat_permute_bitrev_to_custom(mld_polymat *mat);
 
 void harness(void)
 {
-  mld_polyvecl *mat;
+  mld_polymat *mat;
   mld_polymat_permute_bitrev_to_custom(mat);
 }

--- a/proofs/cbmc/polyvec_matrix_expand/polyvec_matrix_expand_harness.c
+++ b/proofs/cbmc/polyvec_matrix_expand/polyvec_matrix_expand_harness.c
@@ -5,7 +5,7 @@
 
 void harness(void)
 {
-  mld_polyvecl *mat;
+  mld_polymat *mat;
   uint8_t *rho;
 
   mld_polyvec_matrix_expand(mat, rho);

--- a/proofs/cbmc/polyvec_matrix_expand_serial/polyvec_matrix_expand_harness.c
+++ b/proofs/cbmc/polyvec_matrix_expand_serial/polyvec_matrix_expand_harness.c
@@ -5,7 +5,7 @@
 
 void harness(void)
 {
-  mld_polyvecl *mat;
+  mld_polymat *mat;
   uint8_t *rho;
 
   mld_polyvec_matrix_expand(mat, rho);

--- a/proofs/cbmc/polyvec_matrix_pointwise_montgomery/polyvec_matrix_pointwise_montgomery_harness.c
+++ b/proofs/cbmc/polyvec_matrix_pointwise_montgomery/polyvec_matrix_pointwise_montgomery_harness.c
@@ -6,6 +6,7 @@
 void harness(void)
 {
   mld_polyveck *a;
-  mld_polyvecl *b, *c;
+  mld_polymat *b;
+  mld_polyvecl *c;
   mld_polyvec_matrix_pointwise_montgomery(a, b, c);
 }

--- a/test/bench_components_mldsa.c
+++ b/test/bench_components_mldsa.c
@@ -23,27 +23,27 @@ static int cmp_uint64_t(const void *a, const void *b)
   return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
 }
 
-#define BENCH(txt, code)                                            \
-  for (i = 0; i < NTESTS; i++)                                      \
-  {                                                                 \
-    mld_randombytes((uint8_t *)data0, sizeof(data0));               \
-    mld_randombytes((uint8_t *)&polyvecl_a, sizeof(polyvecl_a));    \
-    mld_randombytes((uint8_t *)&polyvecl_b, sizeof(polyvecl_b));    \
-    mld_randombytes((uint8_t *)polyvecl_mat, sizeof(polyvecl_mat)); \
-    for (j = 0; j < NWARMUP; j++)                                   \
-    {                                                               \
-      code;                                                         \
-    }                                                               \
-                                                                    \
-    t0 = get_cyclecounter();                                        \
-    for (j = 0; j < NITERATIONS; j++)                               \
-    {                                                               \
-      code;                                                         \
-    }                                                               \
-    t1 = get_cyclecounter();                                        \
-    (cyc)[i] = t1 - t0;                                             \
-  }                                                                 \
-  qsort((cyc), NTESTS, sizeof(uint64_t), cmp_uint64_t);             \
+#define BENCH(txt, code)                                         \
+  for (i = 0; i < NTESTS; i++)                                   \
+  {                                                              \
+    mld_randombytes((uint8_t *)data0, sizeof(data0));            \
+    mld_randombytes((uint8_t *)&polyvecl_a, sizeof(polyvecl_a)); \
+    mld_randombytes((uint8_t *)&polyvecl_b, sizeof(polyvecl_b)); \
+    mld_randombytes((uint8_t *)&polymat, sizeof(polymat));       \
+    for (j = 0; j < NWARMUP; j++)                                \
+    {                                                            \
+      code;                                                      \
+    }                                                            \
+                                                                 \
+    t0 = get_cyclecounter();                                     \
+    for (j = 0; j < NITERATIONS; j++)                            \
+    {                                                            \
+      code;                                                      \
+    }                                                            \
+    t1 = get_cyclecounter();                                     \
+    (cyc)[i] = t1 - t0;                                          \
+  }                                                              \
+  qsort((cyc), NTESTS, sizeof(uint64_t), cmp_uint64_t);          \
   printf(txt " cycles=%" PRIu64 "\n", (cyc)[NTESTS >> 1] / NITERATIONS);
 
 static int bench(void)
@@ -52,7 +52,7 @@ static int bench(void)
   MLD_ALIGN mld_poly poly_out;
   MLD_ALIGN mld_polyvecl polyvecl_a, polyvecl_b;
   MLD_ALIGN mld_polyveck polyveck_out;
-  MLD_ALIGN mld_polyvecl polyvecl_mat[MLDSA_K];
+  MLD_ALIGN mld_polymat polymat;
   uint64_t cyc[NTESTS];
   unsigned i, j;
   uint64_t t0, t1;
@@ -66,7 +66,7 @@ static int bench(void)
         mld_polyvecl_pointwise_acc_montgomery(&poly_out, &polyvecl_a,
                                               &polyvecl_b))
   BENCH("polyvec_matrix_pointwise_montgomery",
-        mld_polyvec_matrix_pointwise_montgomery(&polyveck_out, polyvecl_mat,
+        mld_polyvec_matrix_pointwise_montgomery(&polyveck_out, &polymat,
                                                 &polyvecl_b))
 
   return 0;


### PR DESCRIPTION
- Change mld_polymat from mld_polyvecl[MLDSA_K] to struct wrapper
- Update all function signatures to use pointer style
- Fix all implementations to use struct member access
- Update CBMC harnesses and contracts

- Resolves #737 (step 1 of #736)