### PR TITLE
CI: Do not use npx in lint-markdown-link

### DIFF
--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -15,4 +15,5 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Check markdown links
       run: |
-        find . -name '*.md' -print0 | xargs -0 -P16 -n1 npx -y markdown-link-check@3.14.2 -q
+        npm install -g markdown-link-check@3.14.2
+        find . -name '*.md' -print0 | xargs -0 -P16 -n1 markdown-link-check -q


### PR DESCRIPTION
We keep seeing spurious failures of the lint-markdown-link job in CI

Those are potentially caused by race conditions in npx. This commit splits off a separate installation step which should solve the problem - it also eliminates npx as it's no longer needed.

- Ported from https://github.com/pq-code-package/mlkem-native/pull/1436