### PR TITLE
CI: Benchmark stack consumption with MLD_CONFIG_REDUCE_RAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,11 @@ jobs:
             name: x86_64
           - runner: ubuntu-24.04-arm
             name: aarch64
-        cflags: ['-O3', '-Os']
+        cflags:
+          - '-O3'
+          - '-Os'
+          - '-O3 -DMLD_CONFIG_REDUCE_RAM'
+          - '-Os -DMLD_CONFIG_REDUCE_RAM'
         exclude:
           - external: true
     runs-on: ${{ matrix.target.runner }}


### PR DESCRIPTION
This commit duplicates the stack analysis CI to also measure stack consumption with MLD_CONFIG_REDUCE_RAM set.