### PR TITLE
Move MLD_MUST_CHECK_RETURN_VALUE from randombytes to mlk_randombytes

### DIFF
--- a/mldsa/src/randombytes.h
+++ b/mldsa/src/randombytes.h
@@ -13,8 +13,9 @@
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 #if !defined(MLD_CONFIG_CUSTOM_RANDOMBYTES)
-MLD_MUST_CHECK_RETURN_VALUE
 int randombytes(uint8_t *out, size_t outlen);
+
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_randombytes(uint8_t *out, size_t outlen)
 __contract__(
   requires(memory_no_alias(out, outlen))


### PR DESCRIPTION
MLD_MUST_CHECK_RETURN_VALUE was misplaced at randombytes. This commit moves it to mlk_randombytes.