### PR TITLE
Eliminate SUPERCOP API from tests

### DIFF
--- a/test/acvp/acvp_mldsa.c
+++ b/test/acvp/acvp_mldsa.c
@@ -11,18 +11,18 @@
 
 #include "mldsa_native.h"
 
-/* Additional SUPERCOP-style macros for functions not in the standard set */
-#define crypto_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
-#define crypto_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
-#define crypto_sign_verify_internal MLD_API_NAMESPACE(verify_internal)
-#define crypto_sign_verify_extmu MLD_API_NAMESPACE(verify_extmu)
-#define crypto_sign_signature_pre_hash_internal \
+#define mld_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
+#define mld_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+#define mld_sign_verify MLD_API_NAMESPACE(verify)
+#define mld_sign_verify_extmu MLD_API_NAMESPACE(verify_extmu)
+#define mld_sign_verify_internal MLD_API_NAMESPACE(verify_internal)
+#define mld_sign_signature_pre_hash_internal \
   MLD_API_NAMESPACE(signature_pre_hash_internal)
-#define crypto_sign_verify_pre_hash_internal \
+#define mld_sign_verify_pre_hash_internal \
   MLD_API_NAMESPACE(verify_pre_hash_internal)
-#define crypto_sign_signature_pre_hash_shake256 \
+#define mld_sign_signature_pre_hash_shake256 \
   MLD_API_NAMESPACE(signature_pre_hash_shake256)
-#define crypto_sign_verify_pre_hash_shake256 \
+#define mld_sign_verify_pre_hash_shake256 \
   MLD_API_NAMESPACE(verify_pre_hash_shake256)
 
 #define USAGE "acvp_mldsa{lvl} [keyGen|sigGen|sigVer] {test specific arguments}"
@@ -286,7 +286,7 @@ static void acvp_mldsa_keyGen_AFT(const unsigned char seed[MLDSA_RNDBYTES])
   unsigned char pk[CRYPTO_PUBLICKEYBYTES];
   unsigned char sk[CRYPTO_SECRETKEYBYTES];
 
-  CHECK(crypto_sign_keypair_internal(pk, sk, seed) == 0);
+  CHECK(mld_sign_keypair_internal(pk, sk, seed) == 0);
 
   print_hex("pk", pk, sizeof(pk));
   print_hex("sk", sk, sizeof(sk));
@@ -310,8 +310,8 @@ static void acvp_mldsa_sigGen_AFT(const unsigned char *message, size_t mlen,
   pre[1] = (uint8_t)ctxlen;
   memcpy(pre + 2, context, ctxlen);
 
-  CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                       ctxlen + 2, rnd, sk, 0) == 0);
+  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, pre,
+                                    ctxlen + 2, rnd, sk, 0) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 
@@ -322,8 +322,8 @@ static void acvp_mldsa_sigGenInternal_AFT(
 {
   unsigned char sig[CRYPTO_BYTES];
   size_t siglen;
-  CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0,
-                                       rnd, sk, externalMu) == 0);
+  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0, rnd,
+                                    sk, externalMu) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 
@@ -346,8 +346,8 @@ static void acvp_mldsa_sigGenDeterministic_AFT(
   pre[1] = (uint8_t)ctxlen;
   memcpy(pre + 2, context, ctxlen);
 
-  CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                       ctxlen + 2, rnd, sk, 0) == 0);
+  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, pre,
+                                    ctxlen + 2, rnd, sk, 0) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 
@@ -359,8 +359,8 @@ static void acvp_mldsa_sigGenInternalDeterministic_AFT(
   size_t siglen;
   unsigned char rnd[MLDSA_SEEDBYTES] = {0}; /* Zero rnd for deterministic */
 
-  CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0,
-                                       rnd, sk, externalMu) == 0);
+  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0, rnd,
+                                    sk, externalMu) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 #endif /* !MLD_CONFIG_NO_SIGN_API */
@@ -372,8 +372,8 @@ static int acvp_mldsa_sigVer_AFT(const unsigned char *message, size_t mlen,
                                  const unsigned char signature[CRYPTO_BYTES],
                                  const unsigned char pk[CRYPTO_PUBLICKEYBYTES])
 {
-  return crypto_sign_verify(signature, CRYPTO_BYTES, message, mlen, context,
-                            ctxlen, pk);
+  return mld_sign_verify(signature, CRYPTO_BYTES, message, mlen, context,
+                         ctxlen, pk);
 }
 
 
