### PR TITLE
Correct assertion in polyveck_add()

### DIFF
--- a/mldsa/src/polyvec.c
+++ b/mldsa/src/polyvec.c
@@ -495,7 +495,7 @@ void mld_polyveck_add(mld_polyveck *u, const mld_polyveck *v)
   {
     mld_poly_add(&u->vec[i], &v->vec[i]);
   }
-  mld_assert_bound_2d(u->vec, MLDSA_L, MLDSA_N, INT32_MIN,
+  mld_assert_bound_2d(u->vec, MLDSA_K, MLDSA_N, INT32_MIN,
                       MLD_REDUCE32_DOMAIN_MAX);
 }
 


### PR DESCRIPTION
Correct assertion in polyveck_add()

It was previously asserting the correct range on values in u->vec in the range 0 .. <MLDSA_L, but this should be 0 .. <MLDSA_K.

Since MLDSA_L <= MLDSA_K for all parameter sets, this passes proof and runtime checking, but is weak.

The loop-invariant and post-condition of this function are correct, so proof of calling units is not affected.