### PR TITLE
Mark all non-static declarations as internal or external

### DIFF
--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -192,64 +192,75 @@ __contract__(
   return pos;
 }
 
+MLD_INTERNAL_API
 void mld_shake128_init(mld_shake128ctx *state)
 {
   keccak_init(state->s);
   state->pos = 0;
 }
 
+MLD_INTERNAL_API
 void mld_shake128_absorb(mld_shake128ctx *state, const uint8_t *in,
                          size_t inlen)
 {
   state->pos = keccak_absorb(state->s, state->pos, SHAKE128_RATE, in, inlen);
 }
 
+MLD_INTERNAL_API
 void mld_shake128_finalize(mld_shake128ctx *state)
 {
   keccak_finalize(state->s, state->pos, SHAKE128_RATE, 0x1F);
   state->pos = SHAKE128_RATE;
 }
 
+MLD_INTERNAL_API
 void mld_shake128_squeeze(uint8_t *out, size_t outlen, mld_shake128ctx *state)
 {
   state->pos = keccak_squeeze(out, outlen, state->s, state->pos, SHAKE128_RATE);
 }
 
+MLD_INTERNAL_API
 void mld_shake128_release(mld_shake128ctx *state)
 {
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
   mld_zeroize(state, sizeof(mld_shake128ctx));
 }
 
+MLD_INTERNAL_API
 void mld_shake256_init(mld_shake256ctx *state)
 {
   keccak_init(state->s);
   state->pos = 0;
 }
 
+MLD_INTERNAL_API
 void mld_shake256_absorb(mld_shake256ctx *state, const uint8_t *in,
                          size_t inlen)
 {
   state->pos = keccak_absorb(state->s, state->pos, SHAKE256_RATE, in, inlen);
 }
 
+MLD_INTERNAL_API
 void mld_shake256_finalize(mld_shake256ctx *state)
 {
   keccak_finalize(state->s, state->pos, SHAKE256_RATE, 0x1F);
   state->pos = SHAKE256_RATE;
 }
 
+MLD_INTERNAL_API
 void mld_shake256_squeeze(uint8_t *out, size_t outlen, mld_shake256ctx *state)
 {
   state->pos = keccak_squeeze(out, outlen, state->s, state->pos, SHAKE256_RATE);
 }
 
+MLD_INTERNAL_API
 void mld_shake256_release(mld_shake256ctx *state)
 {
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
   mld_zeroize(state, sizeof(mld_shake256ctx));
 }
 
+MLD_INTERNAL_API
 void mld_shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
 {
   mld_shake256ctx state;

--- a/mldsa/src/fips202/fips202.h
+++ b/mldsa/src/fips202/fips202.h
@@ -39,6 +39,7 @@ typedef struct
  *
  * Arguments:   - mld_shake128ctx *state: pointer to (uninitialized) state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake128_init(mld_shake128ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake128ctx)))
@@ -57,6 +58,7 @@ __contract__(
  *              - const uint8_t *in: pointer to input to be absorbed into s
  *              - size_t inlen: length of input in bytes
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake128_absorb(mld_shake128ctx *state, const uint8_t *in,
                          size_t inlen)
 __contract__(
@@ -76,6 +78,7 @@ __contract__(
  *
  * Arguments:   - mld_shake128ctx *state: pointer to state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake128_finalize(mld_shake128ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake128ctx)))
@@ -96,6 +99,7 @@ __contract__(
  *output)
  *              - mld_shake128ctx *s: pointer to input/output state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake128_squeeze(uint8_t *out, size_t outlen, mld_shake128ctx *state)
 __contract__(
   requires(outlen <= 8 * SHAKE128_RATE /* somewhat arbitrary bound */)
@@ -115,6 +119,7 @@ __contract__(
  *
  * Arguments:   - mld_shake128ctx *state: pointer to state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake128_release(mld_shake128ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake128ctx)))
@@ -129,6 +134,7 @@ __contract__(
  *
  * Arguments:   - mld_shake256ctx *state: pointer to (uninitialized) state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake256_init(mld_shake256ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake256ctx)))
