### PR TITLE
Fix rng_fail test missing EXTRA_SOURCES on baremetal platforms

### DIFF
--- a/.github/workflows/baremetal.yml
+++ b/.github/workflows/baremetal.yml
@@ -36,4 +36,4 @@ jobs:
           examples: false
           stack: false
           alloc: true
-          rng_fail: false
+          rng_fail: true


### PR DESCRIPTION
The test_rng_fail binaries were not linking against EXTRA_SOURCES because RNG_FAIL_TESTS was not included in ALL_TESTS. This caused failures on baremetal platforms that require platform-specific source files defined in EXTRA_SOURCES.

Add RNG_FAIL_TESTS to ALL_TESTS so the existing dependency rules automatically include EXTRA_SOURCES for rng_fail test binaries. Skip inclusion of notrandombytes.c since rng_fail uses a custom rng wrapper and `#include`s notrandombytes.c directly.

Finally, run `rng_fail` in the baremetal CI.

Fixes #899