### PR TITLE
CI: Disable benchmarking CI on self hosted boards

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,15 +29,15 @@ jobs:
       fail-fast: true
       matrix:
        target:
-        - system: rpi4
-          name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
-          bench_pmu: PMU
-          archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
-          cflags: "-flto -DMLD_FORCE_AARCH64"
-          ldflags: "-flto"
-          bench_extra_args: ""
-          nix_shell: bench
-          only_no_opt: false
+        # - system: rpi4
+        #   name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
+        #   bench_pmu: PMU
+        #   archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
+        #   cflags: "-flto -DMLD_FORCE_AARCH64"
+        #   ldflags: "-flto"
+        #   bench_extra_args: ""
+        #   nix_shell: bench
+        #   only_no_opt: false
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
           bench_pmu: PERF
@@ -47,34 +47,35 @@ jobs:
           bench_extra_args: ""
           nix_shell: bench
           only_no_opt: false
-        - system: a55
-          name: Arm Cortex-A55 (Snapdragon 888) benchmarks
-          bench_pmu: PERF
-          archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: "-flto -DMLD_FORCE_AARCH64"
-          ldflags: "-flto -static"
-          bench_extra_args: -w exec-on-a55
-          nix_shell: bench
-          only_no_opt: false
-        - system: bpi
-          name: SpacemiT K1 8 (Banana Pi F3) benchmarks
-          bench_pmu: PERF
-          archflags: "-march=rv64imafdcv_zicsr_zifencei"
-          cflags: ""
-          ldflags: "-static"
-          bench_extra_args: -w exec-on-bpi
-          cross_prefix: riscv64-unknown-linux-gnu-
-          nix_shell: cross-riscv64
-          only_no_opt: true
-        - system: m1-mac-mini
-          name: Mac Mini (M1, 2020) benchmarks
-          bench_pmu: MAC
-          archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
-          cflags: "-flto"
-          ldflags: "-flto"
-          bench_extra_args: "-r"
-          nix_shell: bench
-          only_no_opt: false
+          cross_prefix: ""
+        # - system: a55
+        #   name: Arm Cortex-A55 (Snapdragon 888) benchmarks
+        #   bench_pmu: PERF
+        #   archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
+        #   cflags: "-flto -DMLD_FORCE_AARCH64"
+        #   ldflags: "-flto -static"
+        #   bench_extra_args: -w exec-on-a55
+        #   nix_shell: bench
+        #   only_no_opt: false
+        # - system: bpi
+        #   name: SpacemiT K1 8 (Banana Pi F3) benchmarks
+        #   bench_pmu: PERF
+        #   archflags: "-march=rv64imafdcv_zicsr_zifencei"
+        #   cflags: ""
+        #   ldflags: "-static"
+        #   bench_extra_args: -w exec-on-bpi
+        #   cross_prefix: riscv64-unknown-linux-gnu-
+        #   nix_shell: cross-riscv64
+        #   only_no_opt: true
+        # - system: m1-mac-mini
+        #   name: Mac Mini (M1, 2020) benchmarks
+        #   bench_pmu: MAC
+        #   archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
+        #   cflags: "-flto"
+        #   ldflags: "-flto"
+        #   bench_extra_args: "-r"
+        #   nix_shell: bench
+        #   only_no_opt: false
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
     runs-on: self-hosted-${{ matrix.target.system }}
     steps:


### PR DESCRIPTION
Due to relocation, we have to temporarily disable CI that is running on most of our self-hosted runners:
 - Arm Cortex-A72 (Raspberry Pi 4)
 - Arm Cortex-A55 (Snapdragon 888)
 - SpacemiT K1 8 (Banana Pi F3)
 -  Mac Mini (M1, 2020)