### PR TITLE
CI: Add OpenTitan build test

### DIFF
--- a/.github/actions/setup-opentitan/action.yml
+++ b/.github/actions/setup-opentitan/action.yml
@@ -1,0 +1,79 @@
+# Copyright (c) The mldsa-native project authors
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: Setup OpenTitan
+description: Setup OpenTitan for build testing
+
+inputs:
+  expo-repository:
+    description: 'Expo repository to clone'
+    required: false
+    default: 'https://github.com/zerorisc/expo'
+  expo-commit:
+    description: 'Expo commit to checkout'
+    required: false
+    default: 'master'
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch expo repository
+      shell: bash
+      run: |
+        # Ensure HOME is set for self-hosted runners
+        echo "HOME=${HOME:-/home/runner}" >> $GITHUB_ENV
+
+        git clone ${{ inputs.expo-repository }}
+        cd expo
+        git checkout ${{ inputs.expo-commit }}
+
+        # Remember expo directory
+        echo EXPO_DIR="$GITHUB_WORKSPACE/expo" >> $GITHUB_ENV
+
+    - name: Install OpenTitan dependencies
+      shell: bash
+      run: |
+        sudo apt update
+        cd expo
+        sed -e '/^#/d' -e '/libncursesw5/d' ./apt-requirements.txt | xargs sudo apt install -y
+        # Install runtime dependencies needed by tools
+        sudo apt install -y gcc g++ libtinfo5 srecord pkg-config libudev-dev libssl-dev \
+          libftdi1-dev libelf-dev zlib1g-dev
+        pip3 install --user -r python-requirements.txt --require-hashes
+
+    - name: Cache Verilator
+      id: cache-verilator
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: /tools/verilator/4.210
+        key: verilator-4.210-ubuntu22-${{ runner.os }}
+
+    - name: Install Verilator
+      if: steps.cache-verilator.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # Install build-time dependencies for Verilator
+        sudo apt install -y make autoconf bison flex libfl-dev gcc-11 g++-11
+
+        # Build and install Verilator
+        export VERILATOR_VERSION=4.210
+        git clone https://github.com/verilator/verilator.git
+        cd verilator
+        git checkout v$VERILATOR_VERSION
+        autoconf
+        CC=gcc-11 CXX=g++-11 ./configure --prefix=/tools/verilator/$VERILATOR_VERSION
+        CC=gcc-11 CXX=g++-11 make -j$(nproc)
+        sudo CC=gcc-11 CXX=g++-11 make install
+
+    - name: Add Verilator to PATH
+      shell: bash
+      run: |
+        echo "/tools/verilator/4.210/bin" >> $GITHUB_PATH
+
+    - name: Set Bazel cache directory and mirror
+      shell: bash
+      run: |
+        echo "BAZEL_CACHE_DIR=/home/runner/bazel_cache" >> $GITHUB_ENV
+        # Use GitHub mirror for Bazel binaries to avoid certificate issues with releases.bazel.build
+        echo "BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download" >> $GITHUB_ENV

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -93,6 +93,14 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/baremetal.yml
     secrets: inherit
+  opentitan_integration:
+    name: OpenTitan
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/integration-opentitan.yml
+    secrets: inherit
   isabelle:
     name: Isabelle
     permissions:

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -1,0 +1,110 @@
+# Copyright (c) The mldsa-native project authors
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: OpenTitan
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  AWS_ROLE: arn:aws:iam::904233116199:role/mldsa-native-ci
+  AWS_REGION: us-east-1
+  AMI_UBUNTU_22_04_X86_64: ami-0bbdd8c17ed981ef9
+
+jobs:
+  start-ec2-runner:
+    name: Start EC2 instance
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # Make this step non-cancellable to avoid orphaned instances
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@fc6e909ff9c17ef354753807e8e9d6fa0a839436
+        with:
+          mode: start
+          github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          ec2-image-id: ${{ env.AMI_UBUNTU_22_04_X86_64 }}
+          ec2-instance-type: c7i.2xlarge
+          ec2-volume-size: 32
+          subnet-id: subnet-094d73eb42eb6bf5b
+          security-group-id: sg-0282706dbc92a1579
+
+  opentitan_build:
+    name: OpenTitan ML-DSA Build Test
+    needs: start-ec2-runner
+    runs-on: ${{ needs.start-ec2-runner.outputs.label }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup-opentitan
+        with:
+          expo-repository: https://github.com/zerorisc/expo
+          expo-commit: 375803409deee1f5f7965f0757e316670b13f544
+
+      - name: Patch mldsa-native dependency
+        run: |
+          cd $EXPO_DIR
+
+          # Calculate sha256 of mldsa-native at the new commit
+          SHA256=$(curl -sL "https://github.com/$GITHUB_REPOSITORY/archive/$GITHUB_SHA.tar.gz" | sha256sum | cut -d' ' -f1)
+
+          # Update the extensions.bzl file with new commit and sha256
+          sed -i \
+            -e "s|sha256 = \"[^\"]*\"|sha256 = \"$SHA256\"|" \
+            -e "s|strip_prefix = \"mldsa-native-[^\"]*\"|strip_prefix = \"mldsa-native-$GITHUB_SHA\"|" \
+            -e "s|archive/[^/]*.tar.gz|archive/$GITHUB_SHA.tar.gz|" \
+            third_party/mldsa_native/extensions.bzl
+
+          # Show the changes
+          echo "=== Patched extensions.bzl ==="
+          cat third_party/mldsa_native/extensions.bzl
+
+      - name: Build mldsa functest
+        run: |
+          cd $EXPO_DIR
+          # Build only -- ML-DSA simulation is too slow for CI
+          ./bazelisk.sh build \
+            --disk_cache=$BAZEL_CACHE_DIR \
+            --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/ \
+            //sw/device/tests/crypto:mldsa_functest_sim_verilator
+
+  stop-ec2-runner:
+    name: Stop EC2 instance
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs:
+      - start-ec2-runner
+      - opentitan_build # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if errors occur
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@a6dbcefcf8a31a861f5e078bb153ed332130c512 # v2.4.3
+        with:
+          mode: stop
+          github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          label: ${{ needs.start-ec2-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
Add CI workflow to verify that mldsa-native builds correctly
within the OpenTitan (expo) build system. Only builds the test
binary without running the Verilator simulation, as ML-DSA is
too slow for simulation in CI.

- Resolves https://github.com/pq-code-package/mldsa-native/issues/886