### PR TITLE
native: Give single assembly unit a unique name

### DIFF
--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native.S
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native.S
@@ -1,1 +1,0 @@
-../../../mldsa/mldsa_native.S

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_asm.S
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_asm.S
@@ -1,0 +1,1 @@
+../../../mldsa/mldsa_native_asm.S

--- a/examples/monolithic_build_multilevel_native/Makefile
+++ b/examples/monolithic_build_multilevel_native/Makefile
@@ -57,7 +57,7 @@ endif
 #
 # Here, the monolithic C file for mldsa-native is directly included in main.c,
 # However, we still need to incldue the monolithic assembly file.
-MLD_SOURCE_ASM = mldsa_native/mldsa_native.S
+MLD_SOURCE_ASM = mldsa_native/mldsa_native_asm.S
 
 INC=-Imldsa_native/ -I./
 

--- a/examples/monolithic_build_multilevel_native/README.md
+++ b/examples/monolithic_build_multilevel_native/README.md
@@ -16,7 +16,7 @@ Use this approach when:
 
 1. Source tree [mldsa_native/*](mldsa_native), including top-level compilation unit
    [mldsa_native.c](mldsa_native/mldsa_native.c) (gathering all C sources),
-   [mldsa_native.S](mldsa_native/mldsa_native.S) (gathering all assembly sources),
+   [mldsa_native_asm.S](mldsa_native/mldsa_native_asm.S) (gathering all assembly sources),
    and the mldsa-native API [mldsa_native.h](mldsa_native/mldsa_native.h).
 2. Manually provided wrapper file [mldsa_native_all.c](mldsa_native_all.c),
    including `mldsa_native.c` three times (in this example, we don't use a
@@ -67,7 +67,7 @@ The application [main.c](main.c) embeds the wrapper and imports constants:
 
 ## Notes
 
-- Both `mldsa_native_all.c` and `mldsa_native.S` must be compiled and linked
+- Both `mldsa_native_all.c` and `mldsa_native_asm.S` must be compiled and linked
 - `MLD_CONFIG_MULTILEVEL_WITH_SHARED` must be set for exactly ONE level
 - `MLD_CONFIG_CONSTANTS_ONLY` imports size constants without function declarations
 - Native backends are auto-selected based on target architecture

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native.S
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native.S
@@ -1,1 +1,0 @@
-../../../mldsa/mldsa_native.S

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_asm.S
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_asm.S
@@ -1,0 +1,1 @@
+../../../mldsa/mldsa_native_asm.S

--- a/examples/monolithic_build_native/Makefile
+++ b/examples/monolithic_build_native/Makefile
@@ -58,7 +58,7 @@ Q ?= @
 #
 # Here, we use just a single C and assembly unit.
 
-MLD_SOURCE=mldsa_native/mldsa_native.c mldsa_native/mldsa_native.S
+MLD_SOURCE=mldsa_native/mldsa_native.c mldsa_native/mldsa_native_asm.S
 
 INC=-Imldsa_native/ -I./
 
@@ -99,7 +99,7 @@ $(LIB44_FULL): $(MLD_SOURCE)
 	$(Q)echo "$@"
 	$(Q)[ -d $(@) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=44 $(INC) mldsa_native/mldsa_native.c -o $(BUILD_DIR)/mldsa_native44.c.o
-	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=44 $(INC) mldsa_native/mldsa_native.S -o $(BUILD_DIR)/mldsa_native44.S.o
+	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=44 $(INC) mldsa_native/mldsa_native_asm.S -o $(BUILD_DIR)/mldsa_native44.S.o
 	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mldsa_native44.c.o $(BUILD_DIR)/mldsa_native44.S.o
 	$(Q)strip -S $@
 
@@ -107,7 +107,7 @@ $(LIB65_FULL): $(MLD_SOURCE)
 	$(Q)echo "$@"
 	$(Q)[ -d $(@) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=65 $(INC) mldsa_native/mldsa_native.c -o $(BUILD_DIR)/mldsa_native65.c.o
-	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=65 $(INC) mldsa_native/mldsa_native.S -o $(BUILD_DIR)/mldsa_native65.S.o
+	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=65 $(INC) mldsa_native/mldsa_native_asm.S -o $(BUILD_DIR)/mldsa_native65.S.o
 	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mldsa_native65.c.o $(BUILD_DIR)/mldsa_native65.S.o
 	$(Q)strip -S $@
 
@@ -115,7 +115,7 @@ $(LIB87_FULL): $(MLD_SOURCE)
 	$(Q)echo "$@"
 	$(Q)[ -d $(@) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=87 $(INC) mldsa_native/mldsa_native.c -o $(BUILD_DIR)/mldsa_native87.c.o
-	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=87 $(INC) mldsa_native/mldsa_native.S -o $(BUILD_DIR)/mldsa_native87.S.o
+	$(Q)$(CC) -c $(CFLAGS) -DMLD_CONFIG_PARAMETER_SET=87 $(INC) mldsa_native/mldsa_native_asm.S -o $(BUILD_DIR)/mldsa_native87.S.o
 	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mldsa_native87.c.o $(BUILD_DIR)/mldsa_native87.S.o
 	$(Q)strip -S $@
 

--- a/examples/monolithic_build_native/README.md
+++ b/examples/monolithic_build_native/README.md
@@ -3,7 +3,7 @@
 # Monolithic Build (Native Backend)
 
 This directory contains a minimal example for building mldsa-native as a single compilation unit
-with native assembly backends, using the auto-generated `mldsa_native.c` and `mldsa_native.S` files.
+with native assembly backends, using the auto-generated `mldsa_native.c` and `mldsa_native_asm.S` files.
 
 ## Use Case
 
@@ -15,7 +15,7 @@ Use this approach when:
 
 1. Source tree [mldsa_native/*](mldsa_native), including top-level compilation unit
    [mldsa_native.c](mldsa_native/mldsa_native.c) (gathering all C sources),
-   [mldsa_native.S](mldsa_native/mldsa_native.S) (gathering all assembly sources),
+   [mldsa_native_asm.S](mldsa_native/mldsa_native_asm.S) (gathering all assembly sources),
    and the mldsa-native API [mldsa_native.h](mldsa_native/mldsa_native.h).
 2. A secure random number generator implementing [`randombytes.h`](../../mldsa/src/randombytes.h)
 3. Your application source code
@@ -30,7 +30,7 @@ The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.
 
 ## Notes
 
-- Both `mldsa_native.c` and `mldsa_native.S` must be compiled and linked
+- Both `mldsa_native.c` and `mldsa_native_asm.S` must be compiled and linked
 - Native backends are auto-selected based on target architecture
 - On unsupported platforms, the C backend is used automatically
 

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native.S
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native.S
@@ -1,1 +1,0 @@
-../../../mldsa/mldsa_native.S

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_asm.S
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_asm.S
@@ -1,0 +1,1 @@
+../../../mldsa/mldsa_native_asm.S

--- a/mldsa/mldsa_native_asm.S
+++ b/mldsa/mldsa_native_asm.S
@@ -52,7 +52,7 @@
  *
  * Example:
  * ```bash
- * unifdef -UMLD_CONFIG_USE_NATIVE_BACKEND_ARITH mldsa_native.S
+ * unifdef -UMLD_CONFIG_USE_NATIVE_BACKEND_ARITH mldsa_native_asm.S
  * ```
  */
 

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1746,7 +1746,7 @@ def gen_monolithic_asm_file():
         yield " *"
         yield " * Example:"
         yield " * ```bash"
-        yield " * unifdef -UMLD_CONFIG_USE_NATIVE_BACKEND_ARITH mldsa_native.S"
+        yield " * unifdef -UMLD_CONFIG_USE_NATIVE_BACKEND_ARITH mldsa_native_asm.S"
         yield " * ```"
         yield " */"
         yield ""
@@ -1791,7 +1791,7 @@ def gen_monolithic_asm_file():
         ]
         yield from gen_macro_undefs(extra_notes=extra)
 
-    update_file("mldsa/mldsa_native.S", "\n".join(gen()), force_format=True)
+    update_file("mldsa/mldsa_native_asm.S", "\n".join(gen()), force_format=True)
 
 
 def get_config_options():


### PR DESCRIPTION
Give the single compilation units unique names by renaming the assembly file.  This removes the need for having unique names for object files based on the source language and allows simpler rules, for example "%.o: %.c" and "%.o: %.S".