### PR TITLE
Port: Allow the public header to work in C++ mode.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,7 @@ IncludeBlocks: Preserve
 # as "attributes" so they don't get increasingly indented line after line
 BreakBeforeBraces: Allman
 InsertBraces: true
+IndentExternBlock: NoIndent
 WhitespaceSensitiveMacros: ['__contract__', '__loop__' ]
 Macros:
  # Make this artifically long to avoid function bodies after short contracts

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -199,6 +199,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /*************************************************
  * Name:        crypto_sign_keypair_internal
  *
@@ -844,6 +850,10 @@ int MLD_API_NAMESPACE(pk_from_sk)(
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
 #endif
 );
+
+#ifdef __cplusplus
+}
+#endif
 
 /****************************** SUPERCOP API *********************************/
 


### PR DESCRIPTION
- Resolves: #870

- This PR ports https://github.com/pq-code-package/mlkem-native/pull/1465
 to mldsa-native.

- This change adds standard C++ compatibility guards to `mldsa/mldsa_native.h`, allowing C++ projects to include the header directly without requiring manual extern "C" wrapping (the extern "C" declarations are now defined inside mldsa/mldsa_native.h).