### PR TITLE
CI: Use availability-zones-config for EC2 runner workflows

### DIFF
--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -116,10 +116,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-094d73eb42eb6bf5b
-          security-group-id: sg-0282706dbc92a1579
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-094d73eb42eb6bf5b","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-04a982f6584de8063","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-077637f396b264f82","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-00e89932da1332c35","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0262f9d5f938f38bc","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-06e0645f1b6520c42","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c726ece1c22f45d9","securityGroupId":"sg-0282706dbc92a1579"}]
   bench_nix:
     name: Bench (nix)
     permissions:

--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -108,10 +108,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-094d73eb42eb6bf5b
-          security-group-id: sg-0282706dbc92a1579
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-094d73eb42eb6bf5b","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-04a982f6584de8063","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-077637f396b264f82","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-00e89932da1332c35","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0262f9d5f938f38bc","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-06e0645f1b6520c42","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c726ece1c22f45d9","securityGroupId":"sg-0282706dbc92a1579"}]
       - name: Start EC2 runner (wait before retry)
         if: steps.start-ec2-runner-first.outcome == 'failure'
         shell: bash
@@ -125,10 +130,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-094d73eb42eb6bf5b
-          security-group-id: sg-0282706dbc92a1579
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-094d73eb42eb6bf5b","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-04a982f6584de8063","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-077637f396b264f82","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-00e89932da1332c35","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0262f9d5f938f38bc","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-06e0645f1b6520c42","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c726ece1c22f45d9","securityGroupId":"sg-0282706dbc92a1579"}]
       - name: Remember runner
         id: remember-runner
         shell: bash

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -115,11 +115,16 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
-          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-094d73eb42eb6bf5b
-          security-group-id: sg-0282706dbc92a1579
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-094d73eb42eb6bf5b","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-04a982f6584de8063","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-077637f396b264f82","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-00e89932da1332c35","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0262f9d5f938f38bc","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-06e0645f1b6520c42","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c726ece1c22f45d9","securityGroupId":"sg-0282706dbc92a1579"}]
       - name: Start EC2c runner (wait before retry)
         if: steps.start-ec2-runner-first.outcome == 'failure'
         shell: bash
@@ -133,11 +138,16 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
-          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-094d73eb42eb6bf5b
-          security-group-id: sg-0282706dbc92a1579
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-094d73eb42eb6bf5b","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-04a982f6584de8063","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-077637f396b264f82","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-00e89932da1332c35","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0262f9d5f938f38bc","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-06e0645f1b6520c42","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c726ece1c22f45d9","securityGroupId":"sg-0282706dbc92a1579"}]
       - name: Remember runner
         id: remember-runner
         shell: bash

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -40,11 +40,16 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ env.AMI_UBUNTU_22_04_X86_64 }}
           ec2-instance-type: c7i.2xlarge
           ec2-volume-size: 32
-          subnet-id: subnet-094d73eb42eb6bf5b
-          security-group-id: sg-0282706dbc92a1579
+          availability-zones-config: >-
+            [{"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-094d73eb42eb6bf5b","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-04a982f6584de8063","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-077637f396b264f82","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-00e89932da1332c35","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0262f9d5f938f38bc","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-06e0645f1b6520c42","securityGroupId":"sg-0282706dbc92a1579"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0c726ece1c22f45d9","securityGroupId":"sg-0282706dbc92a1579"}]
 
   opentitan_build:
     name: OpenTitan ML-DSA Build Test


### PR DESCRIPTION
The hardcoded subnet-id pinned all EC2 instances to a single
availability zone, causing failures when that AZ lacked capacity for
the requested instance type. Replace subnet-id and security-group-id
with availability-zones-config listing all subnets in the VPC, so the
runner action automatically tries other AZs when one lacks capacity.