### PR TITLE
Lint: Ignore unavailable cr.yp.to and mceliece.org links

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Config for markdown-link-check. Domains below are often temporarily unavailable but the links are valid.",
+  "ignorePatterns": [
+    {
+      "pattern": "^https://cr\\.yp\\.to"
+    },
+    {
+      "pattern": "^https://kyberslash\\.cr\\.yp\\.to"
+    },
+    {
+      "pattern": "^https://lib\\.mceliece\\.org"
+    }
+  ]
+}

--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Check markdown links
       run: |
         npm install -g markdown-link-check@3.14.2
-        find . -name '*.md' -print0 | xargs -0 -P16 -n1 markdown-link-check -q
+        find . -name '*.md' -print0 | xargs -0 -P16 -n1 markdown-link-check -q -c .github/mlc_config.json


### PR DESCRIPTION
DJB's domains are often unreachable causing our markdown link lint jobs to fail. This commit changes the CI job to skip those domains.