### PR TITLE
Port: move acvp test source and data into test/acvp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 test/build
 .direnv
 # Downloaded ACVP test data
-test/.acvp-data/
+test/acvp/.acvp-data/

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ run_unit_87: unit_87
 run_unit: run_unit_44 run_unit_65 run_unit_87
 
 run_acvp: acvp
-	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/acvp_client.py $(if $(ACVP_VERSION),--version $(ACVP_VERSION))
+	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/acvp/acvp_client.py $(if $(ACVP_VERSION),--version $(ACVP_VERSION))
 
 func_44: $(MLDSA44_DIR)/bin/test_mldsa44
 	$(Q)echo "  FUNC       ML-DSA-44:   $^"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you'd like contribute new backends, please reach out!
 
 mldsa-native is tested against all official ACVP ML-DSA test vectors[^ACVP].
 
-You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP client](./test/acvp_client.py) directly:
+You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP client](./test/acvp/acvp_client.py) directly:
 
 ```bash
 # Using the tests script
@@ -97,15 +97,15 @@ You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP 
 ./scripts/tests acvp --version v1.1.0.41
 
 # Using the ACVP client directly
-python3 ./test/acvp_client.py
-python3 ./test/acvp_client.py --version v1.1.0.41
+python3 ./test/acvp/acvp_client.py
+python3 ./test/acvp/acvp_client.py --version v1.1.0.41
 
 # Using specific ACVP test vector files (downloaded from the ACVP-Server)
-# python3 ./test/acvp_client.py -p {PROMPT}.json -e {EXPECTED_RESULT}.json
+# python3 ./test/acvp/acvp_client.py -p {PROMPT}.json -e {EXPECTED_RESULT}.json
 # For example, assuming you have run the above
-python3 ./test/acvp_client.py \
-  -p ./test/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/prompt.json \
-  -e ./test/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/expectedResults.json
+python3 ./test/acvp/acvp_client.py \
+  -p ./test/acvp/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/prompt.json \
+  -e ./test/acvp/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/expectedResults.json
 ```
 
 ## Benchmarking

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -37,7 +37,7 @@ def download_acvp_files(version):
     ]
 
     # Create directory structure
-    data_dir = Path(f"test/.acvp-data/{version}/files")
+    data_dir = Path(f"test/acvp/.acvp-data/{version}/files")
     data_dir.mkdir(parents=True, exist_ok=True)
 
     for file_path in files_to_download:
@@ -79,7 +79,7 @@ def loadAcvpData(prompt, expectedResults):
 
 
 def loadDefaultAcvpData(version):
-    data_dir = f"test/.acvp-data/{version}/files"
+    data_dir = f"test/acvp/.acvp-data/{version}/files"
     acvp_jsons_for_version = [
         (
             f"{data_dir}/ML-DSA-keyGen-FIPS204/prompt.json",

--- a/test/acvp/acvp_mldsa.c
+++ b/test/acvp/acvp_mldsa.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../mldsa/src/sign.h"
+#include "../../mldsa/src/sign.h"
 
 #define USAGE "acvp_mldsa{lvl} [keyGen|sigGen|sigVer] {test specific arguments}"
 #define KEYGEN_USAGE "acvp_mldsa{lvl} keyGen seed=HEX"

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -148,7 +148,7 @@ endef
 
 $(foreach scheme,mldsa44 mldsa65 mldsa87, \
 	$(foreach test,$(ACVP_TESTS), \
-		$(eval $(call ADD_SOURCE,$(scheme),$(test),)) \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),acvp/)) \
 	) \
 	$(foreach test,$(BENCH_TESTS), \
 		$(eval $(call ADD_SOURCE,$(scheme),$(test),)) \


### PR DESCRIPTION
- Related: #842
- Port from: https://github.com/pq-code-package/mlkem-native/pull/1414
- Based on: #844 
- This PR move acvp source files, client and data from `test/` to `test/acvp`