### PR TITLE
sign mem: reuse w/w0 buffer

### DIFF
--- a/mldsa/src/native/api.h
+++ b/mldsa/src/native/api.h
@@ -268,7 +268,7 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0,
 __contract__(
   requires(memory_no_alias(a1,  sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(a0, sizeof(int32_t) * MLDSA_N))
-  requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
+  requires(a0 == a || memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   assigns(memory_slice(a1, sizeof(int32_t) * MLDSA_N))
   assigns(memory_slice(a0, sizeof(int32_t) * MLDSA_N))
@@ -302,7 +302,7 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0,
 __contract__(
   requires(memory_no_alias(a1,  sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(a0, sizeof(int32_t) * MLDSA_N))
-  requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
+  requires(a0 == a || memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   assigns(memory_slice(a1, sizeof(int32_t) * MLDSA_N))
   assigns(memory_slice(a0, sizeof(int32_t) * MLDSA_N))

--- a/mldsa/src/poly_kl.c
+++ b/mldsa/src/poly_kl.c
@@ -44,7 +44,7 @@ MLD_STATIC_TESTABLE void mld_poly_decompose_c(mld_poly *a1, mld_poly *a0,
 __contract__(
   requires(memory_no_alias(a1,  sizeof(mld_poly)))
   requires(memory_no_alias(a0, sizeof(mld_poly)))
-  requires(memory_no_alias(a, sizeof(mld_poly)))
+  requires(a0 == a || memory_no_alias(a, sizeof(mld_poly)))
   requires(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
   assigns(memory_slice(a1, sizeof(mld_poly)))
   assigns(memory_slice(a0, sizeof(mld_poly)))
@@ -60,6 +60,8 @@ __contract__(
     invariant(i <= MLDSA_N)
     invariant(array_bound(a1->coeffs, 0, i, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)))
     invariant(array_abs_bound(a0->coeffs, 0, i, MLDSA_GAMMA2+1))
+    invariant(forall(k1, i, MLDSA_N,
+                     a->coeffs[k1] == loop_entry(*a).coeffs[k1]))
   )
   {
     mld_decompose(&a0->coeffs[i], &a1->coeffs[i], a->coeffs[i]);

--- a/mldsa/src/poly_kl.h
+++ b/mldsa/src/poly_kl.h
@@ -31,7 +31,7 @@ void mld_poly_decompose(mld_poly *a1, mld_poly *a0, const mld_poly *a)
 __contract__(
   requires(memory_no_alias(a1,  sizeof(mld_poly)))
   requires(memory_no_alias(a0, sizeof(mld_poly)))
-  requires(memory_no_alias(a, sizeof(mld_poly)))
+  requires(a0 == a || memory_no_alias(a, sizeof(mld_poly)))
   requires(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
   assigns(memory_slice(a1, sizeof(mld_poly)))
   assigns(memory_slice(a0, sizeof(mld_poly)))

--- a/mldsa/src/polyvec.c
+++ b/mldsa/src/polyvec.c
@@ -681,6 +681,8 @@ void mld_polyveck_decompose(mld_polyveck *v1, mld_polyveck *v0,
                      array_bound(v1->vec[k1].coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2))))
     invariant(forall(k2, 0, i,
                      array_abs_bound(v0->vec[k2].coeffs, 0, MLDSA_N, MLDSA_GAMMA2+1)))
+    invariant(forall(k0, i, MLDSA_K, forall(k1, 0, MLDSA_N,
+                     v->vec[k0].coeffs[k1] == loop_entry(*v).vec[k0].coeffs[k1])))
   )
   {
     mld_poly_decompose(&v1->vec[i], &v0->vec[i], &v->vec[i]);

--- a/mldsa/src/polyvec.h
+++ b/mldsa/src/polyvec.h
@@ -484,7 +484,7 @@ void mld_polyveck_decompose(mld_polyveck *v1, mld_polyveck *v0,
 __contract__(
   requires(memory_no_alias(v1,  sizeof(mld_polyveck)))
   requires(memory_no_alias(v0, sizeof(mld_polyveck)))
-  requires(memory_no_alias(v, sizeof(mld_polyveck)))
+  requires(v0 == v || memory_no_alias(v, sizeof(mld_polyveck)))
   requires(forall(k0, 0, MLDSA_K,
     array_bound(v->vec[k0].coeffs, 0, MLDSA_N, 0, MLDSA_Q)))
   assigns(memory_slice(v1, sizeof(mld_polyveck)))


### PR DESCRIPTION
This is the first of a series of commit bringing down the memory consumption of signature_internal.
Memory consumption is reduced by placing buffers whose lifetime does not overlap into a union starting with thw w and w0 buffer. CBMC contracts and proofs are adjusted where necessary.

- Hoisted out from #791 


`-fstack-usage` of `signature_internal` of ML-DSA-86 reduces from 129616 to 121536 (aarch64, -Os, gcc14).