### PR TITLE
tests: Allow specification of parameter set via `-kl` switch

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -54,5 +54,5 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           echo "::group::cbmc_${{ inputs.mldsa_parameter_set }}"
-          tests cbmc --mldsa_parameter_set ${{ inputs.mldsa_parameter_set }} --per-proof-timeout 1800;
+          tests cbmc --mldsa-parameter-set ${{ inputs.mldsa_parameter_set }} --per-proof-timeout 1800;
           echo "::endgroup::"

--- a/scripts/tests
+++ b/scripts/tests
@@ -1264,7 +1264,8 @@ def cli():
     )
 
     cbmc_parser.add_argument(
-        "--mldsa_parameter_set",
+        "-kl",
+        "--mldsa-parameter-set",
         help="MLDSA parameter set (MLD_CONFIG_PARAMETER_SET)",
         choices=["44", "65", "87", "ALL"],
         type=str.upper,


### PR DESCRIPTION
Also, rename long-form `--mldsa_parameter_set` to `--mldsa-parameter-set` in line with other parameters.