### PR TITLE
simpasm: Move .note.GNU-stack outside preprocessor guards

### DIFF
--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S
@@ -40,10 +40,6 @@
  *   dev/fips202/aarch64/src/keccak_f1600_x1_scalar_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm)
@@ -374,3 +370,7 @@ MLD_ASM_FN_SIZE(keccak_f1600_x1_scalar_asm)
 
 #endif /* MLD_FIPS202_AARCH64_NEED_X1_SCALAR && \
           !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
@@ -57,10 +57,6 @@
  *   dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm)
@@ -202,3 +198,7 @@ MLD_ASM_FN_SIZE(keccak_f1600_x1_v84a_asm)
 
 #endif /* MLD_FIPS202_AARCH64_NEED_X1_V84A && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
@@ -57,10 +57,6 @@
  *   dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm)
@@ -257,3 +253,7 @@ MLD_ASM_FN_SIZE(keccak_f1600_x2_v84a_asm)
 
 #endif /* MLD_FIPS202_AARCH64_NEED_X2_V84A && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -40,10 +40,6 @@
  *   dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(keccak_f1600_x4_v8a_scalar_hybrid_asm)
@@ -1075,3 +1071,7 @@ MLD_ASM_FN_SIZE(keccak_f1600_x4_v8a_scalar_hybrid_asm)
 
 #endif /* MLD_FIPS202_AARCH64_NEED_X4_V8A_SCALAR_HYBRID && \
           !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
@@ -42,10 +42,6 @@
  *   dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm)
@@ -985,3 +981,7 @@ MLD_ASM_FN_SIZE(keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm)
 
 #endif /* MLD_FIPS202_AARCH64_NEED_X4_V8A_V84A_SCALAR_HYBRID && \
           !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/fips202/native/armv81m/src/keccak_f1600_x4_mve.S
+++ b/mldsa/src/fips202/native/armv81m/src/keccak_f1600_x4_mve.S
@@ -636,3 +636,7 @@ keccak_f1600_x4_mve_asm_roundend:
 MLD_ASM_FN_SIZE(keccak_f1600_x4_mve_asm)
 
 #endif /* MLD_FIPS202_ARMV81M_NEED_X4 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/intt.S
+++ b/mldsa/src/native/aarch64/src/intt.S
@@ -30,10 +30,6 @@
  *   dev/aarch64_opt/src/intt.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(intt_asm)
@@ -751,3 +747,7 @@ Lintt_layer1234_start:
 MLD_ASM_FN_SIZE(intt_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4.S
@@ -11,10 +11,6 @@
  *   dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l4_asm)
@@ -127,3 +123,7 @@ MLD_ASM_FN_SIZE(polyvecl_pointwise_acc_montgomery_l4_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_L == 4) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5.S
@@ -11,10 +11,6 @@
  *   dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l5_asm)
@@ -143,3 +139,7 @@ MLD_ASM_FN_SIZE(polyvecl_pointwise_acc_montgomery_l5_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_L == 5) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7.S
@@ -11,10 +11,6 @@
  *   dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l7_asm)
@@ -175,3 +171,7 @@ MLD_ASM_FN_SIZE(polyvecl_pointwise_acc_montgomery_l7_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_L == 7) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/ntt.S
+++ b/mldsa/src/native/aarch64/src/ntt.S
@@ -30,10 +30,6 @@
  *   dev/aarch64_opt/src/ntt.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(ntt_asm)
@@ -651,3 +647,7 @@ Lntt_layer45678_start:
 MLD_ASM_FN_SIZE(ntt_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/pointwise_montgomery.S
+++ b/mldsa/src/native/aarch64/src/pointwise_montgomery.S
@@ -10,10 +10,6 @@
  *   dev/aarch64_opt/src/pointwise_montgomery.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_pointwise_montgomery_asm)
@@ -77,3 +73,7 @@ Lpoly_pointwise_montgomery_loop_start:
 MLD_ASM_FN_SIZE(poly_pointwise_montgomery_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/poly_caddq_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_caddq_asm.S
@@ -11,10 +11,6 @@
  *   dev/aarch64_opt/src/poly_caddq_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_caddq_asm)
@@ -51,3 +47,7 @@ Lpoly_caddq_loop:
 MLD_ASM_FN_SIZE(poly_caddq_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/poly_chknorm_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_chknorm_asm.S
@@ -11,10 +11,6 @@
  *   dev/aarch64_opt/src/poly_chknorm_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_chknorm_asm)
@@ -53,3 +49,7 @@ Lpoly_chknorm_loop:
 MLD_ASM_FN_SIZE(poly_chknorm_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/poly_decompose_32_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_decompose_32_asm.S
@@ -12,10 +12,6 @@
  *   dev/aarch64_opt/src/poly_decompose_32_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_decompose_32_asm)
@@ -83,3 +79,7 @@ MLD_ASM_FN_SIZE(poly_decompose_32_asm)
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 65 \
           || MLD_CONFIG_PARAMETER_SET == 87) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/poly_decompose_88_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_decompose_88_asm.S