@@ -147,6 +153,7 @@ __contract__(
  *              - const uint8_t *in: pointer to input to be absorbed into s
  *              - size_t inlen: length of input in bytes
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake256_absorb(mld_shake256ctx *state, const uint8_t *in,
                          size_t inlen)
 __contract__(
@@ -166,6 +173,7 @@ __contract__(
  *
  * Arguments:   - mld_shake256ctx *state: pointer to state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake256_finalize(mld_shake256ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake256ctx)))
@@ -186,6 +194,7 @@ __contract__(
  *output)
  *              - mld_shake256ctx *s: pointer to input/output state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake256_squeeze(uint8_t *out, size_t outlen, mld_shake256ctx *state)
 __contract__(
   requires(outlen <= 8 * SHAKE256_RATE /* somewhat arbitrary bound */)
@@ -205,6 +214,7 @@ __contract__(
  *
  * Arguments:   - mld_shake256ctx *state: pointer to state
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake256_release(mld_shake256ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(mld_shake256ctx)))
@@ -222,6 +232,7 @@ __contract__(
  *              - const uint8_t *in: pointer to input
  *              - size_t inlen: length of input in bytes
  **************************************************/
+MLD_INTERNAL_API
 void mld_shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
 __contract__(
   requires(inlen <= MLD_MAX_BUFFER_SIZE)

--- a/mldsa/src/fips202/fips202x4.c
+++ b/mldsa/src/fips202/fips202x4.c
@@ -14,7 +14,8 @@
  */
 
 #include "../common.h"
-#if !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
+#if !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED) && \
+    !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 
 #include <string.h>
 #include "../ct.h"
@@ -117,6 +118,8 @@ __contract__(
   }
 }
 
+#if !defined(MLD_CONFIG_REDUCE_RAM)
+MLD_INTERNAL_API
 void mld_shake128x4_absorb_once(mld_shake128x4ctx *state, const uint8_t *in0,
                                 const uint8_t *in1, const uint8_t *in2,
                                 const uint8_t *in3, size_t inlen)
@@ -126,6 +129,7 @@ void mld_shake128x4_absorb_once(mld_shake128x4ctx *state, const uint8_t *in0,
                             inlen, 0x1F);
 }
 
+MLD_INTERNAL_API
 void mld_shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                                   uint8_t *out3, size_t nblocks,
                                   mld_shake128x4ctx *state)
@@ -134,14 +138,17 @@ void mld_shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                               SHAKE128_RATE);
 }
 
+MLD_INTERNAL_API
 void mld_shake128x4_init(mld_shake128x4ctx *state) { (void)state; }
+MLD_INTERNAL_API
 void mld_shake128x4_release(mld_shake128x4ctx *state)
 {
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
   mld_zeroize(state, sizeof(mld_shake128x4ctx));
 }
+#endif /* !MLD_CONFIG_REDUCE_RAM */
 
-
+MLD_INTERNAL_API
 void mld_shake256x4_absorb_once(mld_shake256x4ctx *state, const uint8_t *in0,
                                 const uint8_t *in1, const uint8_t *in2,
                                 const uint8_t *in3, size_t inlen)
@@ -151,6 +158,7 @@ void mld_shake256x4_absorb_once(mld_shake256x4ctx *state, const uint8_t *in0,
                             inlen, 0x1F);
 }
 
+MLD_INTERNAL_API
 void mld_shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                                   uint8_t *out3, size_t nblocks,
                                   mld_shake256x4ctx *state)
@@ -159,11 +167,14 @@ void mld_shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                               SHAKE256_RATE);
 }
 
+MLD_INTERNAL_API
 void mld_shake256x4_init(mld_shake256x4ctx *state) { (void)state; }
+MLD_INTERNAL_API
 void mld_shake256x4_release(mld_shake256x4ctx *state)
 {
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
   mld_zeroize(state, sizeof(mld_shake256x4ctx));
 }
 
