### PR TITLE
aarch64: Don't perform unaligned memory accesses

### DIFF
--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -68,43 +68,43 @@ MLD_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_hybrid_asm)
         str	x0, [sp]
         add	x4, x0, #0xc8
         ldp	q25, q26, [x0]
-        ldp	q27, q28, [x4]
+        ld1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v0.2d, v25.2d, v27.2d
         trn2	v1.2d, v25.2d, v27.2d
         trn1	v2.2d, v26.2d, v28.2d
         trn2	v3.2d, v26.2d, v28.2d
         ldp	q25, q26, [x0, #0x20]
-        ldp	q27, q28, [x4, #0x20]
+        ld1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v4.2d, v25.2d, v27.2d
         trn2	v5.2d, v25.2d, v27.2d
         trn1	v6.2d, v26.2d, v28.2d
         trn2	v7.2d, v26.2d, v28.2d
         ldp	q25, q26, [x0, #0x40]
-        ldp	q27, q28, [x4, #0x40]
+        ld1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v8.2d, v25.2d, v27.2d
         trn2	v9.2d, v25.2d, v27.2d
         trn1	v10.2d, v26.2d, v28.2d
         trn2	v11.2d, v26.2d, v28.2d
         ldp	q25, q26, [x0, #0x60]
-        ldp	q27, q28, [x4, #0x60]
+        ld1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v12.2d, v25.2d, v27.2d
         trn2	v13.2d, v25.2d, v27.2d
         trn1	v14.2d, v26.2d, v28.2d
         trn2	v15.2d, v26.2d, v28.2d
         ldp	q25, q26, [x0, #0x80]
-        ldp	q27, q28, [x4, #0x80]
+        ld1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v16.2d, v25.2d, v27.2d
         trn2	v17.2d, v25.2d, v27.2d
         trn1	v18.2d, v26.2d, v28.2d
         trn2	v19.2d, v26.2d, v28.2d
         ldp	q25, q26, [x0, #0xa0]
-        ldp	q27, q28, [x4, #0xa0]
+        ld1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v20.2d, v25.2d, v27.2d
         trn2	v21.2d, v25.2d, v27.2d
         trn1	v22.2d, v26.2d, v28.2d
         trn2	v23.2d, v26.2d, v28.2d
         ldr	d25, [x0, #0xc0]
-        ldr	d27, [x4, #0xc0]
+        ldr	d27, [x4]
         trn1	v24.2d, v25.2d, v27.2d
         add	x0, x0, #0x190
         ldp	x1, x6, [x0]
@@ -979,40 +979,40 @@ Lkeccak_f1600_x4_scalar_v8a_hybrid_done:
         stp	q25, q26, [x0]
         trn2	v27.2d, v0.2d, v1.2d
         trn2	v28.2d, v2.2d, v3.2d
-        stp	q27, q28, [x4]
+        st1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v25.2d, v4.2d, v5.2d
         trn1	v26.2d, v6.2d, v7.2d
         stp	q25, q26, [x0, #0x20]
         trn2	v27.2d, v4.2d, v5.2d
         trn2	v28.2d, v6.2d, v7.2d
-        stp	q27, q28, [x4, #0x20]
+        st1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v25.2d, v8.2d, v9.2d
         trn1	v26.2d, v10.2d, v11.2d
         stp	q25, q26, [x0, #0x40]
         trn2	v27.2d, v8.2d, v9.2d
         trn2	v28.2d, v10.2d, v11.2d
-        stp	q27, q28, [x4, #0x40]
+        st1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v25.2d, v12.2d, v13.2d
         trn1	v26.2d, v14.2d, v15.2d
         stp	q25, q26, [x0, #0x60]
         trn2	v27.2d, v12.2d, v13.2d
         trn2	v28.2d, v14.2d, v15.2d
-        stp	q27, q28, [x4, #0x60]
+        st1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v25.2d, v16.2d, v17.2d
         trn1	v26.2d, v18.2d, v19.2d
         stp	q25, q26, [x0, #0x80]
         trn2	v27.2d, v16.2d, v17.2d
         trn2	v28.2d, v18.2d, v19.2d
-        stp	q27, q28, [x4, #0x80]
+        st1	{v27.2d, v28.2d}, [x4], #0x20
         trn1	v25.2d, v20.2d, v21.2d
         trn1	v26.2d, v22.2d, v23.2d
         stp	q25, q26, [x0, #0xa0]
         trn2	v27.2d, v20.2d, v21.2d
         trn2	v28.2d, v22.2d, v23.2d
-        stp	q27, q28, [x4, #0xa0]
+        st1	{v27.2d, v28.2d}, [x4], #0x20
         str	d24, [x0, #0xc0]
         trn2	v25.2d, v24.2d, v24.2d
-        str	d25, [x4, #0xc0]
+        str	d25, [x4]
         ldp	d14, d15, [sp, #0xc0]
         ldp	d12, d13, [sp, #0xb0]
         ldp	d10, d11, [sp, #0xa0]

--- a/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
@@ -33,9 +33,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov	x9, #0x10               // =16
 
 Lpolyz_unpack_19_loop:
-        ldr	q1, [x1, #0x10]
-        ldr	d2, [x1, #0x20]
-        ldr	q0, [x1], #0x28
+        ld1	{v0.2d, v1.2d}, [x1], #0x20
+        ldr	d2, [x1], #0x08
         tbl	v4.16b, { v0.16b }, v24.16b
         tbl	v5.16b, { v0.16b, v1.16b }, v25.16b
         tbl	v6.16b, { v1.16b }, v26.16b

--- a/mldsa/src/native/aarch64/src/rej_uniform_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_asm.S
@@ -104,13 +104,13 @@ Lrej_uniform_loop48:
         tbl	v17.16b, { v17.16b }, v25.16b
         tbl	v18.16b, { v18.16b }, v26.16b
         tbl	v19.16b, { v19.16b }, v27.16b
-        str	q16, [x7]
+        st1	{v16.4s}, [x7]
         add	x7, x7, x12, lsl #2
-        str	q17, [x7]
+        st1	{v17.4s}, [x7]
         add	x7, x7, x13, lsl #2
-        str	q18, [x7]
+        st1	{v18.4s}, [x7]
         add	x7, x7, x14, lsl #2
-        str	q19, [x7]
+        st1	{v19.4s}, [x7]
         add	x7, x7, x15, lsl #2
         add	x12, x12, x13
         add	x14, x14, x15


### PR DESCRIPTION
On a bare metal system with the MMU disabled or alignment checking enabled, accessing memory using an unaligned address causes an alignment fault exception.  By changing the memory accesses to smaller sizes that matches the alignment of the addresses, the code can run without depending on the CPU handling and accepting unaligned addresses.

Signed-off-by: Anders Sonmark <Anders.Sonmark@axis.com>