@@ -12,10 +12,6 @@
  *   dev/aarch64_opt/src/poly_decompose_88_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_decompose_88_asm)
@@ -83,3 +79,7 @@ MLD_ASM_FN_SIZE(poly_decompose_88_asm)
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 44) \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/poly_use_hint_32_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_use_hint_32_asm.S
@@ -12,10 +12,6 @@
  *   dev/aarch64_opt/src/poly_use_hint_32_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_use_hint_32_asm)
@@ -100,3 +96,7 @@ MLD_ASM_FN_SIZE(poly_use_hint_32_asm)
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 65 \
           || MLD_CONFIG_PARAMETER_SET == 87) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/poly_use_hint_88_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_use_hint_88_asm.S
@@ -12,10 +12,6 @@
  *   dev/aarch64_opt/src/poly_use_hint_88_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_use_hint_88_asm)
@@ -108,3 +104,7 @@ MLD_ASM_FN_SIZE(poly_use_hint_88_asm)
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 44) \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/polyz_unpack_17_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_17_asm.S
@@ -13,10 +13,6 @@
  *   dev/aarch64_opt/src/polyz_unpack_17_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(polyz_unpack_17_asm)
@@ -70,3 +66,7 @@ MLD_ASM_FN_SIZE(polyz_unpack_17_asm)
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 44) \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_19_asm.S
@@ -13,10 +13,6 @@
  *   dev/aarch64_opt/src/polyz_unpack_19_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(polyz_unpack_19_asm)
@@ -67,3 +63,7 @@ MLD_ASM_FN_SIZE(polyz_unpack_19_asm)
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 65 \
           || MLD_CONFIG_PARAMETER_SET == 87) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/rej_uniform_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_asm.S
@@ -13,10 +13,6 @@
  *   dev/aarch64_opt/src/rej_uniform_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(rej_uniform_asm)