-#endif /* !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+#endif /* !MLD_CONFIG_MULTILEVEL_NO_SHARED && !MLD_CONFIG_SERIAL_FIPS202_ONLY \
+        */

--- a/mldsa/src/fips202/fips202x4.h
+++ b/mldsa/src/fips202/fips202x4.h
@@ -6,12 +6,14 @@
 #ifndef MLD_FIPS202_FIPS202X4_H
 #define MLD_FIPS202_FIPS202X4_H
 
+#include "../common.h"
+
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
+
 #include <stddef.h>
 #include <stdint.h>
 
 #include "../cbmc.h"
-#include "../common.h"
-
 #include "fips202.h"
 #include "keccakf1600.h"
 
@@ -26,7 +28,9 @@ typedef struct
   uint64_t ctx[MLD_KECCAK_LANES * MLD_KECCAK_WAY];
 } mld_shake256x4ctx;
 
+#if !defined(MLD_CONFIG_REDUCE_RAM)
 #define mld_shake128x4_absorb_once MLD_NAMESPACE(shake128x4_absorb_once)
+MLD_INTERNAL_API
 void mld_shake128x4_absorb_once(mld_shake128x4ctx *state, const uint8_t *in0,
                                 const uint8_t *in1, const uint8_t *in2,
                                 const uint8_t *in3, size_t inlen)
@@ -41,6 +45,7 @@ __contract__(
 );
 
 #define mld_shake128x4_squeezeblocks MLD_NAMESPACE(shake128x4_squeezeblocks)
+MLD_INTERNAL_API
 void mld_shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                                   uint8_t *out3, size_t nblocks,
                                   mld_shake128x4ctx *state)
@@ -59,13 +64,16 @@ __contract__(
 );
 
 #define mld_shake128x4_init MLD_NAMESPACE(shake128x4_init)
+MLD_INTERNAL_API
 void mld_shake128x4_init(mld_shake128x4ctx *state);
 
 #define mld_shake128x4_release MLD_NAMESPACE(shake128x4_release)
+MLD_INTERNAL_API
 void mld_shake128x4_release(mld_shake128x4ctx *state);
-
+#endif /* !MLD_CONFIG_REDUCE_RAM */
 
 #define mld_shake256x4_absorb_once MLD_NAMESPACE(shake256x4_absorb_once)
+MLD_INTERNAL_API
 void mld_shake256x4_absorb_once(mld_shake256x4ctx *state, const uint8_t *in0,
                                 const uint8_t *in1, const uint8_t *in2,
                                 const uint8_t *in3, size_t inlen)
@@ -80,6 +88,7 @@ __contract__(
 );
 
 #define mld_shake256x4_squeezeblocks MLD_NAMESPACE(shake256x4_squeezeblocks)
+MLD_INTERNAL_API
 void mld_shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                                   uint8_t *out3, size_t nblocks,
                                   mld_shake256x4ctx *state)
@@ -98,10 +107,12 @@ __contract__(
 );
 
 #define mld_shake256x4_init MLD_NAMESPACE(shake256x4_init)
+MLD_INTERNAL_API
 void mld_shake256x4_init(mld_shake256x4ctx *state);
 
 #define mld_shake256x4_release MLD_NAMESPACE(shake256x4_release)
+MLD_INTERNAL_API
 void mld_shake256x4_release(mld_shake256x4ctx *state);
 
-
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
 #endif /* !MLD_FIPS202_FIPS202X4_H */

--- a/mldsa/src/fips202/keccakf1600.c
+++ b/mldsa/src/fips202/keccakf1600.c
@@ -36,6 +36,7 @@
 #define MLD_KECCAK_NROUNDS 24
 #define MLD_KECCAK_ROL(a, offset) ((a << offset) ^ (a >> (64 - offset)))
 
+MLD_INTERNAL_API
 void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
                                    unsigned offset, unsigned length)
 {
@@ -57,6 +58,7 @@ void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
 #endif /* !MLD_SYS_LITTLE_ENDIAN */
 }
 
