### PR TITLE
CT: Update comment on valgrind issue

### DIFF
--- a/.github/actions/ct-test/action.yml
+++ b/.github/actions/ct-test/action.yml
@@ -44,7 +44,8 @@ runs:
           # --vex-guest-max-insns=55 (default is 60) is a workaround for 
           # "VEX temporary storage exhausted" errors in the x86 backend (poly_chknorm)
           # It may increase run-time of the valgrind tests.
-          # TODO: Check with future versions of valgrind if this is still needed (both 3.24 and 3.25 fail without)
+          # TODO: Check with future versions of valgrind if this is still needed (3.24, 3.25, 3.26 fail without)
+          # Last checked: 12/04/26
           # TODO: Check if this is still needed once the poly_chknorm intrinsics implementation is replaced by assembly
           # Disable the AArch64 SHA3 extension as it's not yet supported by valgrind
           MK_COMPILER_SUPPORTS_SHA3=0 tests func --exec-wrapper="valgrind --vex-guest-max-insns=55 --error-exitcode=1 ${{ inputs.valgrind_flags }}" --cflags="-DMLD_CONFIG_CT_TESTING_ENABLED -DNTESTS=5 ${{ inputs.cflags }}"


### PR DESCRIPTION
I was hoping to be able to remove the workaround, but it turns out to persist in v3.26.