### PR TITLE
MAINTAINERS.md: Remove affiliations

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,8 @@
 
 ## Active Maintainers
 
-| Name                    | GitHub                                          | Affliation
-|-------------------------|-------------------------------------------------|----------------------
-| Hanno Becker            | [hanno-becker](https://github.com/hanno-becker) | AWS                  |
-| Matthias J. Kannwischer | [mkannwischer](https://github.com/mkannwischer) | Chelpis Quantum Corp |
-| Jake Massimo            | [jakemas](https://github.com/jakemas)           | AWS                  |
+| Name                    | GitHub                                          |
+|-------------------------|-------------------------------------------------|
+| Hanno Becker            | [hanno-becker](https://github.com/hanno-becker) |
+| Matthias J. Kannwischer | [mkannwischer](https://github.com/mkannwischer) |
+| Jake Massimo            | [jakemas](https://github.com/jakemas)           |


### PR DESCRIPTION
I recently switched from Chelpis to zeroRISC meaning our MAINTAINERS.md is outdated.
This commit removes affilations from the file as they are unnecessary.