### PR TITLE
Unit-test: add consistency tests for mld_poly_uniform*_x1/x4

### DIFF
--- a/mldsa/src/poly.c
+++ b/mldsa/src/poly.c
@@ -657,7 +657,9 @@ void mld_poly_uniform(mld_poly *a, const uint8_t seed[MLDSA_SEEDBYTES + 2])
   mld_zeroize(buf, sizeof(buf));
 }
 
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) && !defined(MLD_CONFIG_REDUCE_RAM)
+#if (!defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) && \
+     !defined(MLD_CONFIG_REDUCE_RAM)) ||         \
+    defined(MLD_UNIT_TEST)
 MLD_INTERNAL_API
 void mld_poly_uniform_4x(mld_poly *vec0, mld_poly *vec1, mld_poly *vec2,
                          mld_poly *vec3,
@@ -722,7 +724,7 @@ void mld_poly_uniform_4x(mld_poly *vec0, mld_poly *vec1, mld_poly *vec2,
   mld_zeroize(buf, sizeof(buf));
 }
 
-#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY && !MLD_CONFIG_REDUCE_RAM */
+#endif /* (!MLD_CONFIG_SERIAL_FIPS202_ONLY && !MLD_CONFIG_REDUCE_RAM) || MLD_UNIT_TEST */
 
 MLD_INTERNAL_API
 void mld_polyt1_pack(uint8_t r[MLDSA_POLYT1_PACKEDBYTES], const mld_poly *a)

--- a/mldsa/src/poly.h
+++ b/mldsa/src/poly.h
@@ -243,7 +243,9 @@ __contract__(
   ensures(array_bound(a->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
 );
 
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) && !defined(MLD_CONFIG_REDUCE_RAM)
+#if (!defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) && \
+     !defined(MLD_CONFIG_REDUCE_RAM)) ||         \
+    defined(MLD_UNIT_TEST)
 #define mld_poly_uniform_4x MLD_NAMESPACE(poly_uniform_4x)
 /*************************************************
  * Name:        mld_poly_uniform_x4
@@ -277,7 +279,8 @@ __contract__(
   ensures(array_bound(vec2->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
   ensures(array_bound(vec3->coeffs, 0, MLDSA_N, 0, MLDSA_Q))
 );
-#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY && !MLD_CONFIG_REDUCE_RAM */
+#endif /* (!MLD_CONFIG_SERIAL_FIPS202_ONLY && !MLD_CONFIG_REDUCE_RAM) || \
+          MLD_UNIT_TEST */
 
 #define mld_polyt1_pack MLD_NAMESPACE(polyt1_pack)
 /*************************************************

--- a/mldsa/src/poly_kl.c
+++ b/mldsa/src/poly_kl.c
@@ -341,7 +341,7 @@ __contract__(
   return mld_rej_eta_c(a, target, offset, buf, buflen);
 }
 
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 MLD_INTERNAL_API
 void mld_poly_uniform_eta_4x(mld_poly *r0, mld_poly *r1, mld_poly *r2,
                              mld_poly *r3, const uint8_t seed[MLDSA_CRHBYTES],
@@ -425,8 +425,9 @@ void mld_poly_uniform_eta_4x(mld_poly *r0, mld_poly *r1, mld_poly *r2,
   mld_zeroize(buf, sizeof(buf));
   mld_zeroize(extseed, sizeof(extseed));
 }
-#else  /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY || MLD_UNIT_TEST */
 
+#if defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 MLD_INTERNAL_API
 void mld_poly_uniform_eta(mld_poly *r, const uint8_t seed[MLDSA_CRHBYTES],
                           uint8_t nonce)
@@ -482,13 +483,14 @@ void mld_poly_uniform_eta(mld_poly *r, const uint8_t seed[MLDSA_CRHBYTES],
   mld_zeroize(buf, sizeof(buf));
   mld_zeroize(extseed, sizeof(extseed));
 }
-#endif /* MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* MLD_CONFIG_SERIAL_FIPS202_ONLY || MLD_UNIT_TEST */
 
 #define MLD_POLY_UNIFORM_GAMMA1_NBLOCKS                       \
   ((MLDSA_POLYZ_PACKEDBYTES + MLD_STREAM256_BLOCKBYTES - 1) / \
    MLD_STREAM256_BLOCKBYTES)
 
-#if MLD_CONFIG_PARAMETER_SET == 65 || defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if MLD_CONFIG_PARAMETER_SET == 65 || \
+    defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 MLD_INTERNAL_API
 void mld_poly_uniform_gamma1(mld_poly *a, const uint8_t seed[MLDSA_CRHBYTES],
                              uint16_t nonce)
@@ -516,10 +518,11 @@ void mld_poly_uniform_gamma1(mld_poly *a, const uint8_t seed[MLDSA_CRHBYTES],
   mld_zeroize(buf, sizeof(buf));
   mld_zeroize(extseed, sizeof(extseed));
 }
-#endif /* MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_SERIAL_FIPS202_ONLY || \
+          MLD_UNIT_TEST */
 
 
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 MLD_INTERNAL_API
 void mld_poly_uniform_gamma1_4x(mld_poly *r0, mld_poly *r1, mld_poly *r2,
                                 mld_poly *r3,
@@ -568,7 +571,7 @@ void mld_poly_uniform_gamma1_4x(mld_poly *r0, mld_poly *r1, mld_poly *r2,
   mld_zeroize(buf, sizeof(buf));
   mld_zeroize(extseed, sizeof(extseed));
 }
-#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY || MLD_UNIT_TEST */
 
 MLD_INTERNAL_API
 void mld_poly_challenge(mld_poly *c, const uint8_t seed[MLDSA_CTILDEBYTES])

--- a/mldsa/src/poly_kl.h
+++ b/mldsa/src/poly_kl.h
@@ -92,7 +92,7 @@ __contract__(
   ensures(array_bound(b->coeffs, 0, MLDSA_N, 0, (MLDSA_Q-1)/(2*MLDSA_GAMMA2)))
 );
 
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 #define mld_poly_uniform_eta_4x MLD_NAMESPACE_KL(poly_uniform_eta_4x)
 /*************************************************
  * Name:        mld_poly_uniform_eta
@@ -132,9 +132,9 @@ __contract__(
   ensures(array_abs_bound(r2->coeffs, 0, MLDSA_N, MLDSA_ETA + 1))
   ensures(array_abs_bound(r3->coeffs, 0, MLDSA_N, MLDSA_ETA + 1))
 );
-#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY || MLD_UNIT_TEST */
 
-#if defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 #define mld_poly_uniform_eta MLD_NAMESPACE_KL(poly_uniform_eta)
 /*************************************************
  * Name:        mld_poly_uniform_eta
@@ -157,9 +157,10 @@ __contract__(
   assigns(memory_slice(r, sizeof(mld_poly)))
   ensures(array_abs_bound(r->coeffs, 0, MLDSA_N, MLDSA_ETA + 1))
 );
-#endif /* MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* MLD_CONFIG_SERIAL_FIPS202_ONLY || MLD_UNIT_TEST */
 
-#if MLD_CONFIG_PARAMETER_SET == 65 || defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if MLD_CONFIG_PARAMETER_SET == 65 || \
+    defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 #define mld_poly_uniform_gamma1 MLD_NAMESPACE_KL(poly_uniform_gamma1)
 /*************************************************
  * Name:        mld_poly_uniform_gamma1
@@ -182,9 +183,10 @@ __contract__(
   assigns(memory_slice(a, sizeof(mld_poly)))
   ensures(array_bound(a->coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1))
 );
-#endif /* MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_SERIAL_FIPS202_ONLY || \
+          MLD_UNIT_TEST */
 
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 #define mld_poly_uniform_gamma1_4x MLD_NAMESPACE_KL(poly_uniform_gamma1_4x)
 /*************************************************
  * Name:        mld_poly_uniform_gamma1_4x
@@ -219,7 +221,7 @@ __contract__(
   ensures(array_bound(r2->coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1))
   ensures(array_bound(r3->coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1))
 );
-#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY || MLD_UNIT_TEST */
 
 #define mld_poly_challenge MLD_NAMESPACE_KL(poly_challenge)
 /*************************************************

--- a/mldsa/src/symmetric.h
+++ b/mldsa/src/symmetric.h
@@ -10,7 +10,7 @@
 #include "common.h"
 
 #include MLD_FIPS202_HEADER_FILE
-#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY) || defined(MLD_UNIT_TEST)
 #include MLD_FIPS202X4_HEADER_FILE
 #endif
 

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1817,6 +1817,7 @@ def get_config_options():
         "MLD_CONFIG_XXX",
         "MLD_CONFIG_API_CONSTANTS_ONLY",
         "MLD_PREHASH_",
+        "MLD_UNIT_TEST",
     ]
 
     return configs

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -35,11 +35,11 @@ $(MLDSA87_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=87
 
 # Unit test object files - same sources but with MLD_STATIC_TESTABLE=
 MLDSA44_UNIT_OBJS = $(call MAKE_OBJS,$(MLDSA44_DIR)/unit,$(SOURCES) $(FIPS202_SRCS))
-$(MLDSA44_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
+$(MLDSA44_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
 MLDSA65_UNIT_OBJS = $(call MAKE_OBJS,$(MLDSA65_DIR)/unit,$(SOURCES) $(FIPS202_SRCS))
-$(MLDSA65_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
+$(MLDSA65_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
 MLDSA87_UNIT_OBJS = $(call MAKE_OBJS,$(MLDSA87_DIR)/unit,$(SOURCES) $(FIPS202_SRCS))
-$(MLDSA87_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
+$(MLDSA87_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
 
 # Alloc test object files - same sources but with custom alloc config
 MLDSA44_ALLOC_OBJS = $(call MAKE_OBJS,$(MLDSA44_DIR)/alloc,$(SOURCES) $(FIPS202_SRCS))
@@ -82,14 +82,14 @@ $(MLDSA44_DIR)/test/src/test_alloc.c.o: CFLAGS += -DMLD_CONFIG_FILE=\"../test/co
 $(MLDSA65_DIR)/test/src/test_alloc.c.o: CFLAGS += -DMLD_CONFIG_FILE=\"../test/configs/test_alloc_config.h\"
 $(MLDSA87_DIR)/test/src/test_alloc.c.o: CFLAGS += -DMLD_CONFIG_FILE=\"../test/configs/test_alloc_config.h\"
 
-$(MLDSA44_DIR)/bin/test_unit44: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
-$(MLDSA65_DIR)/bin/test_unit65: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
-$(MLDSA87_DIR)/bin/test_unit87: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
+$(MLDSA44_DIR)/bin/test_unit44: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA65_DIR)/bin/test_unit65: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA87_DIR)/bin/test_unit87: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
 
 # Unit library object files compiled with MLD_STATIC_TESTABLE=
-$(MLDSA44_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
-$(MLDSA65_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
-$(MLDSA87_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes
+$(MLDSA44_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA65_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA87_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
 
 
 $(MLDSA44_DIR)/bin/bench_mldsa44: $(MLDSA44_DIR)/test/hal/hal.c.o


### PR DESCRIPTION
- Resolves: #658 

This PR adds consistency tests to test_unit.c to verify that the scalar and 4-way batched implementations produce identical results.

In mldsa-native, there are three functions that provide both scalar and 4-way batched variants:
```
mld_poly_uniform_gamma1 / mld_poly_uniform_gamma1_4x
mld_poly_uniform_eta    / mld_poly_uniform_eta_4x
mld_poly_uniform        / mld_poly_uniform_4x
```
For each of the above pairs, this PR implements consistency test functions in test_unit.c that compare the outputs of the scalar and 4-way batched variants.

For mld_poly_uniform_eta and mld_poly_uniform_eta_4x, the two variants are not defined under the same compilation conditions in poly_kl.h. To enable testing both variants, this PR introduces a new macro, `MLD_UNIT_TEST`, which is made available in `test_unit.c` to override the conditional compilation and allow both implementations to be exercised in the unit tests.
