### PR TITLE
CI: Sync with mlkem-native (RISC-V runners, fork guards, examples, benchmarking)

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -218,6 +218,50 @@ jobs:
       - name: make lib
         run: |
           make lib
+  examples:
+    name: Examples
+    strategy:
+      matrix:
+        system: [macos-latest, macos-15-intel, ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: basic
+        run: |
+          CFLAGS="-O0" make run -C examples/basic
+      - name: basic_deterministic
+        run: |
+          CFLAGS="-O0" make run -C examples/basic_deterministic
+      - name: basic_lowram
+        run: |
+          CFLAGS="-O0" make run -C examples/basic_lowram
+      - name: bring_your_own_fips202
+        run: |
+          CFLAGS="-O0" make run -C examples/bring_your_own_fips202
+      - name: bring_your_own_fips202_static
+        run: |
+          CFLAGS="-O0" make run -C examples/bring_your_own_fips202_static
+      - name: custom_backend
+        run: |
+          CFLAGS="-O0" make run -C examples/custom_backend
+      - name: monolithic_build
+        run: |
+          CFLAGS="-O0" make run -C examples/monolithic_build
+      - name: monolithic_build_native
+        run: |
+          CFLAGS="-O0" make run -C examples/monolithic_build_native
+      - name: monolithic_build_multilevel
+        run: |
+          CFLAGS="-O0" make run -C examples/monolithic_build_multilevel
+      - name: monolithic_build_multilevel_native
+        run: |
+          CFLAGS="-O0" make run -C examples/monolithic_build_multilevel_native
+      - name: multilevel_build
+        run: |
+          CFLAGS="-O0" make run -C examples/multilevel_build
+      - name: multilevel_build_native
+        run: |
+          CFLAGS="-O0" make run -C examples/multilevel_build_native
   simpasm:
     strategy:
       fail-fast: false
@@ -233,7 +277,7 @@ jobs:
            - arg: '--no-simplify'
              name: Unmodified
     runs-on: ubuntu-24.04-arm
-    name: AArch64 dev backend (${{ matrix.simplify.name }})
+    name: AArch64 dev backend (${{ matrix.backend.name }}, ${{ matrix.simplify.name }})
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Reinstate and test backend
@@ -242,7 +286,7 @@ jobs:
           nix-shell: 'ci'
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            ./scripts/autogen ${{ matrix.simplify.arg }}
+            ./scripts/autogen ${{ matrix.backend.arg }} ${{ matrix.simplify.arg }}
             make clean
             OPT=1 make quickcheck
   x86_64_intel_syntax:

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -35,6 +35,9 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
+         # via https://riseproject-dev.github.io/riscv-runner/
+         - runner: ubuntu-24.04-riscv
+           name: 'riscv'
          - runner: macos-latest
            name: 'macos (aarch64)'
          - runner: macos-15-intel
@@ -69,6 +72,9 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
+         # via https://riseproject-dev.github.io/riscv-runner/
+         - runner: ubuntu-24.04-riscv
+           name: 'riscv'
         acvp-version: [v1.1.0.39, v1.1.0.40, v1.1.0.41]
         exclude:
           - {external: true,
@@ -215,7 +221,7 @@ jobs:
   simpasm:
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         backend:
            - arg: '--aarch64-clean'
              name: Clean

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,15 +29,15 @@ jobs:
       fail-fast: true
       matrix:
        target:
-        # - system: rpi4
-        #   name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
-        #   bench_pmu: PMU
-        #   archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
-        #   cflags: "-flto -DMLD_FORCE_AARCH64"
-        #   ldflags: "-flto"
-        #   bench_extra_args: ""
-        #   nix_shell: bench
-        #   only_no_opt: false
+        - system: rpi4
+          name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
+          bench_pmu: PMU
+          archflags: -mcpu=cortex-a72 -DMLD_SYS_AARCH64_SLOW_BARREL_SHIFTER
+          cflags: "-flto -DMLD_FORCE_AARCH64"
+          ldflags: "-flto"
+          bench_extra_args: ""
+          nix_shell: bench
+          only_no_opt: false
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
           bench_pmu: PERF
@@ -48,34 +48,34 @@ jobs:
           nix_shell: bench
           only_no_opt: false
           cross_prefix: ""
-        # - system: a55
-        #   name: Arm Cortex-A55 (Snapdragon 888) benchmarks
-        #   bench_pmu: PERF
-        #   archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-        #   cflags: "-flto -DMLD_FORCE_AARCH64"
-        #   ldflags: "-flto -static"
-        #   bench_extra_args: -w exec-on-a55
-        #   nix_shell: bench
-        #   only_no_opt: false
-        # - system: bpi
-        #   name: SpacemiT K1 8 (Banana Pi F3) benchmarks
-        #   bench_pmu: PERF
-        #   archflags: "-march=rv64imafdcv_zicsr_zifencei"
-        #   cflags: ""
-        #   ldflags: "-static"
-        #   bench_extra_args: -w exec-on-bpi
-        #   cross_prefix: riscv64-unknown-linux-gnu-
-        #   nix_shell: cross-riscv64
-        #   only_no_opt: true
-        # - system: m1-mac-mini
-        #   name: Mac Mini (M1, 2020) benchmarks
-        #   bench_pmu: MAC
-        #   archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
-        #   cflags: "-flto"
-        #   ldflags: "-flto"
-        #   bench_extra_args: "-r"
-        #   nix_shell: bench
-        #   only_no_opt: false
+        - system: a55
+          name: Arm Cortex-A55 (Snapdragon 888) benchmarks
+          bench_pmu: PERF
+          archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
+          cflags: "-flto -DMLD_FORCE_AARCH64"
+          ldflags: "-flto -static"
+          bench_extra_args: -w exec-on-a55
+          nix_shell: bench
+          only_no_opt: false
+        - system: bpi
+          name: SpacemiT K1 8 (Banana Pi F3) benchmarks
+          bench_pmu: PERF
+          archflags: "-march=rv64imafdcv_zicsr_zifencei"
+          cflags: ""
+          ldflags: "-static"
+          bench_extra_args: -w exec-on-bpi
+          cross_prefix: riscv64-unknown-linux-gnu-
+          nix_shell: cross-riscv64
+          only_no_opt: true
+        - system: m1-mac-mini
+          name: Mac Mini (M1, 2020) benchmarks
+          bench_pmu: MAC
+          archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
+          cflags: "-flto"
+          ldflags: "-flto"
+          bench_extra_args: "-r"
+          nix_shell: bench
+          only_no_opt: false
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
     runs-on: self-hosted-${{ matrix.target.system }}
     steps:

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -54,6 +54,7 @@ jobs:
   opentitan_build:
     name: OpenTitan ML-DSA Build Test
     needs: start-ec2-runner
+    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
     runs-on: ${{ needs.start-ec2-runner.outputs.label }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,9 @@ ifeq ($(ARCH),x86_64)
 else ifeq ($(ARCH),aarch64)
 	@echo "=== AArch64 Feature Support ==="
 	@echo "SHA3: Host $(if $(filter 1,$(MK_HOST_SUPPORTS_SHA3)),✅,❌) Compiler $(if $(filter 1,$(MK_COMPILER_SUPPORTS_SHA3)),✅,❌)"
+else ifeq ($(ARCH),riscv64)
+	@echo "=== RISC-V 64-bit Feature Support ==="
+	@echo "RVV: Host $(if $(filter 1,$(MK_HOST_SUPPORTS_RVV)),✅,❌) Compiler $(if $(filter 1,$(MK_COMPILER_SUPPORTS_RVV)),✅,❌)"
 else
 	@echo "=== Architecture Not Supported ==="
 	@echo "No specific feature detection available for $(ARCH)"

--- a/test/mk/auto.mk
+++ b/test/mk/auto.mk
@@ -68,6 +68,14 @@ MK_COMPILER_SUPPORTS_SHA3 ?= $(shell echo 'int main() { __asm__("eor3 v0.16b, v1
 
 endif # aarch64 compiler detection
 
+# RISC-V 64-bit compiler feature detection
+ifeq ($(ARCH),riscv64)
+
+# Test RVV support using C with inline assembly
+MK_COMPILER_SUPPORTS_RVV ?= $(shell echo 'int main() { __asm__("vadd.vv v0, v1, v2"); return 0; }' | $(CC) -march=rv64gcv -x c - -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+
+endif # riscv64 compiler detection
+
 # Define HOST_PLATFORM if not already defined
 HOST_PLATFORM ?= $(shell uname -s)-$(shell uname -m)
 
@@ -125,6 +133,25 @@ endif # HOST_PLATFORM aarch64
 
 endif # aarch64
 
+# RISC-V 64-bit architecture detection
+ifeq ($(ARCH),riscv64)
+
+# Host CPU feature detection for RISC-V 64-bit
+ifeq ($(HOST_PLATFORM),Linux-riscv64)
+# Linux: Parse ISA string from /proc/cpuinfo
+# Format: rv64imafdcv_sscofpmf_... -- extract single-letter extensions
+# (before first '_') and check for 'v'
+MK_HOST_SUPPORTS_RVV := $(shell sed -n '/^isa/{s/.*rv64//;s/_.*//;p;q}' /proc/cpuinfo 2>/dev/null | grep -q v && echo 1 || echo 0)
+else ifneq ($(CROSS_PREFIX),)
+# Cross-compilation: assume all features are supported
+MK_HOST_SUPPORTS_RVV := 1
+else
+# Other platforms: assume no support
+MK_HOST_SUPPORTS_RVV := 0
+endif # HOST_PLATFORM riscv64
+
+endif # riscv64
+
 # Only apply CFLAGS modifications if AUTO=1
 ifeq ($(AUTO),1)
 
@@ -160,7 +187,11 @@ endif # aarch64_be
 # RISC-V 64-bit CFLAGS configuration
 ifeq ($(ARCH),riscv64)
 CFLAGS += -DMLD_FORCE_RISCV64
+
+# Add RVV flags only if both compiler and host support it
+ifeq ($(MK_COMPILER_SUPPORTS_RVV)$(MK_HOST_SUPPORTS_RVV),11)
 CFLAGS += -march=rv64gcv
+endif
 endif # riscv64
 
 # RISC-V 32-bit CFLAGS configuration


### PR DESCRIPTION
  - Skip OpenTitan build on fork PRs (port of pq-code-package/mlkem-native#1649)                                          
  - Add RISC-V runners to base CI via RISE project (port of pq-code-package/mlkem-native#1643)
  - Reenable benchmarking on self-hosted runners (port of https://github.com/pq-code-package/mlkem-native/pull/1641)                      
  - Add `examples` job and wire `simpasm` backend matrix axis through to autogen, matching mlkem-native  