### PR TITLE
aarch64: Fix verify with unaligned signature

### DIFF
--- a/dev/aarch64_clean/src/polyz_unpack_17_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_17_asm.S
@@ -65,8 +65,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_17_asm)
         mov count, #(64/4)
 
 polyz_unpack_17_loop:
-        ld1	{v0.4s, v1.4s}, [buf], #0x20
-        ldr	s2, [buf], #0x04
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x24
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/dev/aarch64_clean/src/polyz_unpack_19_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_19_asm.S
@@ -62,8 +62,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov count, #(64/4)
 
 polyz_unpack_19_loop:
-        ld1	{v0.2d, v1.2d}, [buf], #0x20
-        ldr	d2, [buf], #0x08
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x28
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/dev/aarch64_opt/src/polyz_unpack_17_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_17_asm.S
@@ -65,8 +65,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_17_asm)
         mov count, #(64/4)
 
 polyz_unpack_17_loop:
-        ld1	{v0.4s, v1.4s}, [buf], #0x20
-        ldr	s2, [buf], #0x04
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x24
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/dev/aarch64_opt/src/polyz_unpack_19_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_19_asm.S
@@ -62,8 +62,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov count, #(64/4)
 
 polyz_unpack_19_loop:
-        ld1	{v0.2d, v1.2d}, [buf], #0x20
-        ldr	d2, [buf], #0x08
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x28
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/mldsa/src/native/aarch64/src/polyz_unpack_17_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_17_asm.S
@@ -37,8 +37,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_17_asm)
         mov	x9, #0x10               // =16
 
 Lpolyz_unpack_17_loop:
-        ld1	{ v0.4s, v1.4s }, [x1], #32
-        ldr	s2, [x1], #0x4
+        ld1	{ v0.16b, v1.16b, v2.16b }, [x1]
+        add	x1, x1, #0x24
         tbl	v4.16b, { v0.16b }, v24.16b
         tbl	v5.16b, { v0.16b, v1.16b }, v25.16b
         tbl	v6.16b, { v1.16b }, v26.16b

--- a/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
@@ -34,8 +34,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov	x9, #0x10               // =16
 
 Lpolyz_unpack_19_loop:
-        ld1	{ v0.2d, v1.2d }, [x1], #32
-        ldr	d2, [x1], #0x8
+        ld1	{ v0.16b, v1.16b, v2.16b }, [x1]
+        add	x1, x1, #0x28
         tbl	v4.16b, { v0.16b }, v24.16b
         tbl	v5.16b, { v0.16b, v1.16b }, v25.16b
         tbl	v6.16b, { v1.16b }, v26.16b


### PR DESCRIPTION
If the signature passed to mldsa_verify_internal() wasn't 64bit aligned, the polyz_unpack_XX_asm() functions would trigger an exception on systems where unaligned accesses aren't allowed.