### PR TITLE
CBMC: Increase OBJECT_BITS for polyvecl_pointwise_acc_montgomery_c

### DIFF
--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
@@ -39,7 +39,7 @@ FUNCTION_NAME = mld_polyvecl_pointwise_acc_montgomery_c
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 12
+CBMC_OBJECT_BITS = 13
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
…ery_c

https://github.com/pq-code-package/mldsa-native/pull/820 introduced a massive performance regression to the CBMC proofs caused by the polyvecl_pointwise_acc_montgomery_c.

This commit increases the OBJECT_BITS for that proof fixing the problem.