### PR TITLE
FIPS202/x86_64: Don't use native x4 backend on x86_64 when not needed

### DIFF
--- a/dev/fips202/aarch64/auto.h
+++ b/dev/fips202/aarch64/auto.h
@@ -37,6 +37,7 @@
 #include "x1_scalar.h"
 #endif
 
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 /*
  * Keccak-f1600x2/x4
  *
@@ -67,5 +68,7 @@
 #include "x4_v8a_scalar.h"
 
 #endif /* !__ARM_FEATURE_SHA3 */
+
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 #endif /* !MLD_DEV_FIPS202_AARCH64_AUTO_H */

--- a/mldsa/src/fips202/keccakf1600.c
+++ b/mldsa/src/fips202/keccakf1600.c
@@ -84,6 +84,7 @@ void mld_keccakf1600_xor_bytes(uint64_t *state, const unsigned char *data,
 #endif /* !MLD_SYS_LITTLE_ENDIAN */
 }
 
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 MLD_INTERNAL_API
 void mld_keccakf1600x4_extract_bytes(uint64_t *state, unsigned char *data0,
                                      unsigned char *data1, unsigned char *data2,
@@ -131,6 +132,7 @@ void mld_keccakf1600x4_permute(uint64_t *state)
   mld_keccakf1600_permute(state + MLD_KECCAK_LANES * 2);
   mld_keccakf1600_permute(state + MLD_KECCAK_LANES * 3);
 }
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 static const uint64_t mld_KeccakF_RoundConstants[MLD_KECCAK_NROUNDS] = {
     (uint64_t)0x0000000000000001ULL, (uint64_t)0x0000000000008082ULL,

--- a/mldsa/src/fips202/keccakf1600.h
+++ b/mldsa/src/fips202/keccakf1600.h
@@ -43,6 +43,7 @@ __contract__(
     assigns(memory_slice(state, sizeof(uint64_t) * MLD_KECCAK_LANES))
 );
 
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 #define mld_keccakf1600x4_extract_bytes \
   MLD_NAMESPACE(keccakf1600x4_extract_bytes)
 MLD_INTERNAL_API
@@ -93,6 +94,7 @@ __contract__(
     requires(memory_no_alias(state, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY))
     assigns(memory_slice(state, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY))
 );
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 #define mld_keccakf1600_permute MLD_NAMESPACE(keccakf1600_permute)
 MLD_INTERNAL_API

--- a/mldsa/src/fips202/native/aarch64/auto.h
+++ b/mldsa/src/fips202/native/aarch64/auto.h
@@ -37,6 +37,7 @@
 #include "x1_scalar.h"
 #endif
 
+#if !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 /*
  * Keccak-f1600x2/x4
  *
@@ -67,5 +68,7 @@
 #include "x4_v8a_scalar.h"
 
 #endif /* !__ARM_FEATURE_SHA3 */
+
+#endif /* !MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 #endif /* !MLD_FIPS202_NATIVE_AARCH64_AUTO_H */

--- a/mldsa/src/fips202/native/auto.h
+++ b/mldsa/src/fips202/native/auto.h
@@ -16,7 +16,8 @@
 #include "aarch64/auto.h"
 #endif
 
-#if defined(MLD_SYS_X86_64) && defined(MLD_SYS_X86_64_AVX2)
+#if defined(MLD_SYS_X86_64) && defined(MLD_SYS_X86_64_AVX2) && \
+    !defined(MLD_CONFIG_SERIAL_FIPS202_ONLY)
 #include "x86_64/xkcp.h"
 #endif
 


### PR DESCRIPTION
Match the AArch64 behavior and skip the native Keccak-f1600x4 backend when MLD_CONFIG_SERIAL_FIPS202_ONLY or MLD_CONFIG_REDUCE_RAM is set.

This change was part of PR #1000 but doesn't need to be part of that stack.