### PR TITLE
AArch64: Support unaligned inputs for top-level APIs

### DIFF
--- a/dev/aarch64_clean/src/polyz_unpack_17_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_17_asm.S
@@ -65,8 +65,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_17_asm)
         mov count, #(64/4)
 
 polyz_unpack_17_loop:
-        ld1	{v0.4s, v1.4s}, [buf], #0x20
-        ldr	s2, [buf], #0x04
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x24
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/dev/aarch64_clean/src/polyz_unpack_19_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_19_asm.S
@@ -62,8 +62,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov count, #(64/4)
 
 polyz_unpack_19_loop:
-        ld1	{v0.2d, v1.2d}, [buf], #0x20
-        ldr	d2, [buf], #0x08
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x28
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/dev/aarch64_opt/src/polyz_unpack_17_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_17_asm.S
@@ -65,8 +65,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_17_asm)
         mov count, #(64/4)
 
 polyz_unpack_17_loop:
-        ld1	{v0.4s, v1.4s}, [buf], #0x20
-        ldr	s2, [buf], #0x04
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x24
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/dev/aarch64_opt/src/polyz_unpack_19_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_19_asm.S
@@ -62,8 +62,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov count, #(64/4)
 
 polyz_unpack_19_loop:
-        ld1	{v0.2d, v1.2d}, [buf], #0x20
-        ldr	d2, [buf], #0x08
+        ld1	{v0.16b, v1.16b, v2.16b}, [buf]
+        add	buf, buf, #0x28
 
         tbl v4.16b, {v0.16b}, idx0.16b
         tbl v5.16b, {v0.16b - v1.16b}, idx1.16b

--- a/mldsa/src/native/aarch64/src/polyz_unpack_17_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_17_asm.S
@@ -37,8 +37,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_17_asm)
         mov	x9, #0x10               // =16
 
 Lpolyz_unpack_17_loop:
-        ld1	{ v0.4s, v1.4s }, [x1], #32
-        ldr	s2, [x1], #0x4
+        ld1	{ v0.16b, v1.16b, v2.16b }, [x1]
+        add	x1, x1, #0x24
         tbl	v4.16b, { v0.16b }, v24.16b
         tbl	v5.16b, { v0.16b, v1.16b }, v25.16b
         tbl	v6.16b, { v1.16b }, v26.16b

--- a/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
@@ -34,8 +34,8 @@ MLD_ASM_FN_SYMBOL(polyz_unpack_19_asm)
         mov	x9, #0x10               // =16
 
 Lpolyz_unpack_19_loop:
-        ld1	{ v0.2d, v1.2d }, [x1], #32
-        ldr	d2, [x1], #0x8
+        ld1	{ v0.16b, v1.16b, v2.16b }, [x1]
+        add	x1, x1, #0x28
         tbl	v4.16b, { v0.16b }, v24.16b
         tbl	v5.16b, { v0.16b, v1.16b }, v25.16b
         tbl	v6.16b, { v1.16b }, v26.16b

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1981,11 +1981,6 @@ def check_macro_typos():
             if m == "MLD_CONTEXT_PARAMETERS_n":
                 return True
 
-        # Baremetal platform configuration and test macros
-        if filename.startswith("test/baremetal/") or filename.startswith("test/src/"):
-            if m in ["MLD_TEST_NO_UNALIGNED"]:
-                return True
-
         return False
 
     run_parallel(

--- a/test/baremetal/platform/aarch64-virt/platform.mk
+++ b/test/baremetal/platform/aarch64-virt/platform.mk
@@ -8,7 +8,7 @@ CROSS_PREFIX=aarch64-none-elf-
 CC=gcc
 
 # Reduce iterations -- bare-metal semihosting I/O is slow
-CFLAGS += -DNTESTS=3 -DMLD_TEST_NO_UNALIGNED
+CFLAGS += -DNTESTS=3
 
 CFLAGS += \
 	-O3 \

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -103,7 +103,6 @@ static int test_sign(void)
   return test_sign_core(pk, sk, sm, m, m2, ctx);
 }
 
-#if !defined(MLD_TEST_NO_UNALIGNED)
 static int test_sign_unaligned(void)
 {
   MLD_ALIGN uint8_t pk[CRYPTO_PUBLICKEYBYTES + 1];
@@ -115,7 +114,6 @@ static int test_sign_unaligned(void)
 
   return test_sign_core(pk + 1, sk + 1, sm + 1, m + 1, m2 + 1, ctx + 1);
 }
-#endif /* !MLD_TEST_NO_UNALIGNED */
 
 static int test_sign_extmu(void)
 {
@@ -388,9 +386,7 @@ int main(void)
   for (i = 0; i < NTESTS; i++)
   {
     r = test_sign();
-#if !defined(MLD_TEST_NO_UNALIGNED)
     r |= test_sign_unaligned();
-#endif
     r |= test_wrong_pk();
     r |= test_wrong_sig();
     r |= test_wrong_ctx();


### PR DESCRIPTION
polyz_unpack_{17,19}_asm are the only AArch64 assembly routines that load from potentially unaligned user-provided buffers (the signature passed to verify). All other assembly (NTT, rej_uniform, etc.) operates on aligned internal buffers.

The ld1 with .4s/.2d element sizes and the ldr s/d instructions used here require 4/8-byte alignment on Device memory (bare-metal AArch64 without MMU). Replace with .16b element sizes and ld1 {v.8b}, which do not require alignment.

With this fixed, remove the MLD_TEST_NO_UNALIGNED workaround from the aarch64-virt baremetal platform so the unaligned-buffer functional test runs on baremetal as well.