### PR TITLE
CI: Run RNG failure test for custom configs

### DIFF
--- a/.github/actions/config-variations/action.yml
+++ b/.github/actions/config-variations/action.yml
@@ -91,7 +91,7 @@ runs:
         extra_env: 'ASAN_OPTIONS=detect_leaks=1'
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom zeroization (explicit_bzero)"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-zeroize') }}
       uses: ./.github/actions/multi-functest
@@ -106,7 +106,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom native capability functions (static ON)"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'native-cap-ON') }}
       uses: ./.github/actions/multi-functest
@@ -121,7 +121,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom native capability functions (static OFF)"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'native-cap-OFF') }}
       uses: ./.github/actions/multi-functest
@@ -136,7 +136,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom native capability functions (ID_AA64PFR1_EL1 detection)"
       if: ${{ (inputs.tests == 'all' || contains(inputs.tests, 'native-cap-ID_AA64PFR1_EL1')) && runner.os == 'Linux' && runner.arch == 'ARM64' }}
       uses: ./.github/actions/multi-functest
@@ -151,7 +151,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom native capability functions (CPUID AVX2 detection)"
       if: ${{ (inputs.tests == 'all' || contains(inputs.tests, 'native-cap-CPUID_AVX2')) && runner.os == 'Linux' && runner.arch == 'X64' }}
       uses: ./.github/actions/multi-functest
@@ -166,7 +166,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "No ASM"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'no-asm') }}
       uses: ./.github/actions/multi-functest
@@ -181,7 +181,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Serial FIPS202 (no batched Keccak)"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'serial-fips202') }}
       uses: ./.github/actions/multi-functest
@@ -196,7 +196,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom randombytes"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-randombytes') }}
       uses: ./.github/actions/multi-functest
@@ -211,7 +211,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: false # Uses its own randombytes implementation
     - name: "Custom memcpy"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-memcpy') }}
       uses: ./.github/actions/multi-functest
@@ -226,7 +226,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom memset"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-memset') }}
       uses: ./.github/actions/multi-functest
@@ -241,7 +241,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "Custom stdlib (memcpy + memset)"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'custom-stdlib') }}
       uses: ./.github/actions/multi-functest
@@ -256,7 +256,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "MLD_POLY_UNIFORM_NBLOCKS=1"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'nblocks-1') }}
       uses: ./.github/actions/multi-functest
@@ -271,7 +271,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "MLD_POLY_UNIFORM_NBLOCKS=4"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'nblocks-4') }}
       uses: ./.github/actions/multi-functest
@@ -286,7 +286,7 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true
     - name: "MLD_POLY_UNIFORM_NBLOCKS=6"
       if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'nblocks-6') }}
       uses: ./.github/actions/multi-functest
@@ -301,4 +301,4 @@ runs:
         opt: ${{ inputs.opt }}
         examples: false # Some examples use a custom config themselves
         alloc: false # Requires custom config
-        rng_fail: false # Requires custom config
+        rng_fail: true


### PR DESCRIPTION
Previously, the RNG failure test relied on a custom configuration and thus had to be skipped in the custom config action.

Now, the RNG failure test no longer relies on a custom config and can hence be included in the custom config action.