### PR TITLE
Consolidate MLD_CONFIG_CUSTOM_ZEROIZE with mlkem-native

### DIFF
--- a/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/basic_lowram/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_lowram/mldsa_native/mldsa_native_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
@@ -365,13 +365,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -384,7 +384,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -392,7 +392,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/custom_backend/mldsa_native/mldsa_native_config.h
+++ b/examples/custom_backend/mldsa_native/mldsa_native_config.h
@@ -360,13 +360,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -379,7 +379,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -387,7 +387,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/monolithic_build/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build/mldsa_native/mldsa_native_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/multilevel_build/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build/mldsa_native/mldsa_native_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
@@ -361,13 +361,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -380,7 +380,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -388,7 +388,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -120,13 +120,13 @@
  * Description: In compliance with FIPS 204 Section 3.6.3, mldsa-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -139,7 +139,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -147,7 +147,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -124,13 +124,13 @@
  * Description: In compliance with FIPS 204 Section 3.6.3, mldsa-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -143,7 +143,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -151,7 +151,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -122,13 +122,13 @@
  * Description: In compliance with FIPS 204 Section 3.6.3, mldsa-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -141,7 +141,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -149,7 +149,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/mldsa/mldsa_native_config.h
+++ b/mldsa/mldsa_native_config.h
@@ -348,13 +348,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -367,7 +367,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -375,7 +375,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/configs.yml
+++ b/test/configs/configs.yml
@@ -17,7 +17,7 @@ configs:
           #include <stdint.h>
           #include <string.h>
           #include "../mldsa/src/sys.h"
-          static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+          static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
           {
             explicit_bzero(ptr, len);
           }
@@ -54,7 +54,7 @@ configs:
           #include <stdint.h>
           #include <string.h>
           #include "../mldsa/src/sys.h"
-          static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+          static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
           {
             explicit_bzero(ptr, len);
           }

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "../mldsa/src/sys.h"
-static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
 {
   explicit_bzero(ptr, len);
 }

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -392,7 +392,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "../mldsa/src/sys.h"
-static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
 {
   explicit_bzero(ptr, len);
 }

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -363,13 +363,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -382,7 +382,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -390,7 +390,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -365,13 +365,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -384,7 +384,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -392,7 +392,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }

--- a/test/configs/test_rng_fail_config.h
+++ b/test/configs/test_rng_fail_config.h
@@ -364,13 +364,13 @@
  *              zeroizes intermediate stack buffers before returning from
  *              function calls.
  *
- *              Set this option and define `mld_zeroize_native` if you want to
+ *              Set this option and define `mld_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
  *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
- *              a custom implementation of `mld_zeroize_native()`.
+ *              a custom implementation of `mld_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mldsa-native
@@ -383,7 +383,7 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of what this feature
- *              provides. In this case, you can set mld_zeroize_native to a
+ *              provides. In this case, you can set mld_zeroize to a
  *              no-op.
  *
  *****************************************************************************/
@@ -391,7 +391,7 @@
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "src/src.h"
-   static MLD_INLINE void mld_zeroize_native(void *ptr, size_t len)
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }


### PR DESCRIPTION
- Resolves: #783

The MLD_CONFIG_CUSTOM_ZEROIZE macro in mldsa/src/ct.h behaves slightly differently from MLK_CONFIG_CUSTOM_ZEROIZE in mlkem/src/verify.h.

This commit aligns their behavior.