### PR TITLE
Build: treat linker warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ BUILD_DIR ?= test/build
 
 # Skip includes for clean target
 ifneq ($(MAKECMDGOALS),clean)
-include test/mk/config.mk
 include test/mk/compiler.mk
+include test/mk/config.mk
 include test/mk/auto.mk
 include test/mk/components.mk
 include test/mk/rules.mk
@@ -266,6 +266,9 @@ else
 	@echo "=== Architecture Not Supported ==="
 	@echo "No specific feature detection available for $(ARCH)"
 endif
+	@echo ""
+	@echo "=== Linker Feature Support ==="
+	@echo "Fatal Warnings: $(if $(filter 1,$(MK_LINKER_SUPPORTS_FATAL_WARNINGS)),✅,❌)"
 
 EXAMPLE_DIRS := \
 	examples/bring_your_own_fips202 \

--- a/test/mk/compiler.mk
+++ b/test/mk/compiler.mk
@@ -72,4 +72,9 @@ MK_COMPILER_SUPPORTS_SHA3 ?= $(shell echo 'int main() { __asm__("eor3 v0.16b, v1
 
 endif # aarch64
 
+# Linker feature detection
+
+# Test --fatal-warnings support
+MK_LINKER_SUPPORTS_FATAL_WARNINGS ?= $(shell echo 'int main() { return 0; }' | $(CC) -x c - -o /dev/null -Wl,--fatal-warnings 2>/dev/null && echo 1 || echo 0)
+
 endif # _COMPILER_MK

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -53,6 +53,11 @@ CFLAGS := \
 	-MMD \
 	$(CFLAGS)
 
+# Treat linker warnings as errors
+ifeq ($(MK_LINKER_SUPPORTS_FATAL_WARNINGS),1)
+LDFLAGS += -Wl,--fatal-warnings
+endif
+
 ##################
 # Some Variables #
 ##################


### PR DESCRIPTION
Add --fatal-warnings to LDFLAGS when supported by the linker. This ensures that linker warnings (such as missing .note.GNU-stack sections) are caught during CI builds.

The flag is detected at build time since GNU ld supports it but Apple's linker does not.

 - Relates to #712