### PR TITLE
Port: Unit tests: Add native Keccak x1 and x4 tests

### DIFF
--- a/mldsa/src/fips202/keccakf1600.c
+++ b/mldsa/src/fips202/keccakf1600.c
@@ -138,7 +138,8 @@ static const uint64_t mld_KeccakF_RoundConstants[MLD_KECCAK_NROUNDS] = {
     (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008080ULL,
     (uint64_t)0x0000000080000001ULL, (uint64_t)0x8000000080008008ULL};
 
-static void mld_keccakf1600_permute_c(uint64_t *state)
+MLD_STATIC_TESTABLE
+void mld_keccakf1600_permute_c(uint64_t *state)
 {
   unsigned round;
 


### PR DESCRIPTION
- Resolves: #904 
- Based on: #855 
- Ported from: https://github.com/pq-code-package/mlkem-native/pull/1516


Add unit tests for keccakf1600 x1 and x4 permutation functions that
compare native implementations against the C reference implementation.

- test_keccakf1600_permute: tests x1 permutation when
  MLD_USE_FIPS202_X1_NATIVE
- test_keccakf1600x4_permute: tests x4 permutation when
  MLD_USE_FIPS202_X4_NATIVE
- Expose mld_keccakf1600_permute_c via MLD_STATIC_TESTABLE for testing