### PR TITLE
RFC: Validate s1/s2 coefficient bounds during signing

### DIFF
--- a/mldsa/src/packing.c
+++ b/mldsa/src/packing.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "common.h"
+#include "ct.h"
 #include "packing.h"
 #include "poly.h"
 #include "polyvec.h"
@@ -76,11 +77,13 @@ void mld_pack_sk(uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
 }
 
 MLD_INTERNAL_API
-void mld_unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
-                   uint8_t key[MLDSA_SEEDBYTES], mld_polyveck *t0,
-                   mld_polyvecl *s1, mld_polyveck *s2,
-                   const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES])
+MLD_MUST_CHECK_RETURN_VALUE
+int mld_unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
+                  uint8_t key[MLDSA_SEEDBYTES], mld_polyveck *t0,
+                  mld_polyvecl *s1, mld_polyveck *s2,
+                  const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES])
 {
+  uint8_t chk1, chk2, check;
   mld_memcpy(rho, sk, MLDSA_SEEDBYTES);
   sk += MLDSA_SEEDBYTES;
 
@@ -97,6 +100,15 @@ void mld_unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
   sk += MLDSA_K * MLDSA_POLYETA_PACKEDBYTES;
 
   mld_polyveck_unpack_t0(t0, sk);
+
+  /* Validate s1 and s2 coefficients are within [-MLDSA_ETA, MLDSA_ETA] */
+  chk1 = mld_polyvecl_chknorm(s1, MLDSA_ETA + 1) & 0xFF;
+  chk2 = mld_polyveck_chknorm(s2, MLDSA_ETA + 1) & 0xFF;
+  check = mld_value_barrier_u8(chk1 | chk2);
+
+  /* Declassify the final result of the validity check. */
+  MLD_CT_TESTING_DECLASSIFY(&check, sizeof(check));
+  return (check != 0) ? MLD_ERR_FAIL : 0;
 }
 
 MLD_INTERNAL_API

