### PR TITLE
Use MLD_MUST_CHECK_RETURN_VALUE for all functions with return values

### DIFF
--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -35,6 +35,7 @@
 #include "../api.h"
 #include "src/arith_native_aarch64.h"
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
   mld_ntt_asm(data, mld_aarch64_ntt_zetas_layer123456,
@@ -42,6 +43,7 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
   mld_intt_asm(data, mld_aarch64_intt_zetas_layer78,
@@ -49,6 +51,7 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
@@ -63,6 +66,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_asm(r, buf, buflen, mld_rej_uniform_table);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -87,6 +91,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -111,24 +116,28 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
   mld_poly_decompose_32_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
   mld_poly_decompose_88_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
   mld_poly_caddq_asm(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -136,6 +145,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -143,23 +153,27 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_asm(a, B);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 {
   mld_polyz_unpack_17_asm(r, buf, mld_polyz_unpack_17_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *buf)
 {
   mld_polyz_unpack_19_asm(r, buf, mld_polyz_unpack_19_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t out[MLDSA_N], const int32_t in0[MLDSA_N],
     const int32_t in1[MLDSA_N])
@@ -168,6 +182,7 @@ static MLD_INLINE int mld_poly_pointwise_montgomery_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
@@ -177,6 +192,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
@@ -186,6 +202,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -57,14 +57,17 @@ void mld_ntt_asm(int32_t *, const int32_t *, const int32_t *);
 void mld_intt_asm(int32_t *, const int32_t *, const int32_t *);
 
 #define mld_rej_uniform_asm MLD_NAMESPACE(rej_uniform_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, unsigned buflen,
                              const uint8_t *table);
 
 #define mld_rej_uniform_eta2_asm MLD_NAMESPACE(rej_uniform_eta2_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf,
                                   unsigned buflen, const uint8_t *table);
 
 #define mld_rej_uniform_eta4_asm MLD_NAMESPACE(rej_uniform_eta4_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf,
                                   unsigned buflen, const uint8_t *table);
 
@@ -92,6 +95,7 @@ void mld_poly_use_hint_32_asm(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_asm(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_asm MLD_NAMESPACE(poly_chknorm_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 int mld_poly_chknorm_asm(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_asm MLD_NAMESPACE(polyz_unpack_17_asm)

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -35,6 +35,7 @@
 #include "../api.h"
 #include "src/arith_native_aarch64.h"
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
   mld_ntt_asm(data, mld_aarch64_ntt_zetas_layer123456,
@@ -42,6 +43,7 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
   mld_intt_asm(data, mld_aarch64_intt_zetas_layer78,
@@ -49,6 +51,7 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
@@ -63,6 +66,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_asm(r, buf, buflen, mld_rej_uniform_table);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -87,6 +91,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -111,24 +116,28 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
   mld_poly_decompose_32_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
   mld_poly_decompose_88_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
   mld_poly_caddq_asm(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -136,6 +145,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -143,23 +153,27 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_asm(a, B);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 {
   mld_polyz_unpack_17_asm(r, buf, mld_polyz_unpack_17_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *buf)
 {
   mld_polyz_unpack_19_asm(r, buf, mld_polyz_unpack_19_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t out[MLDSA_N], const int32_t in0[MLDSA_N],
     const int32_t in1[MLDSA_N])
@@ -168,6 +182,7 @@ static MLD_INLINE int mld_poly_pointwise_montgomery_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
@@ -177,6 +192,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
@@ -186,6 +202,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -57,14 +57,17 @@ void mld_ntt_asm(int32_t *, const int32_t *, const int32_t *);
 void mld_intt_asm(int32_t *, const int32_t *, const int32_t *);
 
 #define mld_rej_uniform_asm MLD_NAMESPACE(rej_uniform_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, unsigned buflen,
                              const uint8_t *table);
 
 #define mld_rej_uniform_eta2_asm MLD_NAMESPACE(rej_uniform_eta2_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf,
                                   unsigned buflen, const uint8_t *table);
 
 #define mld_rej_uniform_eta4_asm MLD_NAMESPACE(rej_uniform_eta4_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf,
                                   unsigned buflen, const uint8_t *table);
 
@@ -92,6 +95,7 @@ void mld_poly_use_hint_32_asm(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_asm(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_asm MLD_NAMESPACE(poly_chknorm_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 int mld_poly_chknorm_asm(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_asm MLD_NAMESPACE(polyz_unpack_17_asm)

--- a/dev/fips202/aarch64/x2_v84a.h
+++ b/dev/fips202/aarch64/x2_v84a.h
@@ -19,6 +19,7 @@
 #if !defined(__ASSEMBLER__)
 #include "../api.h"
 #include "src/fips202_native_aarch64.h"
+
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {

--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -44,6 +44,7 @@ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
   }
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -54,6 +55,8 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
   mld_ntt_avx2(data, mld_qdata);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
+
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -64,6 +67,7 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
@@ -79,6 +83,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_avx2(r, buf);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -105,6 +110,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -131,6 +137,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -141,6 +148,7 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -151,6 +159,7 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -160,6 +169,8 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
   mld_poly_caddq_avx2(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
+
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -171,6 +182,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -182,6 +194,7 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -191,6 +204,7 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
   return mld_poly_chknorm_avx2(a, B);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -201,6 +215,7 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -211,6 +226,7 @@ static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t c[MLDSA_N], const int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
@@ -222,6 +238,7 @@ static MLD_INLINE int mld_poly_pointwise_montgomery_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
@@ -234,6 +251,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
@@ -246,6 +264,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -53,14 +53,17 @@ void mld_invntt_avx2(int32_t *r, const int32_t *mld_qdata);
 void mld_nttunpack_avx2(int32_t *r);
 
 #define mld_rej_uniform_avx2 MLD_NAMESPACE(mld_rej_uniform_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned mld_rej_uniform_avx2(int32_t *r,
                               const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN]);
 
 #define mld_rej_uniform_eta2_avx2 MLD_NAMESPACE(mld_rej_uniform_eta2_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned mld_rej_uniform_eta2_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN]);
 
 #define mld_rej_uniform_eta4_avx2 MLD_NAMESPACE(mld_rej_uniform_eta4_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned mld_rej_uniform_eta4_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN]);
 
@@ -80,6 +83,7 @@ void mld_poly_use_hint_32_avx2(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_avx2(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_avx2 MLD_NAMESPACE(mld_poly_chknorm_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 int mld_poly_chknorm_avx2(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_avx2 MLD_NAMESPACE(mld_polyz_unpack_17_avx2)

--- a/mldsa/src/ct.h
+++ b/mldsa/src/ct.h
@@ -83,30 +83,38 @@ extern volatile uint64_t mld_ct_opt_blocker_u64;
  * Its validity relies on the assumption that the global opt-blocker
  * constant mld_ct_opt_blocker_u64 is not modified.
  */
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint64_t mld_ct_get_optblocker_u64(void)
 __contract__(ensures(return_value == 0)) { return mld_ct_opt_blocker_u64; }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int64_t mld_ct_get_optblocker_i64(void)
 __contract__(ensures(return_value == 0)) { return (int64_t)mld_ct_get_optblocker_u64(); }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint32_t mld_ct_get_optblocker_u32(void)
 __contract__(ensures(return_value == 0)) { return (uint32_t)mld_ct_get_optblocker_u64(); }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint8_t mld_ct_get_optblocker_u8(void)
 __contract__(ensures(return_value == 0)) { return (uint8_t)mld_ct_get_optblocker_u64(); }
 
 /* Opt-blocker based implementation of value barriers */
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int64_t mld_value_barrier_i64(int64_t b)
 __contract__(ensures(return_value == b)) { return (b ^ mld_ct_get_optblocker_i64()); }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint32_t mld_value_barrier_u32(uint32_t b)
 __contract__(ensures(return_value == b)) { return (b ^ mld_ct_get_optblocker_u32()); }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint8_t mld_value_barrier_u8(uint8_t b)
 __contract__(ensures(return_value == b)) { return (b ^ mld_ct_get_optblocker_u8()); }
 
 
 #else  /* !MLD_USE_ASM_VALUE_BARRIER */
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int64_t mld_value_barrier_i64(int64_t b)
 __contract__(ensures(return_value == b))
 {
@@ -114,6 +122,7 @@ __contract__(ensures(return_value == b))
   return b;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint32_t mld_value_barrier_u32(uint32_t b)
 __contract__(ensures(return_value == b))
 {
@@ -121,6 +130,7 @@ __contract__(ensures(return_value == b))
   return b;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint8_t mld_value_barrier_u8(uint8_t b)
 __contract__(ensures(return_value == b))
 {
@@ -147,6 +157,7 @@ __contract__(ensures(return_value == b))
  *              - x >= 2^31: returns x - 2^31
  *
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_ALWAYS_INLINE int32_t mld_cast_uint32_to_int32(uint32_t x)
 {
   /*
@@ -172,6 +183,7 @@ static MLD_ALWAYS_INLINE int32_t mld_cast_uint32_to_int32(uint32_t x)
  * Returns:     For int64_t x, the unique y in uint32_t
  *              so that x == y mod 2^32.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_ALWAYS_INLINE uint32_t mld_cast_int64_to_uint32(int64_t x)
 {
   return (uint32_t)(x & (int64_t)UINT32_MAX);
@@ -185,6 +197,7 @@ static MLD_ALWAYS_INLINE uint32_t mld_cast_int64_to_uint32(int64_t x)
  * Returns:     For int32_t x, the unique y in uint32_t
  *              so that x == y mod 2^32.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_ALWAYS_INLINE uint32_t mld_cast_int32_to_uint32(int32_t x)
 {
   return mld_cast_int64_to_uint32((int64_t)x);
@@ -203,6 +216,7 @@ static MLD_ALWAYS_INLINE uint32_t mld_cast_int32_to_uint32(int32_t x)
  *
  *
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int32_t mld_ct_sel_int32(int32_t a, int32_t b, uint32_t cond)
 __contract__(
   requires(cond == 0x0 || cond == 0xFFFFFFFF)
@@ -223,6 +237,7 @@ __contract__(
  * Arguments:   uint32_t x: Value to be converted into a mask
  *
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint32_t mld_ct_cmask_nonzero_u32(uint32_t x)
 __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFFFFFFFF)))
 {
@@ -239,6 +254,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFFFFFFFF)))
  * Arguments:   uint8_t x: Value to be converted into a mask
  *
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint8_t mld_ct_cmask_nonzero_u8(uint8_t x)
 __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFF)))
 {
@@ -254,6 +270,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFF)))
  * Arguments:   int32_t x: Value to be converted into a mask
  *
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint32_t mld_ct_cmask_neg_i32(int32_t x)
 __contract__(
   ensures(return_value == ((x < 0) ? 0xFFFFFFFF : 0))
@@ -272,6 +289,7 @@ __contract__(
  * Arguments:   int32_t x: Input value
  *
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int32_t mld_ct_abs_i32(int32_t x)
 __contract__(
   requires(x >= -INT32_MAX)
@@ -294,6 +312,7 @@ __contract__(
  *
  * Returns 0 if the byte arrays are equal, 0xFF otherwise.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE uint8_t mld_ct_memcmp(const uint8_t *a, const uint8_t *b,
                                         const size_t len)
 __contract__(

--- a/mldsa/src/fips202/native/aarch64/x2_v84a.h
+++ b/mldsa/src/fips202/native/aarch64/x2_v84a.h
@@ -19,6 +19,7 @@
 #if !defined(__ASSEMBLER__)
 #include "../api.h"
 #include "src/fips202_native_aarch64.h"
+
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {

--- a/mldsa/src/fips202/native/api.h
+++ b/mldsa/src/fips202/native/api.h
@@ -46,6 +46,7 @@
  */
 
 #if defined(MLD_USE_FIPS202_X1_NATIVE)
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x1_native(uint64_t *state)
 __contract__(
     requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 1))
@@ -55,6 +56,7 @@ __contract__(
 );
 #endif /* MLD_USE_FIPS202_X1_NATIVE */
 #if defined(MLD_USE_FIPS202_X4_NATIVE)
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 __contract__(
     requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))

--- a/mldsa/src/fips202/native/x86_64/xkcp.h
+++ b/mldsa/src/fips202/native/x86_64/xkcp.h
@@ -17,6 +17,7 @@
 #include "src/KeccakP_1600_times4_SIMD256.h"
 
 #define MLD_USE_FIPS202_X4_NATIVE
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))

--- a/mldsa/src/native/aarch64/meta.h
+++ b/mldsa/src/native/aarch64/meta.h
@@ -35,6 +35,7 @@
 #include "../api.h"
 #include "src/arith_native_aarch64.h"
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
   mld_ntt_asm(data, mld_aarch64_ntt_zetas_layer123456,
@@ -42,6 +43,7 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
   mld_intt_asm(data, mld_aarch64_intt_zetas_layer78,
@@ -49,6 +51,7 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
@@ -63,6 +66,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_asm(r, buf, buflen, mld_rej_uniform_table);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -87,6 +91,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -111,24 +116,28 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
   mld_poly_decompose_32_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
   mld_poly_decompose_88_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
   mld_poly_caddq_asm(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -136,6 +145,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -143,23 +153,27 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   return mld_poly_chknorm_asm(a, B);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 {
   mld_polyz_unpack_17_asm(r, buf, mld_polyz_unpack_17_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *buf)
 {
   mld_polyz_unpack_19_asm(r, buf, mld_polyz_unpack_19_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t out[MLDSA_N], const int32_t in0[MLDSA_N],
     const int32_t in1[MLDSA_N])
@@ -168,6 +182,7 @@ static MLD_INLINE int mld_poly_pointwise_montgomery_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
@@ -177,6 +192,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
@@ -186,6 +202,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])

--- a/mldsa/src/native/aarch64/src/arith_native_aarch64.h
+++ b/mldsa/src/native/aarch64/src/arith_native_aarch64.h
@@ -57,14 +57,17 @@ void mld_ntt_asm(int32_t *, const int32_t *, const int32_t *);
 void mld_intt_asm(int32_t *, const int32_t *, const int32_t *);
 
 #define mld_rej_uniform_asm MLD_NAMESPACE(rej_uniform_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_asm(int32_t *r, const uint8_t *buf, unsigned buflen,
                              const uint8_t *table);
 
 #define mld_rej_uniform_eta2_asm MLD_NAMESPACE(rej_uniform_eta2_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_eta2_asm(int32_t *r, const uint8_t *buf,
                                   unsigned buflen, const uint8_t *table);
 
 #define mld_rej_uniform_eta4_asm MLD_NAMESPACE(rej_uniform_eta4_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 uint64_t mld_rej_uniform_eta4_asm(int32_t *r, const uint8_t *buf,
                                   unsigned buflen, const uint8_t *table);
 
@@ -92,6 +95,7 @@ void mld_poly_use_hint_32_asm(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_asm(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_asm MLD_NAMESPACE(poly_chknorm_asm)
+MLD_MUST_CHECK_RETURN_VALUE
 int mld_poly_chknorm_asm(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_asm MLD_NAMESPACE(polyz_unpack_17_asm)

--- a/mldsa/src/native/api.h
+++ b/mldsa/src/native/api.h
@@ -85,6 +85,7 @@
  *
  * Arguments:   - int32_t p[MLDSA_N]: pointer to in/output polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t p[MLDSA_N])
 __contract__(
     requires(memory_no_alias(p, sizeof(int32_t) * MLDSA_N))
@@ -147,6 +148,7 @@ __contract__(
  *
  * Arguments:   - uint32_t p[MLDSA_N]: pointer to in/output polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t p[MLDSA_N])
 __contract__(
   requires(memory_no_alias(p, sizeof(int32_t) * MLDSA_N))
@@ -177,6 +179,7 @@ __contract__(
  * lengths. Otherwise, returns non-negative number of sampled 32-bit integers
  * (at most len).
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
@@ -209,6 +212,7 @@ __contract__(
  *lengths. Otherwise, returns non-negative number of sampled 32-bit integers
  *(at most len).
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -241,6 +245,7 @@ __contract__(
  *lengths. Otherwise, returns non-negative number of sampled 32-bit integers
  *(at most len).
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -272,6 +277,7 @@ __contract__(
  *              - int32_t *a0: input/output polynomial.
  *                             Output has coefficients c0
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 __contract__(
   requires(memory_no_alias(a1,  sizeof(int32_t) * MLDSA_N))
@@ -304,6 +310,7 @@ __contract__(
  *              - int32_t *a0: output polynomial with coefficients c0.
  *                             Output has coefficients c0
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 __contract__(
   requires(memory_no_alias(a1,  sizeof(int32_t) * MLDSA_N))
@@ -328,6 +335,7 @@ __contract__(
  *
  * Arguments:   - int32_t *a: pointer to input/output polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
@@ -352,6 +360,7 @@ __contract__(
  *              - const int32_t *a: pointer to input polynomial
  *              - const int32_t *h: pointer to input hint polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 __contract__(
@@ -379,6 +388,7 @@ __contract__(
  *              - const int32_t *a: pointer to input polynomial
  *              - const int32_t *h: pointer to input hint polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 __contract__(
@@ -407,6 +417,7 @@ __contract__(
  * Returns 0 if the infinity norm is strictly smaller than B, and 1
  * otherwise. B must not be larger than MLDSA_Q - MLD_REDUCE32_RANGE_MAX.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
@@ -428,6 +439,7 @@ __contract__(
  * Arguments:   - int32_t *r: pointer to output polynomial
  *              - const uint8_t *a: byte array with bit-packed polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
@@ -450,6 +462,7 @@ __contract__(
  * Arguments:   - int32_t *r: pointer to output polynomial
  *              - const uint8_t *a: byte array with bit-packed polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
@@ -475,6 +488,7 @@ __contract__(
  *              - const int32_t a[MLDSA_N]: first input polynomial
  *              - const int32_t b[MLDSA_N]: second input polynomial
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t c[MLDSA_N], const int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 __contract__(
@@ -507,6 +521,7 @@ __contract__(
  *              - const int32_t u[MLDSA_L][MLDSA_N]: first input vector
  *              - const int32_t v[MLDSA_L][MLDSA_N]: second input vector
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
@@ -540,6 +555,7 @@ __contract__(
  *              - const int32_t u[MLDSA_L][MLDSA_N]: first input vector
  *              - const int32_t v[MLDSA_L][MLDSA_N]: second input vector
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
@@ -573,6 +589,7 @@ __contract__(
  *              - const int32_t u[MLDSA_L][MLDSA_N]: first input vector
  *              - const int32_t v[MLDSA_L][MLDSA_N]: second input vector
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])

--- a/mldsa/src/native/x86_64/meta.h
+++ b/mldsa/src/native/x86_64/meta.h
@@ -44,6 +44,7 @@ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
   }
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -54,6 +55,8 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
   mld_ntt_avx2(data, mld_qdata);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
+
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -64,6 +67,7 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
@@ -79,6 +83,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
   return (int)mld_rej_uniform_avx2(r, buf);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -105,6 +110,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
                                                   const uint8_t *buf,
                                                   unsigned buflen)
@@ -131,6 +137,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
   return (int)outlen;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -141,6 +148,7 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -151,6 +159,7 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -160,6 +169,8 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
   mld_poly_caddq_avx2(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
+
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -171,6 +182,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
                                                   const int32_t *h)
 {
@@ -182,6 +194,7 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *b, const int32_t *a,
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -191,6 +204,7 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
   return mld_poly_chknorm_avx2(a, B);
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -201,6 +215,7 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
 {
   if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
@@ -211,6 +226,7 @@ static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t c[MLDSA_N], const int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
@@ -222,6 +238,7 @@ static MLD_INLINE int mld_poly_pointwise_montgomery_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
@@ -234,6 +251,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
@@ -246,6 +264,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
   return MLD_NATIVE_FUNC_SUCCESS;
 }
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])

--- a/mldsa/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mldsa/src/native/x86_64/src/arith_native_x86_64.h
@@ -53,14 +53,17 @@ void mld_invntt_avx2(int32_t *r, const int32_t *mld_qdata);
 void mld_nttunpack_avx2(int32_t *r);
 
 #define mld_rej_uniform_avx2 MLD_NAMESPACE(mld_rej_uniform_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned mld_rej_uniform_avx2(int32_t *r,
                               const uint8_t buf[MLD_AVX2_REJ_UNIFORM_BUFLEN]);
 
 #define mld_rej_uniform_eta2_avx2 MLD_NAMESPACE(mld_rej_uniform_eta2_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned mld_rej_uniform_eta2_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN]);
 
 #define mld_rej_uniform_eta4_avx2 MLD_NAMESPACE(mld_rej_uniform_eta4_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned mld_rej_uniform_eta4_avx2(
     int32_t *r, const uint8_t buf[MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN]);
 
@@ -80,6 +83,7 @@ void mld_poly_use_hint_32_avx2(int32_t *b, const int32_t *a, const int32_t *h);
 void mld_poly_use_hint_88_avx2(int32_t *b, const int32_t *a, const int32_t *h);
 
 #define mld_poly_chknorm_avx2 MLD_NAMESPACE(mld_poly_chknorm_avx2)
+MLD_MUST_CHECK_RETURN_VALUE
 int mld_poly_chknorm_avx2(const int32_t *a, int32_t B);
 
 #define mld_polyz_unpack_17_avx2 MLD_NAMESPACE(mld_polyz_unpack_17_avx2)

--- a/mldsa/src/poly.h
+++ b/mldsa/src/poly.h
@@ -381,6 +381,7 @@ __contract__(
  *
  **************************************************/
 MLD_INTERNAL_API
+MLD_MUST_CHECK_RETURN_VALUE
 uint32_t mld_poly_chknorm(const mld_poly *a, int32_t B)
 __contract__(
   requires(memory_no_alias(a, sizeof(mld_poly)))

--- a/mldsa/src/poly_kl.h
+++ b/mldsa/src/poly_kl.h
@@ -58,6 +58,7 @@ __contract__(
  * Returns number of 1 bits.
  **************************************************/
 MLD_INTERNAL_API
+MLD_MUST_CHECK_RETURN_VALUE
 unsigned int mld_poly_make_hint(mld_poly *h, const mld_poly *a0,
                                 const mld_poly *a1)
 __contract__(

--- a/mldsa/src/polyvec.h
+++ b/mldsa/src/polyvec.h
@@ -656,6 +656,7 @@ __contract__(
  * Returns pointer to the row (mld_polyvecl)
  **************************************************/
 MLD_INTERNAL_API
+MLD_MUST_CHECK_RETURN_VALUE
 const mld_polyvecl *mld_polymat_get_row(mld_polymat *mat, unsigned int row);
 
 #define mld_polyvec_matrix_expand MLD_NAMESPACE_KL(polyvec_matrix_expand)

--- a/mldsa/src/randombytes.h
+++ b/mldsa/src/randombytes.h
@@ -13,6 +13,7 @@
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 #if !defined(MLD_CONFIG_CUSTOM_RANDOMBYTES)
+MLD_MUST_CHECK_RETURN_VALUE
 int randombytes(uint8_t *out, size_t outlen);
 
 MLD_MUST_CHECK_RETURN_VALUE

--- a/mldsa/src/reduce.h
+++ b/mldsa/src/reduce.h
@@ -36,6 +36,7 @@
  *              In particular, if |a| < 2^31 * MLDSA_Q, the absolute value
  *              of the return value is < MLDSA_Q.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int32_t mld_montgomery_reduce(int64_t a)
 __contract__(
   /* We don't attempt to express an input-dependent output bound
@@ -97,6 +98,7 @@ __contract__(
  *
  * Returns r.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int32_t mld_reduce32(int32_t a)
 __contract__(
   requires(a <= MLD_REDUCE32_DOMAIN_MAX)
@@ -121,6 +123,7 @@ __contract__(
  *
  * Returns r.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int32_t mld_caddq(int32_t a)
 __contract__(
   requires(a > -MLDSA_Q)

--- a/mldsa/src/rounding.h
+++ b/mldsa/src/rounding.h
@@ -184,6 +184,7 @@ __contract__(
  *
  * Returns 1 if overflow, 0 otherwise
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE unsigned int mld_make_hint(int32_t a0, int32_t a1)
 __contract__(
   ensures(return_value >= 0 && return_value <= 1)
@@ -208,6 +209,7 @@ __contract__(
  *
  * Returns corrected high bits.
  **************************************************/
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int32_t mld_use_hint(int32_t a, int32_t hint)
 __contract__(
   requires(hint >= 0 && hint <= 1)

--- a/mldsa/src/sys.h
+++ b/mldsa/src/sys.h
@@ -237,6 +237,7 @@ typedef enum
 #if !defined(MLD_CONFIG_CUSTOM_CAPABILITY_FUNC)
 #include "cbmc.h"
 
+MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 __contract__(
   ensures(return_value == 0 || return_value == 1)

--- a/proofs/cbmc/polyvec_matrix_expand/Makefile
+++ b/proofs/cbmc/polyvec_matrix_expand/Makefile
@@ -40,7 +40,7 @@ FUNCTION_NAME = polyvec_matrix_expand
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 11
+CBMC_OBJECT_BITS = 12
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
Resolves https://github.com/pq-code-package/mldsa-native/issues/856

"Enforcing internal error checking discipline. In particular, this applies to the backend APIs that can now signal fallback -- this must always be checked."