### PR TITLE
sign stack usage: Re-use y/h buffer

### DIFF
--- a/proofs/cbmc/cbmc_workaround_8813/Makefile
+++ b/proofs/cbmc/cbmc_workaround_8813/Makefile
@@ -4,11 +4,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = attempt_signature_generation_harness
+HARNESS_FILE = cbmc_workaround_8813_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = mld_attempt_signature_generation
+PROOF_UID = mld_cbmc_workaround_8813
 
 DEFINES +=
 INCLUDES +=
@@ -19,42 +19,19 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mldsa/src/sign.c
 
-CHECK_FUNCTION_CONTRACTS=mld_attempt_signature_generation
-USE_FUNCTION_CONTRACTS=$(MLD_NAMESPACE)polyvecl_uniform_gamma1 \
-                       $(MLD_NAMESPACE)polyvecl_ntt \
-                       $(MLD_NAMESPACE)polyvec_matrix_pointwise_montgomery \
-                       $(MLD_NAMESPACE)polyveck_reduce \
-                       $(MLD_NAMESPACE)polyveck_invntt_tomont \
-                       $(MLD_NAMESPACE)polyveck_caddq \
-                       $(MLD_NAMESPACE)polyveck_decompose \
-                       $(MLD_NAMESPACE)polyveck_pack_w1 \
-                       mld_H \
-                       $(MLD_NAMESPACE)poly_challenge \
-                       $(MLD_NAMESPACE)poly_ntt \
-                       $(MLD_NAMESPACE)polyvecl_pointwise_poly_montgomery \
-                       $(MLD_NAMESPACE)polyvecl_invntt_tomont \
-                       $(MLD_NAMESPACE)polyvecl_add \
-                       $(MLD_NAMESPACE)polyvecl_reduce \
-                       $(MLD_NAMESPACE)polyvecl_chknorm \
-                       $(MLD_NAMESPACE)polyveck_pointwise_poly_montgomery \
-                       $(MLD_NAMESPACE)polyveck_sub \
-                       $(MLD_NAMESPACE)polyveck_reduce \
-                       $(MLD_NAMESPACE)polyveck_chknorm \
-                       $(MLD_NAMESPACE)polyveck_add \
-                       $(MLD_NAMESPACE)polyveck_make_hint \
-                       $(MLD_NAMESPACE)pack_sig
-USE_FUNCTION_CONTRACTS+=mld_zeroize mld_cbmc_workaround_8813
+CHECK_FUNCTION_CONTRACTS=mld_cbmc_workaround_8813
+USE_FUNCTION_CONTRACTS=
 
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
+CBMCFLAGS=--smt2
 CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 
-FUNCTION_NAME = mld_attempt_signature_generation
+FUNCTION_NAME = mld_cbmc_workaround_8813
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/proofs/cbmc/cbmc_workaround_8813/cbmc_workaround_8813_harness.c
+++ b/proofs/cbmc/cbmc_workaround_8813/cbmc_workaround_8813_harness.c
@@ -1,0 +1,14 @@
+// Copyright (c) The mldsa-native project authors
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#include "sign.h"
+
+void mld_cbmc_workaround_8813(mld_polyvecl **p1, mld_polyveck **p2);
+
+void harness(void)
+{
+  mld_polyvecl **p1;
+  mld_polyveck **p2;
+
+  mld_cbmc_workaround_8813(p1, p2);
+}


### PR DESCRIPTION
This commit is the second commit working towards bringing down the memory consumption of signature_internal. It combines the y and h buffer as those lifetime does not overlap.

We work around https://github.com/diffblue/cbmc/issues/8813 by introducing a no-op mld_cbmc_workaround_8813 whose contract states that y and h point to the same piece of memory of correct size.

- Alternative to #800 