--- a/mldsa/src/packing.h
+++ b/mldsa/src/packing.h
@@ -153,6 +153,8 @@ __contract__(
  * Name:        mld_unpack_sk
  *
  * Description: Unpack secret key sk = (rho, tr, key, t0, s1, s2).
+ *              Validates that s1 and s2 coefficients are within
+ *              [-MLDSA_ETA, MLDSA_ETA].
  *
  * Arguments:   - const uint8_t rho[]: output byte array for rho
  *              - const uint8_t tr[]: output byte array for tr
@@ -161,12 +163,16 @@ __contract__(
  *              - const mld_polyvecl *s1: pointer to output vector s1
  *              - const mld_polyveck *s2: pointer to output vector s2
  *              - uint8_t sk[]: byte array containing bit-packed sk
+ *
+ * Returns:     - 0: Success
+ *              - MLD_ERR_FAIL: s1 or s2 coefficients out of range
  **************************************************/
 MLD_INTERNAL_API
-void mld_unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
-                   uint8_t key[MLDSA_SEEDBYTES], mld_polyveck *t0,
-                   mld_polyvecl *s1, mld_polyveck *s2,
-                   const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES])
+MLD_MUST_CHECK_RETURN_VALUE
+int mld_unpack_sk(uint8_t rho[MLDSA_SEEDBYTES], uint8_t tr[MLDSA_TRBYTES],
+                  uint8_t key[MLDSA_SEEDBYTES], mld_polyveck *t0,
+                  mld_polyvecl *s1, mld_polyveck *s2,
+                  const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES])
 __contract__(
   requires(memory_no_alias(rho, MLDSA_SEEDBYTES))
   requires(memory_no_alias(tr, MLDSA_TRBYTES))
@@ -181,12 +187,13 @@ __contract__(
   assigns(memory_slice(t0, sizeof(mld_polyveck)))
   assigns(memory_slice(s1, sizeof(mld_polyvecl)))
   assigns(memory_slice(s2, sizeof(mld_polyveck)))
+  ensures(return_value == 0 || return_value == MLD_ERR_FAIL)
   ensures(forall(k0, 0, MLDSA_K,
     array_bound(t0->vec[k0].coeffs, 0, MLDSA_N, -(1<<(MLDSA_D-1)) + 1, (1<<(MLDSA_D-1)) + 1)))
-  ensures(forall(k1, 0, MLDSA_L,
-    array_bound(s1->vec[k1].coeffs, 0, MLDSA_N, MLD_POLYETA_UNPACK_LOWER_BOUND, MLDSA_ETA + 1)))
-  ensures(forall(k2, 0, MLDSA_K,
-    array_bound(s2->vec[k2].coeffs, 0, MLDSA_N, MLD_POLYETA_UNPACK_LOWER_BOUND, MLDSA_ETA + 1)))
+  ensures((return_value == 0) ==> forall(k1, 0, MLDSA_L,
+    array_abs_bound(s1->vec[k1].coeffs, 0, MLDSA_N, MLDSA_ETA + 1)))
+  ensures((return_value == 0) ==> forall(k2, 0, MLDSA_K,
+    array_abs_bound(s2->vec[k2].coeffs, 0, MLDSA_N, MLDSA_ETA + 1)))
 );
 
 #define mld_unpack_sig MLD_NAMESPACE_KL(unpack_sig)

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -755,7 +755,11 @@ int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
   key = tr + MLDSA_TRBYTES;
   mu = key + MLDSA_SEEDBYTES;
   rhoprime = mu + MLDSA_CRHBYTES;
-  mld_unpack_sk(rho, tr, key, t0, s1, s2, sk);
+  ret = mld_unpack_sk(rho, tr, key, t0, s1, s2, sk);
+  if (ret != 0)
+  {
+    goto cleanup;
+  }
 
   if (!externalmu)
   {
@@ -1427,7 +1431,7 @@ int mld_sign_pk_from_sk(uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                         const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
                         MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 {
-  uint8_t check, cmp0, cmp1, chk1, chk2;
+  uint8_t check, cmp0, cmp1;
   int ret;
   MLD_ALLOC(rho, uint8_t, MLDSA_SEEDBYTES, context);
   MLD_ALLOC(tr, uint8_t, MLDSA_TRBYTES, context);
@@ -1447,12 +1451,12 @@ int mld_sign_pk_from_sk(uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
     goto cleanup;
   }
 
-  /* Unpack secret key */
-  mld_unpack_sk(rho, tr, key, t0, s1, s2, sk);
-
-  /* Validate s1 and s2 coefficients are within [-MLDSA_ETA, MLDSA_ETA] */
-  chk1 = mld_polyvecl_chknorm(s1, MLDSA_ETA + 1) & 0xFF;
-  chk2 = mld_polyveck_chknorm(s2, MLDSA_ETA + 1) & 0xFF;
+  /* Unpack and validate secret key */
+  ret = mld_unpack_sk(rho, tr, key, t0, s1, s2, sk);
+  if (ret != 0)
+  {
+    goto cleanup;
+  }
 
   /* Recompute t0, t1, tr, and pk from rho, s1, s2 */
   ret = mld_compute_t0_t1_tr_from_sk_components(t0_computed, t1, tr_computed,
@@ -1467,7 +1471,7 @@ int mld_sign_pk_from_sk(uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                        sizeof(mld_polyveck));
   cmp1 = mld_ct_memcmp((const uint8_t *)tr, (const uint8_t *)tr_computed,
                        MLDSA_TRBYTES);
-  check = mld_value_barrier_u8(cmp0 | cmp1 | chk1 | chk2);
+  check = mld_value_barrier_u8(cmp0 | cmp1);
 
   /* Declassify the final result of the validity check. */
   MLD_CT_TESTING_DECLASSIFY(&check, sizeof(check));

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -220,6 +220,38 @@ static int test_pk_from_sk(void)
   return 0;
 }
 
+static int test_invalid_sk_sign(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t sm[MLEN + CRYPTO_BYTES];
+  uint8_t m[MLEN];
+  uint8_t ctx[CTXLEN];
+  size_t smlen;
+  int rc;
+
+  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(randombytes(ctx, CTXLEN) == 0);
+  CHECK(randombytes(m, MLEN) == 0);
+
+  /* Corrupt s1 portion of the secret key by setting bytes to 0xFF,
+   * producing out-of-range coefficients.
+   * SK layout: rho (SEEDBYTES) || key (SEEDBYTES) || tr (TRBYTES) || s1 ... */
+  memset(sk + 2 * MLDSA_SEEDBYTES + MLDSA_TRBYTES, 0xFF, 3);
+
+  rc = crypto_sign(sm, &smlen, m, MLEN, ctx, CTXLEN, sk);
+
+  MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(int));
+
+  if (rc != -1)
+  {
+    printf("ERROR: signing with invalid sk should fail\n");
+    return 1;
+  }
+
+  return 0;
+}
+
 static int test_wrong_pk(void)
 {
   uint8_t pk[CRYPTO_PUBLICKEYBYTES];
@@ -393,6 +425,7 @@ int main(void)
     r |= test_sign_extmu();
     r |= test_sign_pre_hash();
     r |= test_pk_from_sk();
+    r |= test_invalid_sk_sign();
     if (r)
     {
       return 1;


### PR DESCRIPTION
**RFC**: This PR is to evaluate the performance impact of this change and to discuss if such a check should be added or not. From a standard compliance point, I don't see a reason why it needs to be added. If performance impact is negligible, I wouldn't object adding it. It is just somewhat unclean, that it performs _some_ input validation, while other parts of the inputs are not validated (see the other checks that have been added to pk_from_sk) - but the other checks would require recomputing the public key which is clearly too expensive. I am interested to hear what others think.

Validate s1 and s2 coefficient bounds in unpack_sk, ensuring that signing rejects secret keys with out-of-range s1/s2 encodings. Neither FIPS 204 nor the FIPS 140-3 IG describe this check, but it is covered by Wycheproof test vectors.

The bounds check was previously only performed in pk_from_sk. By moving it into unpack_sk, both signing and pk_from_sk benefit from the same check.

Note that pk_from_sk performs additional validation beyond this: it recomputes t0 and tr from (rho, s1, s2) and checks them against the stored values to verify internal consistency of the secret key.


TODO: 
 - [  ] Adjust CBMC proofs