### PR TITLE
OQS: Add missing bmi2 flag and clean up

### DIFF
--- a/integration/liboqs/ML-DSA-44_META.yml
+++ b/integration/liboqs/ML-DSA-44_META.yml
@@ -52,8 +52,8 @@ implementations:
   supported_platforms:
   - architecture: x86_64
     operating_systems:
-    - Darwin
     - Linux
+    - Darwin
     required_flags:
     - avx2
     - bmi2

--- a/integration/liboqs/ML-DSA-65_META.yml
+++ b/integration/liboqs/ML-DSA-65_META.yml
@@ -52,8 +52,8 @@ implementations:
   supported_platforms:
   - architecture: x86_64
     operating_systems:
-    - Darwin
     - Linux
+    - Darwin
     required_flags:
     - avx2
     - bmi2

--- a/integration/liboqs/ML-DSA-87_META.yml
+++ b/integration/liboqs/ML-DSA-87_META.yml
@@ -52,10 +52,11 @@ implementations:
   supported_platforms:
   - architecture: x86_64
     operating_systems:
-    - Darwin
     - Linux
+    - Darwin
     required_flags:
     - avx2
+    - bmi2
     - popcnt
 - name: aarch64
   version: FIPS204


### PR DESCRIPTION
This commit adds the missing bmi2 flag to the ML-DSA-87 yml. bmi2 is currently not strictly needed as asm is not using any bmi2 instructions, but in practice there are no CPUs that have AVX2, but not bmi2 so we might as well keep it as we may use later (as in rejection sampling in mlkem-native) or the compiler may use it.

This commit also cleans up ordering of Darwin and Linux in the ymls.