@@ -187,3 +183,7 @@ Lrej_uniform_return:
 MLD_ASM_FN_SIZE(rej_uniform_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/rej_uniform_eta2_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_eta2_asm.S
@@ -14,10 +14,6 @@
  *   dev/aarch64_opt/src/rej_uniform_eta2_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(rej_uniform_eta2_asm)
@@ -133,3 +129,7 @@ MLD_ASM_FN_SIZE(rej_uniform_eta2_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_ETA == 2) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/aarch64/src/rej_uniform_eta4_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_eta4_asm.S
@@ -14,10 +14,6 @@
  *   dev/aarch64_opt/src/rej_uniform_eta4_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(rej_uniform_eta4_asm)
@@ -126,3 +122,7 @@ MLD_ASM_FN_SIZE(rej_uniform_eta4_asm)
 
 #endif /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_ETA == 4) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/intt.S
+++ b/mldsa/src/native/x86_64/src/intt.S
@@ -27,10 +27,6 @@
  *   dev/x86_64/src/intt.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(invntt_avx2)
@@ -2309,3 +2305,7 @@ MLD_ASM_FN_SIZE(invntt_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/ntt.S
+++ b/mldsa/src/native/x86_64/src/ntt.S
@@ -27,10 +27,6 @@
  *   dev/x86_64/src/ntt.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(ntt_avx2)
@@ -2381,3 +2377,7 @@ MLD_ASM_FN_SIZE(ntt_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/nttunpack.S
+++ b/mldsa/src/native/x86_64/src/nttunpack.S
@@ -28,10 +28,6 @@
  *   dev/x86_64/src/nttunpack.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(nttunpack_avx2)
@@ -237,3 +233,7 @@ MLD_ASM_FN_SIZE(nttunpack_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/pointwise.S
+++ b/mldsa/src/native/x86_64/src/pointwise.S
@@ -26,10 +26,6 @@
  *   dev/x86_64/src/pointwise.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(pointwise_avx2)
@@ -129,3 +125,7 @@ MLD_ASM_FN_SIZE(pointwise_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/pointwise_acc_l4.S
+++ b/mldsa/src/native/x86_64/src/pointwise_acc_l4.S
@@ -27,10 +27,6 @@
  *   dev/x86_64/src/pointwise_acc_l4.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(pointwise_acc_l4_avx2)
@@ -137,3 +133,7 @@ MLD_ASM_FN_SIZE(pointwise_acc_l4_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
           && (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_L == 4) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/pointwise_acc_l5.S
+++ b/mldsa/src/native/x86_64/src/pointwise_acc_l5.S
@@ -27,10 +27,6 @@
  *   dev/x86_64/src/pointwise_acc_l5.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(pointwise_acc_l5_avx2)
@@ -153,3 +149,7 @@ MLD_ASM_FN_SIZE(pointwise_acc_l5_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
           && (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_L == 5) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/pointwise_acc_l7.S
+++ b/mldsa/src/native/x86_64/src/pointwise_acc_l7.S
@@ -27,10 +27,6 @@
  *   dev/x86_64/src/pointwise_acc_l7.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(pointwise_acc_l7_avx2)
@@ -185,3 +181,7 @@ MLD_ASM_FN_SIZE(pointwise_acc_l7_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
           && (MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLDSA_L == 7) */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/mldsa/src/native/x86_64/src/poly_caddq_avx2.S
+++ b/mldsa/src/native/x86_64/src/poly_caddq_avx2.S
@@ -38,10 +38,6 @@
  *   dev/x86_64/src/poly_caddq_avx2.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 .global MLD_ASM_NAMESPACE(poly_caddq_avx2)
@@ -82,3 +78,7 @@ MLD_ASM_FN_SIZE(poly_caddq_avx2)
 
 #endif /* MLD_ARITH_BACKEND_X86_64_DEFAULT && !MLD_CONFIG_MULTILEVEL_NO_SHARED \
         */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/proofs/hol_light/aarch64/mldsa/mldsa_poly_caddq.S
+++ b/proofs/hol_light/aarch64/mldsa/mldsa_poly_caddq.S
@@ -9,10 +9,6 @@
  *   dev/aarch64_opt/src/poly_caddq_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 #ifdef __APPLE__
@@ -50,3 +46,7 @@ Lpoly_caddq_loop:
         b.ne	Lpoly_caddq_loop
         ret
         .cfi_endproc
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/proofs/hol_light/aarch64/mldsa/mldsa_poly_chknorm.S
+++ b/proofs/hol_light/aarch64/mldsa/mldsa_poly_chknorm.S
@@ -9,10 +9,6 @@
  *   dev/aarch64_opt/src/poly_chknorm_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 #ifdef __APPLE__
@@ -52,3 +48,7 @@ Lpoly_chknorm_loop:
         and	w0, w0, #0x1
         ret
         .cfi_endproc
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/proofs/hol_light/x86_64/mldsa/mldsa_intt.S
+++ b/proofs/hol_light/x86_64/mldsa/mldsa_intt.S
@@ -24,10 +24,6 @@
  *   dev/x86_64/src/intt.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 #ifdef __APPLE__
@@ -2307,3 +2303,7 @@ PQCP_MLDSA_NATIVE_MLDSA44_invntt_avx2:
         vmovdqa	%ymm7, 0x1e0(%rdi)
         retq
         .cfi_endproc
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/proofs/hol_light/x86_64/mldsa/mldsa_ntt.S
+++ b/proofs/hol_light/x86_64/mldsa/mldsa_ntt.S
@@ -24,10 +24,6 @@
  *   dev/x86_64/src/ntt.S using scripts/simpasm. Do not modify it directly.
  */
 
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
-
 .text
 .balign 4
 #ifdef __APPLE__
@@ -2379,3 +2375,7 @@ PQCP_MLDSA_NATIVE_MLDSA44_ntt_avx2:
         vmovdqa	%ymm11, 0x3e0(%rdi)
         retq
         .cfi_endproc
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -263,6 +263,16 @@ def simplify(logger, args, asm_input, asm_output=None):
         logger.debug("Patching up disassembly ...")
         simplified = patchup_disasm(disasm, cfify=args.cfify)
 
+        # Mark stack as non-executable for ELF targets.
+        # This must be outside any preprocessor guards to ensure the
+        # .note.GNU-stack section is always emitted.
+        elf_stack_section = [
+            "#if defined(__ELF__)",
+            '.section .note.GNU-stack,"",%progbits',
+            "#endif",
+            "",
+        ]
+
         autogen_header = [
             "",
             "/*",
@@ -271,15 +281,6 @@ def simplify(logger, args, asm_input, asm_output=None):
             " */",
             "",
         ]
-
-        # Add ELF section for non-baremetal targets
-        if args.arch != "armv81m":
-            autogen_header += [
-                "#if defined(__ELF__)",
-                '.section .note.GNU-stack,"",@progbits',
-                "#endif",
-                "",
-            ]
 
         # Add Thumb directives for Armv8.1-M
         if args.arch == "armv81m":
@@ -328,7 +329,11 @@ def simplify(logger, args, asm_input, asm_output=None):
 
         # Write simplified assembly file
         full_simplified = (
-            simplified_header + autogen_header + simplified + simplified_footer
+            simplified_header
+            + autogen_header
+            + simplified
+            + simplified_footer
+            + elf_stack_section
         )
 
         logger.debug(f"Writing simplified assembly to {asm_output} ...")
@@ -346,6 +351,7 @@ def simplify(logger, args, asm_input, asm_output=None):
             + autogen_header
             + simplified
             + simplified_footer
+            + elf_stack_section
         )
 
         logger.debug(f"Assembling simplified assembly ...")


### PR DESCRIPTION
The .note.GNU-stack section directive was emitted inside the autogen_header, which ends up inside preprocessor guards like if \!defined(MLD_CONFIG_MULTILEVEL_NO_SHARED). When these guards evaluate to false, the directive is preprocessed away, producing an object file without the section and triggering a linker warning about an executable stack.

Fix by emitting the .note.GNU-stack directive at the end of the file, after the closing #endif of any guards. Also use %progbits instead of @progbits for aarch64 and armv81m, since @ is the comment character in Arm assembly. Emit the directive for all architectures including armv81m.

Port of pq-code-package/mlkem-native#1637.