+MLD_INTERNAL_API
 void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
                                unsigned offset, unsigned length)
 {
@@ -79,6 +81,7 @@ void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
 #endif /* !MLD_SYS_LITTLE_ENDIAN */
 }
 
+MLD_INTERNAL_API
 void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
                                      unsigned char *data1, unsigned char *data2,
                                      unsigned char *data3, unsigned offset,
@@ -94,6 +97,7 @@ void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
                                 length);
 }
 
+MLD_INTERNAL_API
 void mld_keccakf1600x4_xor_bytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
@@ -110,6 +114,7 @@ void mld_keccakf1600x4_xor_bytes(uint64_t *state, const unsigned char *data0,
                             length);
 }
 
+MLD_INTERNAL_API
 void mld_keccakf1600x4_permute(uint64_t *state)
 {
 #if defined(MLD_USE_FIPS202_X4_NATIVE)
@@ -405,6 +410,7 @@ void mld_keccakf1600_permute_c(uint64_t *state)
   state[24] = Asu;
 }
 
+MLD_INTERNAL_API
 void mld_keccakf1600_permute(uint64_t *state)
 {
 #if defined(MLD_USE_FIPS202_X1_NATIVE)

--- a/mldsa/src/fips202/keccakf1600.h
+++ b/mldsa/src/fips202/keccakf1600.h
@@ -21,6 +21,7 @@
  */
 
 #define mld_keccakf1600_extract_bytes MLD_NAMESPACE(keccakf1600_extract_bytes)
+MLD_INTERNAL_API
 void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
                                    unsigned offset, unsigned length)
 __contract__(
@@ -32,6 +33,7 @@ __contract__(
 );
 
 #define mld_keccakf1600_xor_bytes MLD_NAMESPACE(keccakf1600_xor_bytes)
+MLD_INTERNAL_API
 void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
                                unsigned offset, unsigned length)
 __contract__(
@@ -44,6 +46,7 @@ __contract__(
 
 #define mld_keccakf1600x4_extract_bytes \
   MLD_NAMESPACE(keccakf1600x4_extract_bytes)
+MLD_INTERNAL_API
 void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
                                      unsigned char *data1, unsigned char *data2,
                                      unsigned char *data3, unsigned offset,
@@ -63,6 +66,7 @@ __contract__(
 );
 
 #define mld_keccakf1600x4_xor_bytes MLD_NAMESPACE(keccakf1600x4_xor_bytes)
+MLD_INTERNAL_API
 void mld_keccakf1600x4_xor_bytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
@@ -84,6 +88,7 @@ __contract__(
 );
 
 #define mld_keccakf1600x4_permute MLD_NAMESPACE(keccakf1600x4_permute)
+MLD_INTERNAL_API
 void mld_keccakf1600x4_permute(uint64_t *state)
 __contract__(
     requires(memory_no_alias(state, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY))
@@ -91,6 +96,7 @@ __contract__(
 );
 
 #define mld_keccakf1600_permute MLD_NAMESPACE(keccakf1600_permute)
+MLD_INTERNAL_API
 void mld_keccakf1600_permute(uint64_t *state)
 __contract__(
     requires(memory_no_alias(state, sizeof(uint64_t) * MLD_KECCAK_LANES))


### PR DESCRIPTION
This commit ensures that all non-static, non-assembly symbols declared by mldsa-native are explicitly marked as internal or external via the MLD_CONFIG_INTERNAL_API_QUALIFIER / MLD_CONFIG_EXTERNAL_API_QUALIFIER configuration options.

In particular, when mldsa-native is being built in a monobuild and MLD_CONFIG_INTERNAL_API_QUALIFIER set to `static`, only the FIPS204 API should be of external linkage.
If mldsa-native is being built in a monobuild, directly included into another compilation unit, and both MLD_CONFIG_INTERNAL_API_QUALIFIER and MLD_CONFIG_EXTERNAL_API_QUALIFIER set to `static`, no non-assembly symbols should be generated.

* Part of #936 