### PR TITLE
Examples: Remove MLD_CONFIG_NO_SUPERCOP from multi-level header

### DIFF
--- a/examples/monolithic_build_multilevel/README.md
+++ b/examples/monolithic_build_multilevel/README.md
@@ -32,6 +32,7 @@ The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.
 - `MLD_CONFIG_MULTILEVEL_BUILD`: Enables multi-level mode
 - `MLD_CONFIG_NAMESPACE_PREFIX=mldsa`: Base prefix
 - `MLD_CONFIG_INTERNAL_API_QUALIFIER=static`: Makes internal functions static
+- `MLD_CONFIG_NO_SUPERCOP`: Disables the SUPERCOP API (crypto_sign*)
 
 The wrapper [mldsa_native_all.c](mldsa_native_all.c) includes `mldsa_native.c` three times:
 ```c
@@ -59,8 +60,6 @@ The wrapper [mldsa_native_all.c](mldsa_native_all.c) includes `mldsa_native.c` t
 
 The header [mldsa_native_all.h](mldsa_native_all.h) exposes all APIs:
 ```c
-#define MLD_CONFIG_NO_SUPERCOP
-
 #define MLD_CONFIG_PARAMETER_SET 44
 #include <mldsa_native.h>
 #undef MLD_CONFIG_PARAMETER_SET

--- a/examples/monolithic_build_multilevel/mldsa_native_all.h
+++ b/examples/monolithic_build_multilevel/mldsa_native_all.h
@@ -7,8 +7,6 @@
 #ifndef MLD_ALL_H
 #define MLD_ALL_H
 
-#define MLD_CONFIG_NO_SUPERCOP
-
 /* API for MLDSA-44 */
 #define MLD_CONFIG_PARAMETER_SET 44
 #include <mldsa_native.h>

--- a/examples/monolithic_build_multilevel_native/README.md
+++ b/examples/monolithic_build_multilevel_native/README.md
@@ -31,6 +31,7 @@ The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.
 - `MLD_CONFIG_NAMESPACE_PREFIX=mldsa`: Base prefix
 - `MLD_CONFIG_USE_NATIVE_BACKEND_ARITH`: Enables native arithmetic backend
 - `MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202`: Enables native FIPS-202 backend
+- `MLD_CONFIG_NO_SUPERCOP`: Disables the SUPERCOP API (crypto_sign*)
 
 The wrapper [mldsa_native_all.c](mldsa_native_all.c) includes `mldsa_native.c` three times:
 ```c

--- a/examples/multilevel_build/README.md
+++ b/examples/multilevel_build/README.md
@@ -26,6 +26,7 @@ The library is built 3 times into separate directories (`build/mldsa44`, `build/
 The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.h) sets:
 - `MLD_CONFIG_MULTILEVEL_BUILD`: Enables multi-level build mode
 - `MLD_CONFIG_NAMESPACE_PREFIX=mldsa`: Base prefix; level suffix added automatically
+- `MLD_CONFIG_NO_SUPERCOP`: Disables the SUPERCOP API (crypto_sign*)
 
 Build-time flags passed via CFLAGS:
 - `MLD_CONFIG_PARAMETER_SET=44/65/87`: Selects the security level

--- a/examples/multilevel_build_native/README.md
+++ b/examples/multilevel_build_native/README.md
@@ -30,6 +30,7 @@ The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.
 - `MLD_CONFIG_NAMESPACE_PREFIX=mldsa`: Base prefix; level suffix added automatically
 - `MLD_CONFIG_USE_NATIVE_BACKEND_ARITH`: Enables native arithmetic backend
 - `MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202`: Enables native FIPS-202 backend
+- `MLD_CONFIG_NO_SUPERCOP`: Disables the SUPERCOP API (crypto_sign*)
 
 Build-time flags passed via CFLAGS:
 - `MLD_CONFIG_PARAMETER_SET=44/65/87`: Selects the security level


### PR DESCRIPTION
MLD_CONFIG_NO_SUPERCOP is already set in the configuration file; it should not be set again in mldsa_native_all.h.

- Ports https://github.com/pq-code-package/mlkem-native/pull/1477