### PR TITLE
CBMC: Correct operator precedence in ensures clause of mld_caddq()

### DIFF
--- a/mldsa/src/reduce.h
+++ b/mldsa/src/reduce.h
@@ -129,7 +129,7 @@ __contract__(
   requires(a < MLDSA_Q)
   ensures(return_value >= 0)
   ensures(return_value < MLDSA_Q)
-  ensures(return_value == (a >= 0) ? a : (a + MLDSA_Q))
+  ensures(return_value == ((a >= 0) ? a : (a + MLDSA_Q)))
 )
 {
   return mld_ct_sel_int32(a + MLDSA_Q, a, mld_ct_cmask_neg_i32(a));


### PR DESCRIPTION
A pedantic reviewer points out that the ensures contract on mld_caddq() says:

`ensures(return_value == (a >= 0) ? a : (a + MLDSA_Q))`

but operator == binds more tightly than ternary ? : so this parses as:
`(return_value == (a >= 0)) ? a : (a + MLDSA_Q)`

Parentheses are needed here to ensure correctness and readability.

`ensures(return_value == ((a >= 0) ? a : (a + MLDSA_Q)))`

CBMC says "VERIFICATION SUCCESS" for both cases, but I prefer the latter for readability.