@@ -384,12 +384,12 @@ static int acvp_mldsa_sigVerInternal_AFT(
 {
   if (externalMu)
   {
-    return crypto_sign_verify_extmu(signature, CRYPTO_BYTES, message, pk);
+    return mld_sign_verify_extmu(signature, CRYPTO_BYTES, message, pk);
   }
   else
   {
-    return crypto_sign_verify_internal(signature, CRYPTO_BYTES, message, mlen,
-                                       NULL, 0, pk, 0);
+    return mld_sign_verify_internal(signature, CRYPTO_BYTES, message, mlen,
+                                    NULL, 0, pk, 0);
   }
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
@@ -460,9 +460,9 @@ static int acvp_mldsa_sigGenPreHash_AFT(
   unsigned char signature[CRYPTO_BYTES];
   size_t siglen;
 
-  if (crypto_sign_signature_pre_hash_internal(signature, &siglen, ph, phlen,
-                                              context, ctxlen, rng, sk,
-                                              str_to_hash_alg(hashAlg)) != 0)
+  if (mld_sign_signature_pre_hash_internal(signature, &siglen, ph, phlen,
+                                           context, ctxlen, rng, sk,
+                                           str_to_hash_alg(hashAlg)) != 0)
   {
     return 1;
   }
@@ -479,9 +479,9 @@ static int acvp_mldsa_sigVerPreHash_AFT(
     size_t ctxlen, const unsigned char signature[CRYPTO_BYTES],
     const unsigned char pk[CRYPTO_PUBLICKEYBYTES], const char *hashAlg)
 {
-  return crypto_sign_verify_pre_hash_internal(signature, CRYPTO_BYTES, ph,
-                                              phlen, context, ctxlen, pk,
-                                              str_to_hash_alg(hashAlg));
+  return mld_sign_verify_pre_hash_internal(signature, CRYPTO_BYTES, ph, phlen,
+                                           context, ctxlen, pk,
+                                           str_to_hash_alg(hashAlg));
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 
@@ -494,8 +494,8 @@ static int acvp_mldsa_sigGenPreHashShake256_AFT(
   unsigned char signature[CRYPTO_BYTES];
   size_t siglen;
 
-  if (crypto_sign_signature_pre_hash_shake256(signature, &siglen, message, mlen,
-                                              context, ctxlen, rnd, sk) != 0)
+  if (mld_sign_signature_pre_hash_shake256(signature, &siglen, message, mlen,
+                                           context, ctxlen, rnd, sk) != 0)
   {
     return 1;
   }
@@ -512,8 +512,8 @@ static int acvp_mldsa_sigVerPreHashShake256_AFT(
     size_t ctxlen, const unsigned char signature[CRYPTO_BYTES],
     const unsigned char pk[CRYPTO_PUBLICKEYBYTES])
 {
-  return crypto_sign_verify_pre_hash_shake256(signature, CRYPTO_BYTES, message,
-                                              mlen, context, ctxlen, pk);
+  return mld_sign_verify_pre_hash_shake256(signature, CRYPTO_BYTES, message,
+                                           mlen, context, ctxlen, pk);
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 
@@ -528,9 +528,9 @@ static int acvp_mldsa_sigGenPreHashDeterministic_AFT(
   size_t siglen;
   unsigned char rnd[MLDSA_RNDBYTES] = {0}; /* Zero rnd for deterministic */
 
-  if (crypto_sign_signature_pre_hash_internal(signature, &siglen, ph, phlen,
-                                              context, ctxlen, rnd, sk,
-                                              str_to_hash_alg(hashAlg)) != 0)
+  if (mld_sign_signature_pre_hash_internal(signature, &siglen, ph, phlen,
+                                           context, ctxlen, rnd, sk,
+                                           str_to_hash_alg(hashAlg)) != 0)
   {
     return 1;
   }
@@ -547,8 +547,8 @@ static int acvp_mldsa_sigGenPreHashShake256Deterministic_AFT(
   size_t siglen;
   unsigned char rnd[MLDSA_RNDBYTES] = {0}; /* Zero rnd for deterministic */
 
-  if (crypto_sign_signature_pre_hash_shake256(signature, &siglen, message, mlen,
-                                              context, ctxlen, rnd, sk) != 0)
+  if (mld_sign_signature_pre_hash_shake256(signature, &siglen, message, mlen,
+                                           context, ctxlen, rnd, sk) != 0)
   {
     return 1;
   }

--- a/test/bench/bench_mldsa.c
+++ b/test/bench/bench_mldsa.c
@@ -12,11 +12,12 @@
 
 #include "hal.h"
 #include "mldsa_native.h"
-#include "src/randombytes.h"
 
-/* Additional SUPERCOP-style macros for functions not in the standard set */
-#define crypto_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
-#define crypto_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+#define mld_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
+#define mld_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+#define mld_sign_verify MLD_API_NAMESPACE(verify)
+
+#include "src/randombytes.h"
 
 #ifndef MLD_BENCHMARK_NWARMUP
 #define MLD_BENCHMARK_NWARMUP 3
@@ -122,13 +123,13 @@ static int bench(void)
       /* Key-pair generation */
       for (j = 0; j < MLD_BENCHMARK_NWARMUP; j++)
       {
-        ret |= crypto_sign_keypair_internal(pk, sk, kg_rand);
+        ret |= mld_sign_keypair_internal(pk, sk, kg_rand);
       }
 
       t0 = get_cyclecounter();
       for (j = 0; j < MLD_BENCHMARK_NITERATIONS; j++)
       {
-        ret |= crypto_sign_keypair_internal(pk, sk, kg_rand);
+        ret |= mld_sign_keypair_internal(pk, sk, kg_rand);
       }
       t1 = get_cyclecounter();
       cycles_kg[i] = t1 - t0;
@@ -152,14 +153,14 @@ static int bench(void)
 
       for (j = 0; j < MLD_BENCHMARK_NWARMUP; j++)
       {
-        ret |= crypto_sign_signature_internal(sig, &siglen, m, MLEN, pre,
-                                              CTXLEN + 2, sig_rand, sk, 0);
+        ret |= mld_sign_signature_internal(sig, &siglen, m, MLEN, pre,
+                                           CTXLEN + 2, sig_rand, sk, 0);
       }
       t0 = get_cyclecounter();
       for (j = 0; j < MLD_BENCHMARK_NITERATIONS; j++)
       {
-        ret |= crypto_sign_signature_internal(sig, &siglen, m, MLEN, pre,
-                                              CTXLEN + 2, sig_rand, sk, 0);
+        ret |= mld_sign_signature_internal(sig, &siglen, m, MLEN, pre,
+                                           CTXLEN + 2, sig_rand, sk, 0);
       }
       t1 = get_cyclecounter();
       cycles_sign[i] = t1 - t0;
@@ -176,12 +177,12 @@ static int bench(void)
       /* Verification */
       for (j = 0; j < MLD_BENCHMARK_NWARMUP; j++)
       {
-        ret |= crypto_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+        ret |= mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
       }
       t0 = get_cyclecounter();
       for (j = 0; j < MLD_BENCHMARK_NITERATIONS; j++)
       {
-        ret |= crypto_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+        ret |= mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
       }
       t1 = get_cyclecounter();
       cycles_verify[i] = t1 - t0;

--- a/test/src/gen_KAT.c
+++ b/test/src/gen_KAT.c
@@ -24,8 +24,9 @@ int main(void)
          MLD_CONFIG_NO_VERIFY_API */
 
 /* Additional SUPERCOP-style macros for functions not in the standard set */
-#define crypto_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
-#define crypto_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+#define mld_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
+#define mld_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+#define mld_sign_verify MLD_API_NAMESPACE(verify)
 
 #if defined(MLD_SYS_WINDOWS)
 #include <fcntl.h>
@@ -86,7 +87,7 @@ int main(void)
 
   /*
    * We cannot rely on randombytes in the KAT test as randombytes() is used
-   * inside of crypto_sign_signature() which is called as a part of
+   * inside of mld_sign_signature() which is called as a part of
    * key generation in case PCT (pairwise-consistency test) is enabled.
    * To allow KAT tests to still pass successfully, we derandomize the
    * KAT test to only use deterministic randomness derived using SHAKE.
@@ -99,17 +100,17 @@ int main(void)
     mld_shake256(coins, sizeof(coins), coins, sizeof(coins));
     m = coins + MLDSA_SEEDBYTES + MLDSA_RNDBYTES;
 
-    CHECK(crypto_sign_keypair_internal(pk, sk, coins) == 0);
+    CHECK(mld_sign_keypair_internal(pk, sk, coins) == 0);
 
     print_hex(pk, CRYPTO_PUBLICKEYBYTES);
     print_hex(sk, CRYPTO_SECRETKEYBYTES);
 
-    CHECK(crypto_sign_signature_internal(s, &slen, m, i, pre, sizeof(pre),
-                                         coins + MLDSA_SEEDBYTES, sk, 0) == 0);
+    CHECK(mld_sign_signature_internal(s, &slen, m, i, pre, sizeof(pre),
+                                      coins + MLDSA_SEEDBYTES, sk, 0) == 0);
 
     print_hex(s, slen);
 
-    rc = crypto_sign_verify(s, slen, m, i, NULL, CTXLEN, pk);
+    rc = mld_sign_verify(s, slen, m, i, NULL, CTXLEN, pk);
 
     if (rc)
     {

--- a/test/src/test_alloc.c
+++ b/test/src/test_alloc.c
@@ -457,7 +457,7 @@ static int test_verify_pre_hash_shake256_alloc_failure(test_ctx_t *ctx)
 
 static int test_open_alloc_failure(test_ctx_t *ctx)
 {
-  /* crypto_sign_open needs a signed message (sig || msg).
+  /* mld_open needs a signed message (sig || msg).
    * Construct it from test vectors. */
   uint8_t sm[CRYPTO_BYTES + TEST_VECTOR_MSG_LEN];
   uint8_t msg_out[CRYPTO_BYTES + TEST_VECTOR_MSG_LEN];

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -11,15 +11,18 @@
 #include "mldsa_native.h"
 #include "src/sys.h"
 
-/* Additional SUPERCOP-style macros for functions not in the standard set */
-#define crypto_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
-#define crypto_sign_signature_extmu MLD_API_NAMESPACE(signature_extmu)
-#define crypto_sign_verify_extmu MLD_API_NAMESPACE(verify_extmu)
-#define crypto_sign_signature_pre_hash_shake256 \
+#define mld_sign_keypair MLD_API_NAMESPACE(keypair)
+#define mld_sign MLD_API_NAMESPACE(sign)
+#define mld_sign_signature MLD_API_NAMESPACE(signature)
+#define mld_open MLD_API_NAMESPACE(open)
+#define mld_sign_verify MLD_API_NAMESPACE(verify)
+#define mld_sign_signature_extmu MLD_API_NAMESPACE(signature_extmu)
+#define mld_sign_verify_extmu MLD_API_NAMESPACE(verify_extmu)
+#define mld_sign_signature_pre_hash_shake256 \
   MLD_API_NAMESPACE(signature_pre_hash_shake256)
-#define crypto_sign_verify_pre_hash_shake256 \
+#define mld_sign_verify_pre_hash_shake256 \
   MLD_API_NAMESPACE(verify_pre_hash_shake256)
-#define crypto_sign_pk_from_sk MLD_API_NAMESPACE(pk_from_sk)
+#define mld_sign_pk_from_sk MLD_API_NAMESPACE(pk_from_sk)
 
 #ifndef NTESTS
 #define NTESTS 100
@@ -52,15 +55,15 @@ static int test_sign_core(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
   int rc;
 
 
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(ctx, CTXLEN) == 0);
   MLD_CT_TESTING_SECRET(ctx, CTXLEN);
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, MLEN);
 
-  CHECK(crypto_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
+  CHECK(mld_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
 
-  rc = crypto_sign_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
+  rc = mld_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -69,25 +72,25 @@ static int test_sign_core(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
 
   if (rc)
   {
-    printf("ERROR: crypto_sign_open\n");
+    printf("ERROR: mld_open\n");
     return 1;
   }
 
   if (memcmp(m, m2, MLEN))
   {
-    printf("ERROR: crypto_sign_open - wrong message\n");
+    printf("ERROR: mld_open - wrong message\n");
     return 1;
   }
 
   if (smlen != MLEN + CRYPTO_BYTES)
   {
-    printf("ERROR: crypto_sign_open - wrong smlen\n");
+    printf("ERROR: mld_open - wrong smlen\n");
     return 1;
   }
 
   if (mlen != MLEN)
   {
-    printf("ERROR: crypto_sign_open - wrong mlen\n");
+    printf("ERROR: mld_open - wrong mlen\n");
     return 1;
   }
 
@@ -126,12 +129,12 @@ static int test_sign_extmu(void)
   uint8_t mu[MLDSA_CRHBYTES];
   size_t siglen;
 
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(mu, MLDSA_CRHBYTES) == 0);
   MLD_CT_TESTING_SECRET(mu, sizeof(mu));
 
-  CHECK(crypto_sign_signature_extmu(sig, &siglen, mu, sk) == 0);
-  CHECK(crypto_sign_verify_extmu(sig, siglen, mu, pk) == 0);
+  CHECK(mld_sign_signature_extmu(sig, &siglen, mu, sk) == 0);
+  CHECK(mld_sign_verify_extmu(sig, siglen, mu, pk) == 0);
 
   return 0;
 }
@@ -148,7 +151,7 @@ static int test_sign_pre_hash(void)
   size_t siglen;
 
 
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(ctx, CTXLEN) == 0);
   MLD_CT_TESTING_SECRET(ctx, sizeof(ctx));
   CHECK(randombytes(m, MLEN) == 0);
@@ -156,10 +159,10 @@ static int test_sign_pre_hash(void)
   CHECK(randombytes(rnd, MLDSA_RNDBYTES) == 0);
   MLD_CT_TESTING_SECRET(rnd, sizeof(rnd));
 
-  CHECK(crypto_sign_signature_pre_hash_shake256(sig, &siglen, m, MLEN, ctx,
-                                                CTXLEN, rnd, sk) == 0);
-  CHECK(crypto_sign_verify_pre_hash_shake256(sig, siglen, m, MLEN, ctx, CTXLEN,
-                                             pk) == 0);
+  CHECK(mld_sign_signature_pre_hash_shake256(sig, &siglen, m, MLEN, ctx, CTXLEN,
+                                             rnd, sk) == 0);
+  CHECK(mld_sign_verify_pre_hash_shake256(sig, siglen, m, MLEN, ctx, CTXLEN,
+                                          pk) == 0);
 
   return 0;
 }
@@ -176,15 +179,17 @@ static int test_pk_from_sk(void)
   int rc;
 
   /* Generate a keypair */
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
 
   /* Derive public key from secret key */
-  CHECK(crypto_sign_pk_from_sk(pk_derived, sk) == 0);
+  CHECK(mld_sign_pk_from_sk(pk_derived, sk) == 0);
 
   /* Verify derived public key matches original */
   if (memcmp(pk, pk_derived, CRYPTO_PUBLICKEYBYTES) != 0)
   {
-    printf("ERROR: pk_from_sk - derived public key does not match original\n");
+    printf(
+        "ERROR: mld_sign_pk_from_sk - derived public key does not match "
+        "original\n");
     return 1;
   }
 
@@ -193,14 +198,16 @@ static int test_pk_from_sk(void)
   /* Corrupt a byte in the t0 portion of the secret key */
   sk_corrupted[MLDSA_SEEDBYTES + MLDSA_TRBYTES + MLDSA_SEEDBYTES + 10] ^= 1;
 
-  rc = crypto_sign_pk_from_sk(pk_derived, sk_corrupted);
+  rc = mld_sign_pk_from_sk(pk_derived, sk_corrupted);
 
   /* Constant time: Declassify to check result */
   MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(int));
 
   if (rc != -1)
   {
-    printf("ERROR: pk_from_sk - should fail with corrupted t0 in secret key\n");
+    printf(
+        "ERROR: mld_sign_pk_from_sk - should fail with corrupted t0 in secret "
+        "key\n");
     return 1;
   }
 
@@ -210,7 +217,7 @@ static int test_pk_from_sk(void)
   /* tr starts at offset 2 * MLDSA_SEEDBYTES (after rho and key) */
   sk_corrupted[2 * MLDSA_SEEDBYTES + 10] ^= 1;
 
-  rc = crypto_sign_pk_from_sk(pk_derived, sk_corrupted);
+  rc = mld_sign_pk_from_sk(pk_derived, sk_corrupted);
 
   /* Constant time: Declassify to check result */
   MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(int));
@@ -218,7 +225,7 @@ static int test_pk_from_sk(void)
   if (rc != -1)
   {
     printf(
-        "ERROR: crypto_sign_pk_from_sk - should fail with corrupted tr in "
+        "ERROR: mld_sign_pk_from_sk - should fail with corrupted tr in "
         "secret key\n");
     return 1;
   }
@@ -243,13 +250,13 @@ static int test_wrong_pk(void)
   size_t idx;
   size_t i;
 
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(ctx, CTXLEN) == 0);
   MLD_CT_TESTING_SECRET(ctx, sizeof(ctx));
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, sizeof(m));
 
-  CHECK(crypto_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
+  CHECK(mld_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
 
   /* flip bit in public key */
   CHECK(randombytes((uint8_t *)&idx, sizeof(size_t)) == 0);
@@ -257,7 +264,7 @@ static int test_wrong_pk(void)
 
   pk[idx] ^= 1;
 
-  rc = crypto_sign_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
+  rc = mld_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -265,7 +272,7 @@ static int test_wrong_pk(void)
 
   if (!rc)
   {
-    printf("ERROR: wrong_pk: crypto_sign_open\n");
+    printf("ERROR: wrong_pk: mld_open\n");
     return 1;
   }
 
@@ -273,7 +280,7 @@ static int test_wrong_pk(void)
   {
     if (m2[i] != 0)
     {
-      printf("ERROR: wrong_pk: crypto_sign_open - message should be zero\n");
+      printf("ERROR: wrong_pk: mld_open - message should be zero\n");
       return 1;
     }
   }
@@ -294,13 +301,13 @@ static int test_wrong_sig(void)
   size_t idx;
   size_t i;
 
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(ctx, CTXLEN) == 0);
   MLD_CT_TESTING_SECRET(ctx, sizeof(ctx));
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, sizeof(m));
 
-  CHECK(crypto_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
+  CHECK(mld_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
 
   /* flip bit in signed message */
   CHECK(randombytes((uint8_t *)&idx, sizeof(size_t)) == 0);
@@ -308,7 +315,7 @@ static int test_wrong_sig(void)
 
   sm[idx] ^= 1;
 
-  rc = crypto_sign_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
+  rc = mld_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -316,7 +323,7 @@ static int test_wrong_sig(void)
 
   if (!rc)
   {
-    printf("ERROR: wrong_sig: crypto_sign_open\n");
+    printf("ERROR: wrong_sig: mld_open\n");
     return 1;
   }
 
@@ -324,7 +331,7 @@ static int test_wrong_sig(void)
   {
     if (m2[i] != 0)
     {
-      printf("ERROR: wrong_sig: crypto_sign_open - message should be zero\n");
+      printf("ERROR: wrong_sig: mld_open - message should be zero\n");
       return 1;
     }
   }
@@ -346,13 +353,13 @@ static int test_wrong_ctx(void)
   size_t idx;
   size_t i;
 
-  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(ctx, CTXLEN) == 0);
   MLD_CT_TESTING_SECRET(ctx, sizeof(ctx));
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, sizeof(m));
 
-  CHECK(crypto_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
+  CHECK(mld_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk) == 0);
 
   /* flip bit in ctx */
   CHECK(randombytes((uint8_t *)&idx, sizeof(size_t)) == 0);
@@ -360,7 +367,7 @@ static int test_wrong_ctx(void)
 
   ctx[idx] ^= 1;
 
-  rc = crypto_sign_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
+  rc = mld_open(m2, &mlen, sm, smlen, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -368,7 +375,7 @@ static int test_wrong_ctx(void)
 
   if (!rc)
   {
-    printf("ERROR: wrong_sig: crypto_sign_open\n");
+    printf("ERROR: wrong_sig: mld_open\n");
     return 1;
   }
 
@@ -376,7 +383,7 @@ static int test_wrong_ctx(void)
   {
     if (m2[i] != 0)
     {
-      printf("ERROR: wrong_sig: crypto_sign_open - message should be zero\n");
+      printf("ERROR: wrong_sig: mld_open - message should be zero\n");
       return 1;
     }
   }
@@ -394,7 +401,7 @@ static int test_sign_expected(void)
     uint8_t test_vector_sk_copy[CRYPTO_SECRETKEYBYTES];
 
     randombytes_reset();
-    CHECK(crypto_sign_keypair(pk, sk) == 0);
+    CHECK(mld_sign_keypair(pk, sk) == 0);
 
     /* Declassify sk's for comparison. This is for testing purposes only.
      * Don't declassify the test_vector_sk itself because we need it to stay
@@ -418,20 +425,20 @@ static int test_sign_expected(void)
      * and not reseed it afterwards. Here, we reseed to make tests
      * independent and reproducible. */
     randombytes_reset();
-    CHECK(crypto_sign_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
-                                TEST_VECTOR_MSG_LEN,
-                                (const uint8_t *)TEST_VECTOR_CTX,
-                                TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+    CHECK(mld_sign_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+                             TEST_VECTOR_MSG_LEN,
+                             (const uint8_t *)TEST_VECTOR_CTX,
+                             TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
     CHECK(siglen == CRYPTO_BYTES);
     CHECK(memcmp(sig, test_vector_sig, CRYPTO_BYTES) == 0);
   }
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
-  CHECK(crypto_sign_verify(
-            test_vector_sig, CRYPTO_BYTES, (const uint8_t *)TEST_VECTOR_MSG,
-            TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
-            TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
+  CHECK(mld_sign_verify(test_vector_sig, CRYPTO_BYTES,
+                        (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
+                        (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+                        test_vector_pk) == 0);
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 
   return 0;

--- a/test/src/test_rng_fail.c
+++ b/test/src/test_rng_fail.c
@@ -33,6 +33,12 @@ int randombytes(uint8_t *buf, size_t len);
 int randombytes_counter = 0;
 int randombytes_fail_on_counter = -1;
 
+#define mld_sign_keypair MLD_API_NAMESPACE(keypair)
+#define mld_sign_signature MLD_API_NAMESPACE(signature)
+#define mld_sign_verify MLD_API_NAMESPACE(verify)
+#define mld_sign MLD_API_NAMESPACE(sign)
+#define mld_open MLD_API_NAMESPACE(open)
+
 static void reset_all(void)
 {
   randombytes_counter = 0;
@@ -117,7 +123,7 @@ static int test_keygen_rng_failure(void)
   uint8_t pk[CRYPTO_PUBLICKEYBYTES];
   uint8_t sk[CRYPTO_SECRETKEYBYTES];
 
-  TEST_RNG_FAILURE("crypto_sign_keypair", crypto_sign_keypair(pk, sk));
+  TEST_RNG_FAILURE("mld_sign_keypair", mld_sign_keypair(pk, sk));
   return 0;
 }
 
@@ -125,7 +131,7 @@ static int test_pk_from_sk_rng_failure(void)
 {
   uint8_t pk[CRYPTO_PUBLICKEYBYTES];
 
-  TEST_RNG_FAILURE("crypto_sign_pk_from_sk",
+  TEST_RNG_FAILURE("mld_sign_pk_from_sk",
                    MLD_API_NAMESPACE(pk_from_sk)(pk, test_vector_sk));
   return 0;
 }
@@ -137,11 +143,11 @@ static int test_sign_rng_failure(void)
   uint8_t sig[CRYPTO_BYTES];
   size_t siglen;
 
-  TEST_RNG_FAILURE("crypto_sign_signature",
-                   crypto_sign_signature(
-                       sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
-                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
-                       TEST_VECTOR_CTX_LEN, test_vector_sk));
+  TEST_RNG_FAILURE(
+      "mld_sign_signature",
+      mld_sign_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                         TEST_VECTOR_CTX_LEN, test_vector_sk));
   return 0;
 }
 
@@ -151,10 +157,10 @@ static int test_sign_combined_rng_failure(void)
   size_t smlen;
 
   TEST_RNG_FAILURE(
-      "crypto_sign",
-      crypto_sign(sm, &smlen, (const uint8_t *)TEST_VECTOR_MSG,
-                  TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
-                  TEST_VECTOR_CTX_LEN, test_vector_sk));
+      "mld_sign",
+      mld_sign(sm, &smlen, (const uint8_t *)TEST_VECTOR_MSG,
+               TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+               TEST_VECTOR_CTX_LEN, test_vector_sk));
   return 0;
 }
 
@@ -165,7 +171,7 @@ static int test_signature_extmu_rng_failure(void)
   uint8_t mu[64] = {0};
 
   TEST_RNG_FAILURE(
-      "crypto_sign_signature_extmu",
+      "mld_sign_signature_extmu",
       MLD_API_NAMESPACE(signature_extmu)(sig, &siglen, mu, test_vector_sk));
   return 0;
 }
@@ -176,7 +182,7 @@ static int test_signature_pre_hash_shake256_rng_failure(void)
   uint8_t rnd[32] = {0};
   size_t siglen;
 
-  TEST_RNG_FAILURE("crypto_sign_signature_pre_hash_shake256",
+  TEST_RNG_FAILURE("mld_sign_signature_pre_hash_shake256",
                    MLD_API_NAMESPACE(signature_pre_hash_shake256)(
                        sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
                        TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
@@ -189,11 +195,11 @@ static int test_signature_pre_hash_shake256_rng_failure(void)
 static int test_verify_rng_failure(void)
 {
   TEST_RNG_FAILURE(
-      "crypto_sign_verify",
-      crypto_sign_verify(test_vector_sig, CRYPTO_BYTES,
-                         (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                         (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                         test_vector_pk));
+      "mld_sign_verify",
+      mld_sign_verify(test_vector_sig, CRYPTO_BYTES,
+                      (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
+                      (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+                      test_vector_pk));
   return 0;
 }
 
@@ -207,17 +213,16 @@ static int test_open_rng_failure(void)
   memcpy(sm, test_vector_sig, CRYPTO_BYTES);
   memcpy(sm + CRYPTO_BYTES, TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN);
 
-  TEST_RNG_FAILURE("crypto_sign_open",
-                   crypto_sign_open(msg_out, &mlen, sm, smlen,
-                                    (const uint8_t *)TEST_VECTOR_CTX,
-                                    TEST_VECTOR_CTX_LEN, test_vector_pk));
+  TEST_RNG_FAILURE("mld_open", mld_open(msg_out, &mlen, sm, smlen,
+                                        (const uint8_t *)TEST_VECTOR_CTX,
+                                        TEST_VECTOR_CTX_LEN, test_vector_pk));
   return 0;
 }
 
 static int test_verify_extmu_rng_failure(void)
 {
   TEST_RNG_FAILURE(
-      "crypto_sign_verify_extmu",
+      "mld_sign_verify_extmu",
       MLD_API_NAMESPACE(verify_extmu)(test_vector_sig_extmu, CRYPTO_BYTES,
                                       test_vector_mu, test_vector_pk));
   return 0;
@@ -225,7 +230,7 @@ static int test_verify_extmu_rng_failure(void)
 
 static int test_verify_pre_hash_shake256_rng_failure(void)
 {
-  TEST_RNG_FAILURE("crypto_sign_verify_pre_hash_shake256",
+  TEST_RNG_FAILURE("mld_sign_verify_pre_hash_shake256",
                    MLD_API_NAMESPACE(verify_pre_hash_shake256)(
                        test_vector_sig_pre_hash_shake256, CRYPTO_BYTES,
                        (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,

--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -8,6 +8,10 @@
 
 #include "mldsa_native.h"
 
+#define mld_sign_keypair MLD_API_NAMESPACE(keypair)
+#define mld_sign_signature MLD_API_NAMESPACE(signature)
+#define mld_sign_verify MLD_API_NAMESPACE(verify)
+
 static void test_keygen_only(void)
 {
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
@@ -16,7 +20,7 @@ static void test_keygen_only(void)
 
   /* Only call keypair - this is what we're measuring */
   /* Uses the notrandombytes implementation for deterministic randomness */
-  int ret = crypto_sign_keypair(pk, sk);
+  int ret = mld_sign_keypair(pk, sk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_KEYPAIR_API */
   printf("keygen test skipped (API disabled)\n");
@@ -34,8 +38,8 @@ static void test_sign_only(void)
 
   /* Only call signature - this is what we're measuring */
   /* sk is zero-initialized (invalid key, but OK for stack measurement) */
-  int ret = crypto_sign_signature(sig, &siglen, msg, sizeof(msg) - 1, ctx,
-                                  sizeof(ctx) - 1, sk);
+  int ret = mld_sign_signature(sig, &siglen, msg, sizeof(msg) - 1, ctx,
+                               sizeof(ctx) - 1, sk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_SIGN_API */
   printf("sign test skipped (API disabled)\n");
@@ -52,8 +56,8 @@ static void test_verify_only(void)
 
   /* Only call verify - this is what we're measuring */
   /* pk and sig are zero-initialized (invalid, but OK for stack measurement) */
-  int ret = crypto_sign_verify(sig, CRYPTO_BYTES, msg, sizeof(msg) - 1, ctx,
-                               sizeof(ctx) - 1, pk);
+  int ret = mld_sign_verify(sig, CRYPTO_BYTES, msg, sizeof(msg) - 1, ctx,
+                            sizeof(ctx) - 1, pk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_VERIFY_API */
   printf("verify test skipped (API disabled)\n");


### PR DESCRIPTION
- Resolves: #878

- The SUPERCOP API (crypto_sign_*) is a compatibility layer intended for SUPERCOP benchmarking.
Previously, the tests defined a series of SUPERCOP-style names for internal functions (the _internal variants), even though these tests are not part of the standard SUPERCOP API.

- Instead of defining SUPERCOP-related macros in every test source file, this commit updates those macros to target the regular mldsa-native API rather than the SUPERCOP compatibility layer.
As a result, the tests invoke the standard API directly while still using macros for name mapping.

Internal functions are now referenced via:
```
#define keypair_internal MLD_API_NAMESPACE(keypair_internal)
```