### PR TITLE
Better explanation for Barrett division in decompose

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -83,3 +83,11 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/baremetal.yml
     secrets: inherit
+  isabelle:
+    name: Isabelle
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/isabelle.yml
+    secrets: inherit

--- a/.github/workflows/isabelle.yml
+++ b/.github/workflows/isabelle.yml
@@ -1,0 +1,18 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: Isabelle proofs
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  compress:
+    runs-on: ubuntu-latest
+    container: makarius/isabelle:Isabelle2025-1
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build Compress session
+        run: /home/isabelle/Isabelle/bin/isabelle build -D proofs/isabelle/compress

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ HOL-Light functional correctness proofs can be found in [proofs/hol_light](proof
 
 These proofs utilize the verification infrastructure in [s2n-bignum](https://github.com/awslabs/s2n-bignum).
 
+Finally, [proofs/isabelle](proofs/isabelle/compress) contains proofs in [Isabelle/HOL](https://isabelle.in.tum.de/) of the correctness of
+different approaches for computing the scalar decomposition routines used in ML-DSA. Those are still experimental and do not yet operate
+on the source level.
+
 ## Security
 
 All assembly in mldsa-native is constant-time in the sense that it is free of secret-dependent control flow, memory access,

--- a/dev/aarch64_clean/src/poly_decompose_32_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_32_asm.S
@@ -42,6 +42,8 @@
         // round(a * 1074791425 / 2^49), where the round-down on the LHS is
         // essential, and on the RHS the type of rounding again does not matter.
         // This concludes the proof.
+        //
+        // See proofs/isabelle/compress for a formalization of this argument.
         sqdmulh \a1\().4s, \a\().4s, barrett_const.4s
         srshr \a1\().4s, \a1\().4s, #18
         // range: 0 <= a1 <= 16

--- a/dev/aarch64_clean/src/poly_decompose_88_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_88_asm.S
@@ -42,6 +42,8 @@
         // round(a * 1477838209 / 2^48), where the round-down on the LHS is
         // essential, and on the RHS the type of rounding again does not matter.
         // This concludes the proof.
+        //
+        // See proofs/isabelle/compress for a formalization of this argument.
         sqdmulh \a1\().4s, \a\().4s, barrett_const.4s
         srshr \a1\().4s, \a1\().4s, #17
         // range: 0 <= a1 <= 44

--- a/dev/x86_64/src/poly_decompose_32_avx2.c
+++ b/dev/x86_64/src/poly_decompose_32_avx2.c
@@ -75,7 +75,7 @@ void mld_poly_decompose_32_avx2(int32_t *a1, int32_t *a0)
     /*
      * Compute f1 = round-(f1' / B) ≈ round(f1' * 1025 / 2^22). This is exact
      * for 0 <= f1' < 2^16. See mld_decompose() in mldsa/src/rounding.h for the
-     * proof.
+     * proof, and proofs/isabelle/compress for a formalization of the argument.
      *
      * round(f1' * 1025 / 2^22) is in turn computed in 2 steps as
      * round(floor(f1' * 1025 / 2^16) / 2^6). The mulhi computes f1'' =

--- a/dev/x86_64/src/poly_decompose_88_avx2.c
+++ b/dev/x86_64/src/poly_decompose_88_avx2.c
@@ -76,7 +76,7 @@ void mld_poly_decompose_88_avx2(int32_t *a1, int32_t *a0)
     /*
      * Compute f1 = round-(f1' / B) ≈ round(f1' * 11275 / 2^24). This is exact
      * for 0 <= f1' < 2^16. See mld_decompose() in mldsa/src/rounding.h for the
-     * proof.
+     * proof, and proofs/isabelle/compress for a formalization of the argument.
      *
      * round(f1' * 11275 / 2^24) is in turn computed in 2 steps as
      * round(floor(f1' * 11275 / 2^16) / 2^8). The mulhi computes f1'' =

--- a/mldsa/src/native/x86_64/src/poly_decompose_32_avx2.c
+++ b/mldsa/src/native/x86_64/src/poly_decompose_32_avx2.c
@@ -75,7 +75,7 @@ void mld_poly_decompose_32_avx2(int32_t *a1, int32_t *a0)
     /*
      * Compute f1 = round-(f1' / B) ≈ round(f1' * 1025 / 2^22). This is exact
      * for 0 <= f1' < 2^16. See mld_decompose() in mldsa/src/rounding.h for the
-     * proof.
+     * proof, and proofs/isabelle/compress for a formalization of the argument.
      *
      * round(f1' * 1025 / 2^22) is in turn computed in 2 steps as
      * round(floor(f1' * 1025 / 2^16) / 2^6). The mulhi computes f1'' =

--- a/mldsa/src/native/x86_64/src/poly_decompose_88_avx2.c
+++ b/mldsa/src/native/x86_64/src/poly_decompose_88_avx2.c
@@ -76,7 +76,7 @@ void mld_poly_decompose_88_avx2(int32_t *a1, int32_t *a0)
     /*
      * Compute f1 = round-(f1' / B) ≈ round(f1' * 11275 / 2^24). This is exact
      * for 0 <= f1' < 2^16. See mld_decompose() in mldsa/src/rounding.h for the
-     * proof.
+     * proof, and proofs/isabelle/compress for a formalization of the argument.
      *
      * round(f1' * 11275 / 2^24) is in turn computed in 2 steps as
      * round(floor(f1' * 11275 / 2^16) / 2^8). The mulhi computes f1'' =

--- a/mldsa/src/rounding.h
+++ b/mldsa/src/rounding.h
@@ -141,6 +141,8 @@ __contract__(
    * round(f1' * 11275 / 2^24), where the round-down on the LHS is essential,
    * and on the RHS the type of rounding again does not matter. This concludes
    * the proof.
+   *
+   * See proofs/isabelle/compress for a formalization of the above argument.
    */
   *a1 = (*a1 * 11275 + (1 << 23)) >> 24;
   mld_assert(*a1 >= 0 && *a1 <= 44);

--- a/proofs/isabelle/compress/Barrett_Division.thy
+++ b/proofs/isabelle/compress/Barrett_Division.thy
@@ -1,0 +1,224 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Barrett_Division
+  imports Rounding HOL.Bit_Operations
+begin
+
+section \<open>Barrett Division\<close>
+
+text \<open>The Barrett magic constant approximates @{term "2^N / b"}.\<close>
+definition barrett_magic :: \<open>int \<Rightarrow> nat \<Rightarrow> int\<close> where
+  \<open>barrett_magic b N \<equiv> \<lfloor>(Rat.rat_of_int (2 ^ N)) / (rat_of_int b)\<rfloor>\<close>
+
+text \<open>Rational approximation of @{term "1/b"} using the magic constant.\<close>
+definition barrett_approximation :: \<open>int \<Rightarrow> nat \<Rightarrow> rat\<close> where
+  \<open>barrett_approximation b N \<equiv> rat_of_int (barrett_magic b N) / rat_of_int (2 ^ N)\<close>
+
+text \<open>Error in the Barrett approximation (always non-negative).\<close>
+definition barrett_error :: \<open>int \<Rightarrow> nat \<Rightarrow> rat\<close> where
+  \<open>barrett_error b N = 1.0 / (rat_of_int b) - barrett_approximation b N\<close>
+
+text \<open>Floor of a rational is exact iff divisibility holds.\<close>
+lemma rat_floor_exact_iff:
+  assumes \<open>b \<noteq> 0\<close>
+  shows \<open>rat_of_int \<lfloor>rat_of_int a / rat_of_int b\<rfloor> = rat_of_int a / rat_of_int b
+         \<longleftrightarrow> b dvd a\<close>
+proof -
+  { 
+    assume \<open>b dvd a\<close>
+    then obtain k where \<open>a = k * b\<close> by force
+    then have \<open>rat_of_int \<lfloor>rat_of_int a / rat_of_int b\<rfloor> = rat_of_int a / rat_of_int b\<close>
+      by simp 
+  }
+  moreover {
+    let ?k = \<open>\<lfloor>rat_of_int a / rat_of_int b\<rfloor>\<close>
+    assume \<open>rat_of_int \<lfloor>rat_of_int a / rat_of_int b\<rfloor> = rat_of_int a / rat_of_int b\<close>
+    then have \<open>a = ?k * b\<close>
+      by (metis assms nonzero_eq_divide_eq of_int_eq_0_iff of_int_eq_iff of_int_mult)
+    then have \<open>b dvd a\<close>
+      by (metis dvd_triv_left mult.commute)
+  }
+  ultimately show ?thesis 
+    by safe
+qed
+
+lemma barrett_error_zero_iff:
+  assumes \<open>b > 0\<close>
+  shows \<open>barrett_error b N = 0 \<longleftrightarrow> b dvd 2^N\<close>
+proof -
+  have \<open>barrett_error b N = 0 \<longleftrightarrow> rat_of_int (barrett_magic b N) = Rat.rat_of_int (2 ^ N) / (rat_of_int b)\<close>
+    unfolding barrett_error_def barrett_approximation_def 
+    using Fract_of_int_quotient divide_rat_def by fastforce
+  moreover have \<open>rat_of_int (barrett_magic b N) = Rat.rat_of_int (2 ^ N) / (rat_of_int b) \<longleftrightarrow> b dvd 2^N\<close> 
+    using rat_floor_exact_iff unfolding barrett_magic_def by (metis assms less_int_code(1))
+  ultimately show ?thesis 
+    by simp
+qed
+
+lemma barrett_approximation_leq:
+  assumes \<open>b > 0\<close>
+  shows \<open>barrett_approximation b N \<le> 1.0 / (rat_of_int b)\<close>
+proof -
+  note assms
+  moreover from assms have \<open>\<lfloor>2 ^ N / rat_of_int b\<rfloor> * b \<le> 2 ^ N\<close> 
+    by (metis floor_divide_lower of_int_mult of_int_numeral of_int_pos of_int_power_le_of_int_cancel_iff)  
+  ultimately show ?thesis
+    unfolding barrett_approximation_def barrett_magic_def by (simp add: divide_le_eq)
+qed
+
+lemma barrett_approximation_eq_iff:
+  assumes \<open>b > 0\<close>
+  shows \<open>barrett_approximation b N = 1.0 / (rat_of_int b) \<longleftrightarrow> b dvd 2^N\<close>
+  by (metis assms barrett_error_def barrett_error_zero_iff right_minus_eq)
+
+text \<open>Rational result of Barrett division (before rounding).\<close>
+definition barrett_division_rat :: \<open>int \<Rightarrow> int \<Rightarrow> nat \<Rightarrow> rat\<close>
+  where \<open>barrett_division_rat a b N \<equiv> rat_of_int a * barrett_approximation b N\<close>
+
+text \<open>Barrett division: multiply by magic constant, then round.\<close>
+definition barrett_division :: \<open>int \<Rightarrow> int \<Rightarrow> nat \<Rightarrow> int\<close>
+  where \<open>barrett_division a b N \<equiv> round (barrett_division_rat a b N)\<close>
+
+text \<open>Rounding division by a power of 2.\<close>
+lemma round_div_by_power2:
+  assumes \<open>N > 0\<close>
+  shows \<open>round (rat_of_int a / 2^N) = (a + 2^(N-1)) div 2^N\<close>
+proof -
+  have \<open>\<And>x. floor (rat_of_int x / 2^N) = x div 2^N\<close> 
+    by (metis floor_divide_of_int_eq of_int_eq_numeral_power_cancel_iff)
+  moreover from \<open>N > 0\<close> have \<open>(1/2 :: rat) = 2^(N-1) / 2^N\<close> 
+    by (metis (no_types, lifting) div_self divide_divide_eq_left power_eq_0_iff power_minus_mult zero_neq_numeral)
+  moreover from this have \<open>rat_of_int a / 2^N + 1 / 2 = rat_of_int (a + 2^(N-1)) / 2^N\<close>
+    using \<open>N > 0\<close> by (simp add: add_divide_distrib)
+  ultimately show ?thesis
+    by (metis round_def)
+qed
+
+text \<open>Concrete form of Barrett division.\<close>
+lemma barrett_division:
+  assumes \<open>N > 0\<close>
+  shows \<open>barrett_division a b N = (a * barrett_magic b N + 2^(N-1)) div 2^N\<close>
+  using assms by (simp add: round_div_by_power2 barrett_division_def barrett_division_rat_def 
+    barrett_approximation_def flip: of_int_mult)
+ 
+text \<open>Examples showing convergence as precision increases.\<close>
+lemma
+ \<open>round ((29837438.0 :: rat) / 386) = 77299\<close>
+ \<open>barrett_division 29837438 386 10  = 58276\<close>
+ \<open>barrett_division 29837438 386 15  = 76488\<close>
+ \<open>barrett_division 29837438 386 20  = 77284\<close>
+ \<open>barrett_division 29837438 386 25  = 77299\<close>
+ by eval+
+
+lemma barrett_division_rat_concrete:
+  shows \<open>barrett_division_rat a b N = rat_of_int (a * barrett_magic b N) / 2^N\<close>
+  unfolding barrett_division_rat_def barrett_approximation_def 
+  by (simp add: Fract_of_int_quotient)
+
+lemma rat_inverse_of_int:
+  shows \<open>1 / rat_of_int b = Fract 1 b\<close>
+  by (simp add: Fract_of_int_quotient) 
+
+lemma barrett_division_leq:
+  assumes \<open>a \<ge> 0\<close> and \<open>b > 0\<close>
+  shows \<open>barrett_division_rat a b N \<le> rat_of_int a / rat_of_int b\<close>
+proof - 
+  have \<open>rat_of_int a * barrett_approximation b N \<le> rat_of_int a * (1 / rat_of_int b)\<close>    
+    using barrett_approximation_leq assms by (simp add: mult_left_mono rat_inverse_of_int)
+  then show ?thesis
+    unfolding barrett_division_rat_def
+    by (metis Fract_of_int_quotient mult.right_neutral of_int_1 times_divide_eq_right)
+qed
+
+lemma barrett_division_exact:
+  assumes \<open>a > 0\<close> and \<open>b > 0\<close>
+  shows \<open>barrett_division_rat a b N = rat_of_int a / rat_of_int b \<longleftrightarrow> (b dvd 2^N)\<close>
+  using assms barrett_approximation_eq_iff barrett_division_rat_def divide_rat_def by auto
+
+definition barrett_division_error :: \<open>int \<Rightarrow> int \<Rightarrow> nat \<Rightarrow> rat\<close> where
+  \<open>barrett_division_error a b N \<equiv> rat_of_int a / rat_of_int b - barrett_division_rat a b N\<close>
+
+lemma barrett_division_error:
+  assumes \<open>a \<ge> 0\<close> and \<open>b > 0\<close>
+  shows \<open>barrett_division_error a b N \<ge> 0\<close>
+  by (simp add: assms barrett_division_error_def barrett_division_leq)
+
+lemma barrett_division_error_zero:
+  assumes \<open>a > 0\<close> and \<open>b > 0\<close>
+  shows \<open>barrett_division_error a b N = 0 \<longleftrightarrow> b dvd 2^N\<close>
+  by (metis assms barrett_division_error_def barrett_division_exact right_minus_eq)
+
+lemma barrett_division_error_bound:
+  assumes \<open>a \<ge> 0\<close> and \<open>b > 0\<close>
+  shows \<open>barrett_division_error a b N \<le> rat_of_int a * barrett_error b N\<close>
+  unfolding barrett_division_rat_def barrett_division_error_def barrett_error_def 
+  by (simp add: right_diff_distrib')
+
+text \<open>Main theorem: Barrett division equals round-half-down division when error is small enough.\<close>
+theorem barrett_division_correct:
+  assumes \<open>a \<ge> 0\<close> and \<open>b > 0\<close> and \<open>2 dvd b\<close> and \<open>\<not> (b dvd 2^N)\<close>
+     and \<open>a < floor (1 / (barrett_error b N * rat_of_int b))\<close>
+   shows \<open>round_half_down (rat_of_int a / rat_of_int b) = 
+          barrett_division a b N\<close>
+proof -
+  from assms have bd: \<open>rat_of_int a < 1 / (barrett_error b N * rat_of_int b)\<close> 
+    by linarith
+  obtain q where q: \<open>q = rat_of_int a / rat_of_int b\<close> by simp
+  obtain \<epsilon> where \<epsilon>: \<open>\<epsilon> = barrett_division_error a b N\<close> by simp
+  from assms bd have \<open>rat_of_int a * barrett_error b N < (1 / (barrett_error b N * rat_of_int b)) * barrett_error b N\<close>
+  by (metis linorder_not_le mult_le_0_iff mult_less_cancel_right nle_le of_int_nonneg 
+    order_le_less_trans zero_less_divide_1_iff)
+  also have \<open>\<dots> = 1 / rat_of_int b\<close>
+    using calculation by fastforce
+  finally have bd': \<open>rat_of_int a * barrett_error b N < 1 / rat_of_int b\<close>   
+    by simp
+  then have bd'': \<open>\<epsilon> \<le> 1 / rat_of_int b\<close>
+    by (metis \<epsilon> assms(1,2) barrett_division_error_bound dual_order.strict_trans2 less_eq_rat_def)
+  then have \<open>round_half_down q = round_half_down (q - \<epsilon>)\<close>
+    by (metis \<epsilon> bd' assms barrett_division_error barrett_division_error_bound dual_order.strict_trans2 q
+        round_half_down_unchanged_concrete)
+  then have \<open>round_half_down (rat_of_int a / rat_of_int b) = 
+        round_half_down (barrett_division_rat a b N)\<close>
+    using \<epsilon> barrett_division_error_def q by auto
+  moreover have \<open>round_half_down (q - \<epsilon>) = round (q - \<epsilon>)\<close>
+  proof -
+    { assume \<open>a = 0\<close>
+      then have \<open>q - \<epsilon> = 0\<close>
+        by (simp add: \<epsilon> barrett_division_error_def barrett_division_rat_def q)
+      then have \<open>round_half_down (q - \<epsilon>) = round (q - \<epsilon>)\<close>
+        by (simp add: round_half_down_def) 
+    }
+    moreover {
+      assume \<open>a > 0\<close>
+      then have \<open>\<epsilon> > 0\<close>
+        by (simp add: \<epsilon> assms(2,4) barrett_division_error barrett_division_error_zero order_neq_le_trans)
+      then have \<open>round_half_down (q - \<epsilon>) = round (q - \<epsilon>)\<close>
+        by (metis \<epsilon> bd'' bd' assms(1,2,3) barrett_division_error_bound less_eq_rat_def linorder_not_less q
+            round_half_down_unchanged_concrete(2))
+    }
+    ultimately show ?thesis 
+      using \<open>a \<ge> 0\<close> by (cases \<open>a > 0\<close>; simp)
+  qed
+  then have \<open>round_half_down (barrett_division_rat a b N) = 
+             round (barrett_division_rat a b N)\<close>
+    using \<epsilon> barrett_division_error_def q by auto
+  then show ?thesis 
+    by (simp add: calculation barrett_division_def)
+qed
+
+text \<open>A convenience attribute for specializing the above theorem.\<close>
+ML \<open>
+fun eval_core_conv ctxt ct =
+  let val t = Thm.term_of ct
+  in if null (Term.add_frees t []) andalso null (Term.add_vars t [])
+     then Code_Simp.dynamic_conv ctxt ct
+     else raise CTERM ("eval_conv: not ground", [ct])
+  end
+fun eval_conv ctxt = Conv.try_conv (Conv.top_sweep_conv eval_core_conv ctxt) 
+                          then_conv Simplifier.asm_full_rewrite ctxt
+val eval_attr = (Context.proof_of #> eval_conv #> Conv.fconv_rule) |> Thm.rule_attribute [] 
+\<close>
+attribute_setup eval = \<open>Scan.succeed eval_attr\<close> "simplify theorem through evaluation"
+
+end

--- a/proofs/isabelle/compress/ML-DSA_Compress.thy
+++ b/proofs/isabelle/compress/ML-DSA_Compress.thy
@@ -1,0 +1,63 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory "ML-DSA_Compress"
+  imports Barrett_Division
+begin
+
+section \<open>ML-DSA Decompose Specializations\<close>
+
+text \<open>
+  ML-DSA uses two parameter sets with different \<^verbatim>\<open>GAMMA2\<close> values:
+  \<^item> Parameter set 65/87 (ML-DSA-65, ML-DSA-87): \<^verbatim>\<open>GAMMA2 = 261888\<close>, divisor \<^verbatim>\<open>2*GAMMA2 = 523776\<close>
+  \<^item> Parameter set 44 (ML-DSA-44): \<^verbatim>\<open>GAMMA2 = 95232\<close>, divisor \<^verbatim>\<open>2*GAMMA2 = 190464\<close>
+
+  The implementations use different Barrett division strategies:
+  \<^item> C and AVX2: Factor out \<^verbatim>\<open>128\<close> first, then Barrett divide by \<^verbatim>\<open>4092\<close> or \<^verbatim>\<open>1488\<close>
+  \<^item> AArch64: Barrett divide directly by \<^verbatim>\<open>523776\<close> or \<^verbatim>\<open>190464\<close>
+
+  \<^bold>\<open>Limitation:\<close> The results below operate on unbounded integers (@{typ int}), not
+  fixed-width machine words. Connecting these results to the actual implementations
+  requires additional reasoning about word-level operations (e.g., \<^verbatim>\<open>sqdmulh\<close>,
+  \<^verbatim>\<open>mulhi\<close>, overflow behavior) which is left for future work.
+\<close>
+
+subsection \<open>C and AVX2 implementations\<close>
+
+text \<open>
+  The C reference \<^file>\<open>../../../mldsa/src/rounding.h\<close> and AVX2 implementations
+  \<^file>\<open>../../../dev/x86_64/src/poly_decompose_32_avx2.c\<close> and
+  \<^file>\<open>../../../dev/x86_64/src/poly_decompose_88_avx2.c\<close>
+  first compute \<^verbatim>\<open>ceil(f / 128)\<close>, then Barrett divide by \<^verbatim>\<open>B = 2*GAMMA2 / 128\<close>.
+\<close>
+
+corollary barrett_decompose_32_c_avx2:
+  assumes \<open>a \<ge> 0\<close> and \<open>a < 65473\<close>
+  shows \<open>round_half_down (rat_of_int a / 4092) = (a * 1025 + 2^21) div 2^22\<close>
+  using barrett_division_correct[where b=4092 and N=22, simplified barrett_division, eval] assms by simp
+
+corollary barrett_decompose_88_c_avx2:
+  assumes \<open>a \<ge> 0\<close> and \<open>a < 65473\<close>
+  shows \<open>round_half_down (rat_of_int a / 1488) = (a * 11275 + 2^23) div 2^24\<close>
+  using barrett_division_correct[where b=1488 and N=24, simplified barrett_division, eval] assms by simp
+
+subsection \<open>AArch64 implementation\<close>
+
+text \<open>
+  The AArch64 implementations
+  \<^file>\<open>../../../dev/aarch64_clean/src/poly_decompose_32_asm.S\<close> and
+  \<^file>\<open>../../../dev/aarch64_clean/src/poly_decompose_88_asm.S\<close>
+  Barrett divide directly by \<^verbatim>\<open>2*GAMMA2\<close> using \<^verbatim>\<open>sqdmulh\<close> and \<^verbatim>\<open>srshr\<close>.
+\<close>
+
+corollary barrett_decompose_32_aarch64:
+  assumes \<open>a \<ge> 0\<close> and \<open>a < 1099511627776\<close>
+  shows \<open>round_half_down (rat_of_int a / 523776) = (a * 1074791425 + 2^48) div 2^49\<close>
+  using barrett_division_correct[where b=523776 and N=49, simplified barrett_division, eval] assms by simp
+
+corollary barrett_decompose_88_aarch64:
+  assumes \<open>a \<ge> 0\<close> and \<open>a < 3926827242\<close>
+  shows \<open>round_half_down (rat_of_int a / 190464) = (a * 1477838209 + 2^47) div 2^48\<close>
+  using barrett_division_correct[where b=190464 and N=48, simplified barrett_division, eval] assms by simp
+
+end

--- a/proofs/isabelle/compress/Makefile
+++ b/proofs/isabelle/compress/Makefile
@@ -1,0 +1,16 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+ISABELLE_VERSION ?= Isabelle2025
+ISABELLE_HOME ?= /Applications/$(ISABELLE_VERSION).app/bin
+
+all:
+	$(ISABELLE_HOME)/isabelle build -D .
+
+clean:
+	$(ISABELLE_HOME)/isabelle build -c -D .
+
+jedit:
+	$(ISABELLE_HOME)/isabelle jedit -D . ML-DSA_Compress.thy
+
+.PHONY: all clean jedit

--- a/proofs/isabelle/compress/README.md
+++ b/proofs/isabelle/compress/README.md
@@ -1,0 +1,44 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# ML-DSA Compression Proofs
+
+Isabelle/HOL proofs for the Barrett division used in ML-DSA's `Decompose` routine.
+
+## Theory Files
+
+- [Rounding.thy](Rounding.thy) — Round-half-down rounding and its stability properties
+- [Barrett_Division.thy](Barrett_Division.thy) — Barrett approximation and correctness theorem
+- [ML-DSA_Compress.thy](ML-DSA_Compress.thy) — ML-DSA specific instantiations for C/AVX2 and AArch64
+
+## Building
+
+Assuming the `isabelle` binary is in your PATH, you can build via.
+
+```
+isabelle build -D .
+```
+
+Tested with Isabelle2025.1 and Isabelle2025.2.
+
+Alternatively, you can use the provided [Makefile](Makefile). Use
+
+```
+make jedit
+```
+
+to start an interactive proof session in Isabelle/jEdit, and
+
+```
+make
+```
+
+to build the proofs from the command line.
+
+To use the Makefile, you need to set the `ISABELLE_VERSION` to your
+Isabelle version, and `ISABELLE_HOME` to the full path of the directory
+containing the `isabelle` binary.
+
+## Limitation
+
+The proofs operate on unbounded integers, not fixed-width machine words.
+Connecting to actual implementations requires additional word-level reasoning.

--- a/proofs/isabelle/compress/ROOT
+++ b/proofs/isabelle/compress/ROOT
@@ -1,0 +1,7 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+session Compress = HOL +
+  theories
+    Rounding
+    Barrett_Division
+    "ML-DSA_Compress"

--- a/proofs/isabelle/compress/Rounding.thy
+++ b/proofs/isabelle/compress/Rounding.thy
@@ -1,0 +1,176 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Rounding
+  imports HOL.Rat
+begin
+
+section \<open>Round-half-down\<close>
+
+text \<open>The definition of the compression routine in ML-DSA involves rounding with half being rounded
+down. This can be expressed as follows:\<close>
+
+definition round_half_down :: \<open>rat \<Rightarrow> int\<close> where
+  \<open>round_half_down x = - round (-x)\<close>
+
+text \<open>Monotonicity of round-half-down.\<close>
+lemma round_half_down_mono:
+  assumes \<open>x \<le> y\<close>
+  shows \<open>round_half_down x \<le> round_half_down y\<close>
+  by (simp add: assms round_half_down_def round_mono)
+
+text \<open>Predicate for half-multiples (values of the form n + 1/2).\<close>
+definition is_half_multiple :: \<open>rat \<Rightarrow> bool\<close> where
+  \<open>is_half_multiple x \<equiv> \<exists>y. x = rat_of_int y + 1/2\<close>
+
+text \<open>Equivalent characterization.\<close>
+lemma is_half_multiple_alt:
+  shows \<open>is_half_multiple x \<longleftrightarrow> (\<exists>y. x = rat_of_int y - 1/2)\<close>
+proof -
+  have \<open>\<And>y. rat_of_int y - 1/2 = rat_of_int (y - 1) + 1/2\<close> 
+    by simp
+  then show ?thesis
+    unfolding is_half_multiple_def by (metis add_diff_cancel_right')
+qed
+
+text \<open>Characterization of standard rounding.\<close>
+lemma round_eq_iff:
+  shows \<open>round x = y \<longleftrightarrow> (-1/2 \<le> x - rat_of_int y \<and> x - rat_of_int y < 1/2)\<close>
+  by (metis add.commute diff_le_eq diff_less_eq minus_diff_eq minus_divide_left minus_le_iff 
+    of_int_round_gt of_int_round_le round_unique)
+
+text \<open>Characterization of round-half-down.\<close>
+lemma round_half_down_eq_iff:
+  shows \<open>round_half_down x = y \<longleftrightarrow> (-1/2 < x - rat_of_int y \<and> x - rat_of_int y \<le> 1/2)\<close>
+proof -
+  have \<dagger>: \<open>\<And>x y. - round x = y \<longleftrightarrow> round x = -y\<close> 
+    by auto
+  show ?thesis
+    unfolding round_half_down_def by (auto simp add: round_eq_iff \<dagger>) 
+qed
+
+text \<open>Relationship between round-half-down and standard rounding.\<close>
+lemma round_half_down_up:
+  shows \<open>is_half_multiple x \<Longrightarrow> round_half_down x = round x - 1\<close>
+    and \<open>\<not> (is_half_multiple x) \<Longrightarrow> round_half_down x = round x\<close>
+proof -
+  assume \<open>is_half_multiple x\<close>
+  then obtain y where *: \<open>x = rat_of_int y + 1/2\<close> 
+    unfolding is_half_multiple_def by force
+  then have \<open>round_half_down x = y\<close> and \<open>round x = y + 1\<close>
+    by (auto simp add: round_half_down_eq_iff round_eq_iff)
+  then show \<open>round_half_down x = round x - 1\<close>
+    by simp 
+next
+  assume \<open>\<not> (is_half_multiple x)\<close>
+  obtain \<epsilon> where \<epsilon>: \<open>\<epsilon> = x - rat_of_int (round x)\<close> by simp
+  obtain y where y: \<open>y = round x\<close> by simp
+  have x: \<open>x = rat_of_int y + \<epsilon>\<close> 
+    unfolding \<epsilon> y by simp
+  have \<open>-1/2 \<le> \<epsilon>\<close> and \<open>\<epsilon> < 1/2\<close>
+    using round_eq_iff unfolding \<epsilon> by auto
+  moreover { 
+    assume \<open>\<epsilon> = -1/2\<close>
+    then have \<open>is_half_multiple x\<close> 
+      by (subst x; auto simp add: is_half_multiple_def) 
+         (metis add.commute diff_add_cancel of_int_1 of_int_add)
+    then have False 
+      using \<open>\<not> (is_half_multiple x)\<close> by simp
+  }
+  ultimately have \<open>-1/2 < \<epsilon>\<close> and \<open>\<epsilon> \<le> 1/2\<close>
+    using less_eq_rat_def by blast+
+  then have \<open>round_half_down x = y\<close>
+    by (auto simp add: round_half_down_eq_iff \<epsilon> y)
+  then show \<open>round_half_down x = round x\<close>
+    by (simp flip: y)
+qed
+
+corollary round_half_down_up':
+  shows \<open>round x - round_half_down x \<in> {0,1}\<close>
+    and \<open>round x = round_half_down x \<longleftrightarrow> \<not> (is_half_multiple x)\<close>
+  by (cases \<open>is_half_multiple x\<close>; simp add: round_half_down_up)+
+
+text \<open>If rounding is changed by a small disturbance, then there must
+be a half-multiple that's as close to the original value as the disturbance.\<close>
+lemma round_half_down_changed_find_half_multiple:
+  assumes \<open>\<epsilon> \<ge> 0\<close>
+    and \<open>round_half_down x \<noteq> round_half_down (x - \<epsilon>)\<close>
+  obtains y where \<open>is_half_multiple y\<close> \<open>y < x\<close> and \<open>x - y \<le> \<epsilon>\<close>
+proof -
+  obtain r where r: \<open>r = rat_of_int (round_half_down x)\<close> by simp
+  from r have *: \<open>-1/2 < x - r\<close> \<open>x - r \<le> 1/2\<close> 
+    using round_half_down_eq_iff by blast+
+  obtain h where h: \<open>h = r - 1/2\<close> by simp
+  then have **: \<open>h < x\<close> \<open>x - h \<le> 1\<close>
+    using * h by linarith+
+  moreover have \<open>is_half_multiple h\<close> 
+    using is_half_multiple_alt h r by blast
+  {
+    assume \<open>x - h > \<epsilon>\<close>
+    then have \<open>h < x - \<epsilon>\<close> and \<open>(x - \<epsilon>) - h \<le> 1\<close> 
+      using assms ** by auto
+    then have \<open>-1/2 < (x - \<epsilon>) - r\<close> \<open>(x - \<epsilon>) - r \<le> 1/2\<close>  
+      using h by auto
+    then have \<open>round_half_down (x - \<epsilon>) = round_half_down x\<close>
+      using round_half_down_eq_iff r by blast
+    then have False
+      using assms by simp
+  }
+  then have \<open>x - h \<le> \<epsilon>\<close> 
+    by force
+  then show ?thesis 
+    using \<open>is_half_multiple h\<close> ** that by blast
+qed
+
+text \<open>Conversely, if any non-equal half-multiple is farther away than the disturbance,
+then rounding is unchanged:\<close>
+corollary round_half_down_unchanged:
+  assumes \<open>\<epsilon> \<ge> 0\<close>
+      and \<open>\<And>y. is_half_multiple y \<Longrightarrow> x \<noteq> y \<Longrightarrow> abs (x - y) > \<epsilon>\<close>
+    shows \<open>round_half_down (x - \<epsilon>) = round_half_down x\<close> 
+      and \<open>\<epsilon> > 0 \<Longrightarrow> round_half_down (x - \<epsilon>) = round (x - \<epsilon>)\<close>
+proof -
+  show \<open>round_half_down (x - \<epsilon>) = round_half_down x\<close>
+    by (metis abs_of_nonneg assms(1,2) diff_ge_0_iff_ge less_eq_rat_def linorder_not_less 
+      round_half_down_changed_find_half_multiple)
+next
+  assume \<open>\<epsilon> > 0\<close>
+  have \<open>\<not> (is_half_multiple (x - \<epsilon>))\<close>
+    using \<open>0 < \<epsilon>\<close> assms(2) by fastforce
+  then show \<open>round_half_down (x - \<epsilon>) = round (x - \<epsilon>)\<close>
+    by (simp add: round_half_down_up)
+qed
+
+text \<open>For even quotients, the distance from half multiples is easy to find:\<close>
+corollary half_distance_concrete:
+  assumes \<open>2 dvd b\<close> and \<open>b > 0\<close> and x: \<open>x = (rat_of_int a) / (rat_of_int b)\<close>
+  shows \<open>\<And>y. is_half_multiple y \<Longrightarrow> y \<noteq> x \<Longrightarrow> abs (x - y) \<ge> 1 / (rat_of_int b)\<close>
+proof -
+  from assms obtain k where k: \<open>b = 2 * k\<close> \<open>k \<noteq> 0\<close>
+    by auto
+  fix y
+  assume \<open>is_half_multiple y\<close> and \<open>y \<noteq> x\<close>
+  obtain l where y: \<open>y = (2 * rat_of_int l + 1) / 2\<close>
+    using \<open>is_half_multiple y\<close> is_half_multiple_def by auto
+  then have y': \<open>y = rat_of_int (2 * l * k + k) / rat_of_int b\<close> 
+    using k y by (simp add: add_divide_distrib)
+  then have \<open>2 * l * k + k \<noteq> a\<close>
+    using \<open>y \<noteq> x\<close> x by blast
+  then have \<open>abs (2 * l * k + k - a) \<ge> 1\<close>
+    by auto
+  moreover have \<open>abs (x - y) = rat_of_int (abs (2 * l * k + k - a)) / rat_of_int b\<close> 
+    by (simp add: x y' abs_div_pos abs_minus_commute assms(2) diff_divide_distrib)
+  ultimately show \<open>abs (x - y) \<ge> 1 / (rat_of_int b)\<close>
+    by (metis assms(2) divide_right_mono linorder_not_less
+        nle_le of_int_0_less_iff of_int_1_le_iff)
+qed
+
+lemma round_half_down_unchanged_concrete:
+  assumes \<open>2 dvd b\<close> and \<open>b > 0\<close> and \<open>\<epsilon> \<ge> 0\<close> and \<open>\<epsilon> < 1 / rat_of_int b\<close>
+      and \<open>x = rat_of_int a / rat_of_int b\<close>
+    shows \<open>round_half_down (x - \<epsilon>) = round_half_down x\<close> 
+      and \<open>\<epsilon> > 0 \<Longrightarrow> round_half_down (x - \<epsilon>) = round (x - \<epsilon>)\<close>
+  using assms by (intro round_half_down_unchanged; 
+    simp add: half_distance_concrete order_less_le_trans)+
+
+end


### PR DESCRIPTION
- Resolves #654

Along the way, we also fix some minor details in comments for AVX2 decompose:
- The `floor()` in `floor((f + 127) >> 7)` was somewhat unnecessary as the usual semantic for the right-shift operator `>>` has integer output anyway. Seeing as the right-shift operator is not used in other explanation comments, we decided to rewrite it as division by `2^7` for better consistency.
- The bound of `f1''` is correct but the proof was misleading. The new proof should be clearer.