### PR TITLE
aarch64/src/polyz_unpack_table.c: Disable unused tables

### DIFF
--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -29,10 +29,15 @@ extern const uint8_t mld_rej_uniform_table[];
 #define mld_rej_uniform_eta_table MLD_NAMESPACE(rej_uniform_eta_table)
 extern const uint8_t mld_rej_uniform_eta_table[];
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 #define mld_polyz_unpack_17_indices MLD_NAMESPACE(polyz_unpack_17_indices)
 extern const uint8_t mld_polyz_unpack_17_indices[];
+#endif
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \
+    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 #define mld_polyz_unpack_19_indices MLD_NAMESPACE(polyz_unpack_19_indices)
 extern const uint8_t mld_polyz_unpack_19_indices[];
+#endif
 
 
 /*

--- a/dev/aarch64_clean/src/polyz_unpack_table.c
+++ b/dev/aarch64_clean/src/polyz_unpack_table.c
@@ -19,19 +19,26 @@
 /* Table of indices used for tbl instructions in polyz_unpack_{17,19}.
  * See autogen for details. */
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 MLD_ALIGN const uint8_t mld_polyz_unpack_17_indices[] = {
     0,  1,  2,  255, 2,  3,  4,  255, 4,  5,  6,  255, 6,  7,  8,  255,
     9,  10, 11, 255, 11, 12, 13, 255, 13, 14, 15, 255, 15, 16, 17, 255,
     2,  3,  4,  255, 4,  5,  6,  255, 6,  7,  8,  255, 8,  9,  10, 255,
     11, 12, 13, 255, 13, 14, 15, 255, 15, 28, 29, 255, 29, 30, 31, 255,
 };
+#endif /* MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 44 \
+        */
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \
+    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 MLD_ALIGN const uint8_t mld_polyz_unpack_19_indices[] = {
     0,  1,  2,  255, 2,  3,  4,  255, 5,  6,  7,  255, 7,  8,  9,  255,
     10, 11, 12, 255, 12, 13, 14, 255, 15, 16, 17, 255, 17, 18, 19, 255,
     4,  5,  6,  255, 6,  7,  8,  255, 9,  10, 11, 255, 11, 12, 13, 255,
     14, 15, 24, 255, 24, 25, 26, 255, 27, 28, 29, 255, 29, 30, 31, 255,
 };
+#endif /* MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 65 \
+          || MLD_CONFIG_PARAMETER_SET == 87 */
 
 #else /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
 

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -29,10 +29,15 @@ extern const uint8_t mld_rej_uniform_table[];
 #define mld_rej_uniform_eta_table MLD_NAMESPACE(rej_uniform_eta_table)
 extern const uint8_t mld_rej_uniform_eta_table[];
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 #define mld_polyz_unpack_17_indices MLD_NAMESPACE(polyz_unpack_17_indices)
 extern const uint8_t mld_polyz_unpack_17_indices[];
+#endif
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \
+    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 #define mld_polyz_unpack_19_indices MLD_NAMESPACE(polyz_unpack_19_indices)
 extern const uint8_t mld_polyz_unpack_19_indices[];
+#endif
 
 
 /*

--- a/dev/aarch64_opt/src/polyz_unpack_table.c
+++ b/dev/aarch64_opt/src/polyz_unpack_table.c
@@ -19,19 +19,26 @@
 /* Table of indices used for tbl instructions in polyz_unpack_{17,19}.
  * See autogen for details. */
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 MLD_ALIGN const uint8_t mld_polyz_unpack_17_indices[] = {
     0,  1,  2,  255, 2,  3,  4,  255, 4,  5,  6,  255, 6,  7,  8,  255,
     9,  10, 11, 255, 11, 12, 13, 255, 13, 14, 15, 255, 15, 16, 17, 255,
     2,  3,  4,  255, 4,  5,  6,  255, 6,  7,  8,  255, 8,  9,  10, 255,
     11, 12, 13, 255, 13, 14, 15, 255, 15, 28, 29, 255, 29, 30, 31, 255,
 };
+#endif /* MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 44 \
+        */
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \
+    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 MLD_ALIGN const uint8_t mld_polyz_unpack_19_indices[] = {
     0,  1,  2,  255, 2,  3,  4,  255, 5,  6,  7,  255, 7,  8,  9,  255,
     10, 11, 12, 255, 12, 13, 14, 255, 15, 16, 17, 255, 17, 18, 19, 255,
     4,  5,  6,  255, 6,  7,  8,  255, 9,  10, 11, 255, 11, 12, 13, 255,
     14, 15, 24, 255, 24, 25, 26, 255, 27, 28, 29, 255, 29, 30, 31, 255,
 };
