### PR TITLE
Guarding utility functions in test_unit.c with attribute unused.

### DIFF
--- a/test/src/test_unit.c
+++ b/test/src/test_unit.c
@@ -113,6 +113,7 @@ static int compare_u64_arrays(const uint64_t *a, const uint64_t *b,
     defined(MLD_USE_NATIVE_POLYZ_UNPACK_19) ||                      \
     defined(MLD_USE_FIPS202_X1_NATIVE) || defined(MLD_USE_FIPS202_X4_NATIVE)
 
+#ifdef MLD_USE_NATIVE_NTT
 /* Backend unit test helper functions */
 static void print_i32_array(const char *label, const int32_t *array, size_t len)
 {
@@ -140,12 +141,12 @@ static void print_i32_array(const char *label, const int32_t *array, size_t len)
   }
 }
 
-__attribute__((unused)) static void generate_i32_array_zeros(int32_t *data, size_t len)
+static void generate_i32_array_zeros(int32_t *data, size_t len)
 {
   memset(data, 0, len * sizeof(int32_t));
 }
 
-__attribute__((unused)) static void generate_i32_array_single(int32_t *data, size_t len, size_t pos,
+static void generate_i32_array_single(int32_t *data, size_t len, size_t pos,
                                       int32_t value)
 {
   memset(data, 0, len * sizeof(int32_t));
@@ -157,7 +158,7 @@ __attribute__((unused)) static void generate_i32_array_single(int32_t *data, siz
  *
  * The lower bound is inclusive, the upper bound exclusive, matching
  * the CBMC assertions in the code base. */
-__attribute__((unused)) static void generate_i32_array_ranged(int32_t *data, size_t len, int min_incl,
+static void generate_i32_array_ranged(int32_t *data, size_t len, int min_incl,
                                       int max_excl)
 {
   size_t i;
@@ -170,7 +171,7 @@ __attribute__((unused)) static void generate_i32_array_ranged(int32_t *data, siz
   }
 }
 
-__attribute__((unused)) static int compare_i32_arrays(const int32_t *a, const int32_t *b, unsigned len,
+static int compare_i32_arrays(const int32_t *a, const int32_t *b, unsigned len,
                               const char *test_name, const int32_t *input)
 {
   unsigned i;
@@ -194,7 +195,6 @@ __attribute__((unused)) static int compare_i32_arrays(const int32_t *a, const in
   return 1;
 }
 
-#ifdef MLD_USE_NATIVE_NTT
 static int test_ntt_core(const int32_t *input, const char *test_name)
 {
   mld_poly test_poly, ref_poly;


### PR DESCRIPTION
Fixing #969

Some static inline utility functions from test_unit.c are only used for some target, in particular target for which a native NTT implementation exists. For other targets, the build may fail because the warning of unused functions get promoted to an error.


I am not sure this is the best way to fix this, as another way would be to move the static function definitions inside the guard of the macro 
```
#idef MLD_USE_NATIVE_NTT
```
