### PR TITLE
config.h: Align mldsa-native and mlkem-native config.h

### DIFF
--- a/examples/basic_deterministic/mldsa_native/custom_no_randomized_config.h
+++ b/examples/basic_deterministic/mldsa_native/custom_no_randomized_config.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/custom_backend/mldsa_native/custom_config.h
+++ b/examples/custom_backend/mldsa_native/custom_config.h
@@ -136,6 +136,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build/config_44.h
+++ b/examples/monolithic_build/config_44.h
@@ -132,6 +132,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build/config_65.h
+++ b/examples/monolithic_build/config_65.h
@@ -132,6 +132,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build/config_87.h
+++ b/examples/monolithic_build/config_87.h
@@ -132,6 +132,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build_multilevel/multilevel_config.h
+++ b/examples/monolithic_build_multilevel/multilevel_config.h
@@ -133,6 +133,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build_multilevel_native/multilevel_config.h
+++ b/examples/monolithic_build_multilevel_native/multilevel_config.h
@@ -137,6 +137,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build_native/config_44.h
+++ b/examples/monolithic_build_native/config_44.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build_native/config_65.h
+++ b/examples/monolithic_build_native/config_65.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/examples/monolithic_build_native/config_87.h
+++ b/examples/monolithic_build_native/config_87.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/mldsa/src/config.h
+++ b/mldsa/src/config.h
@@ -118,6 +118,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1653,7 +1653,6 @@ def get_config_options():
         "MLD_SYS_AARCH64_SLOW_BARREL_SHIFTER",
         "MLDSA_DEBUG",  # TODO: Rename?
         "MLD_BREAK_PCT",  # Use in PCT breakage test]
-        "MLD_CONFIG_NO_ASM_VALUE_BARRIER",  # TODO: Add to config?
         "MLD_CHECK_APIS",
         "MLD_CONFIG_API_XXX",
         "MLD_USE_NATIVE_XXX",

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_memcpy_config.h
+++ b/test/custom_memcpy_config.h
@@ -133,6 +133,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_memset_config.h
+++ b/test/custom_memset_config.h
@@ -133,6 +133,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_native_capability_config_0.h
+++ b/test/custom_native_capability_config_0.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_native_capability_config_1.h
+++ b/test/custom_native_capability_config_1.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/custom_native_capability_config_CPUID_AVX2.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_randombytes_config.h
+++ b/test/custom_randombytes_config.h
@@ -133,6 +133,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_stdlib_config.h
+++ b/test/custom_stdlib_config.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/custom_zeroize_config.h
+++ b/test/custom_zeroize_config.h
@@ -133,6 +133,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/no_asm_config.h
+++ b/test/no_asm_config.h
@@ -134,6 +134,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH

--- a/test/serial_fips202_config.h
+++ b/test/serial_fips202_config.h
@@ -133,6 +133,21 @@
  *****************************************************************************/
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
 
+/******************************************************************************
+ * Name:        MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mldsa-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_USE_NATIVE_BACKEND_ARITH


### PR DESCRIPTION
- Resolves: #688 

- This PR aligns the config.h differences between mldsa-native and mlkem-native.
- For example, In mlkem-native, MLK_CONFIG_FILE is the second entry, while in mldsa-native, MLD_CONFIG_FILE was moved to the fifth position and mixed with native-backend configuration macros.
- Aligning these discrepancies simplifies future porting and modifications, and helps prevent issues like the missing macros fixed in #686.
- The following discrepancies also had been addressed:
  - `MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS` missing in mldsa-native, fixed.
  - `MLK_CONFIG_NO_ASM_VALUE_BARRIER` missing in mlkem-native, fixed in mlkem-naitve [PR #1325](https://github.com/pq-code-package/mlkem-native/pull/1325)
  - Missing FIPS 203 citation, fixed in mlkem-naitve [PR #1325](https://github.com/pq-code-package/mlkem-native/pull/1325)