+#endif /* MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 65 \
+          || MLD_CONFIG_PARAMETER_SET == 87 */
 
 #else /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
 

--- a/mldsa/src/native/aarch64/src/arith_native_aarch64.h
+++ b/mldsa/src/native/aarch64/src/arith_native_aarch64.h
@@ -29,10 +29,15 @@ extern const uint8_t mld_rej_uniform_table[];
 #define mld_rej_uniform_eta_table MLD_NAMESPACE(rej_uniform_eta_table)
 extern const uint8_t mld_rej_uniform_eta_table[];
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 #define mld_polyz_unpack_17_indices MLD_NAMESPACE(polyz_unpack_17_indices)
 extern const uint8_t mld_polyz_unpack_17_indices[];
+#endif
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \
+    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 #define mld_polyz_unpack_19_indices MLD_NAMESPACE(polyz_unpack_19_indices)
 extern const uint8_t mld_polyz_unpack_19_indices[];
+#endif
 
 
 /*

--- a/mldsa/src/native/aarch64/src/polyz_unpack_table.c
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_table.c
@@ -19,19 +19,26 @@
 /* Table of indices used for tbl instructions in polyz_unpack_{17,19}.
  * See autogen for details. */
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 MLD_ALIGN const uint8_t mld_polyz_unpack_17_indices[] = {
     0,  1,  2,  255, 2,  3,  4,  255, 4,  5,  6,  255, 6,  7,  8,  255,
     9,  10, 11, 255, 11, 12, 13, 255, 13, 14, 15, 255, 15, 16, 17, 255,
     2,  3,  4,  255, 4,  5,  6,  255, 6,  7,  8,  255, 8,  9,  10, 255,
     11, 12, 13, 255, 13, 14, 15, 255, 15, 28, 29, 255, 29, 30, 31, 255,
 };
+#endif /* MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 44 \
+        */
 
+#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \
+    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 MLD_ALIGN const uint8_t mld_polyz_unpack_19_indices[] = {
     0,  1,  2,  255, 2,  3,  4,  255, 5,  6,  7,  255, 7,  8,  9,  255,
     10, 11, 12, 255, 12, 13, 14, 255, 15, 16, 17, 255, 17, 18, 19, 255,
     4,  5,  6,  255, 6,  7,  8,  255, 9,  10, 11, 255, 11, 12, 13, 255,
     14, 15, 24, 255, 24, 25, 26, 255, 27, 28, 29, 255, 29, 30, 31, 255,
 };
+#endif /* MLD_CONFIG_MULTILEVEL_WITH_SHARED || MLD_CONFIG_PARAMETER_SET == 65 \
+          || MLD_CONFIG_PARAMETER_SET == 87 */
 
 #else /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */
 

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1099,6 +1099,15 @@ def gen_aarch64_polyz_unpack_indices(bit_width):
 
 
 def gen_aarch64_polyz_unpack_table():
+    # Map gamma1_bits to parameter set guards
+    param_set_guards = {
+        17: "#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44",
+        19: (
+            "#if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || \\\n"
+            "    (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)"
+        ),
+    }
+
     def format_row(vals):
         return ", ".join(f"{v:>3}" for v in vals) + ","
 
@@ -1117,10 +1126,12 @@ def gen_aarch64_polyz_unpack_table():
         for gamma1_bits in [17, 19]:
             bit_width = gamma1_bits + 1
             indices = list(gen_aarch64_polyz_unpack_indices(bit_width))
+            yield param_set_guards[gamma1_bits]
             yield f"MLD_ALIGN const uint8_t mld_polyz_unpack_{gamma1_bits}_indices[] = {{"
             for row_start in range(0, len(indices), 16):
                 yield "    " + format_row(indices[row_start : row_start + 16])
             yield "};"
+            yield "#endif"
             yield ""
         yield "#else /* MLD_ARITH_BACKEND_AARCH64 && !MLD_CONFIG_MULTILEVEL_NO_SHARED */"
         yield ""


### PR DESCRIPTION
Only one table is used for each parameter set, so add conditions to remove the unused table from non-shared builds.

This change was part of  PR #1000 but it is really a separate change so I've opened this PR for it instead.