### PR TITLE
ACVP: Correct max message length from 65536 bytes to 65536 bits (8192 bytes)

### DIFF
--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -218,7 +218,7 @@ def run_sigGen_test(tg, tc):
     elif tg["signatureInterface"] == "external":
         assert "hashAlg" not in tc or tc["hashAlg"] == "none"
         assert len(tc["context"]) <= 2 * 255
-        assert len(tc["message"]) <= 2 * 65536
+        assert len(tc["message"]) <= 2 * 8192
 
         target = "sigGenDeterministic" if is_deterministic else "sigGen"
         acvp_call = exec_prefix + [
@@ -236,7 +236,7 @@ def run_sigGen_test(tg, tc):
             assert len(tc["mu"]) == 2 * 64
             msg = tc["mu"]
         else:
-            assert len(tc["message"]) <= 2 * 65536
+            assert len(tc["message"]) <= 2 * 8192
             msg = tc["message"]
 
         target = "sigGenInternalDeterministic" if is_deterministic else "sigGenInternal"
@@ -298,7 +298,7 @@ def run_sigVer_test(tg, tc):
     elif tg["signatureInterface"] == "external":
         assert "hashAlg" not in tc or tc["hashAlg"] == "none"
         assert len(tc["context"]) <= 2 * 255
-        assert len(tc["message"]) <= 2 * 65536
+        assert len(tc["message"]) <= 2 * 8192
 
         acvp_call = exec_prefix + [
             acvp_bin,
@@ -316,7 +316,7 @@ def run_sigVer_test(tg, tc):
             assert len(tc["mu"]) == 2 * 64
             msg = tc["mu"]
         else:
-            assert len(tc["message"]) <= 2 * 65536
+            assert len(tc["message"]) <= 2 * 8192
             msg = tc["message"]
 
         acvp_call = exec_prefix + [

--- a/test/acvp/acvp_mldsa.c
+++ b/test/acvp/acvp_mldsa.c
@@ -62,7 +62,7 @@
 
 
 /* maximum message length used in the ACVP tests */
-#define MAX_MSG_LENGTH 65536
+#define MAX_MSG_LENGTH 8192
 /* maximum context length according to FIPS-204 */
 #define MAX_CTX_LENGTH 255
 


### PR DESCRIPTION
The ACVP specification (https://pages.nist.gov/ACVP/draft-celi-acvp-ml-dsa.html) says that the message length is at most 65536 bits (8192 bytes). We incorrectly used 65536 bytes which results in excessive memory allocation in acvp_mldsa.c  which can be problematic on devices with limited stack/memory. This commit corrects the maximum length.

- Hoisted out from #861 