### PR TITLE
Fix context-length validation in ACVP test binary

### DIFF
--- a/test/acvp/acvp_mldsa.c
+++ b/test/acvp/acvp_mldsa.c
@@ -644,7 +644,7 @@ int main(int argc, char *argv[])
         goto siggen_usage;
       }
       ctxlen = (strlen(*argv) - strlen("context=")) / 2;
-      if (mlen > MAX_MSG_LENGTH ||
+      if (ctxlen > MAX_CTX_LENGTH ||
           decode_hex("context", context, ctxlen, *argv) != 0)
       {
         goto siggen_usage;
@@ -745,7 +745,7 @@ int main(int argc, char *argv[])
         goto siggen_deterministic_usage;
       }
       ctxlen = (strlen(*argv) - strlen("context=")) / 2;
-      if (mlen > MAX_MSG_LENGTH ||
+      if (ctxlen > MAX_CTX_LENGTH ||
           decode_hex("context", context, ctxlen, *argv) != 0)
       {
         goto siggen_deterministic_usage;
@@ -825,7 +825,7 @@ int main(int argc, char *argv[])
         goto sigver_usage;
       }
       ctxlen = (strlen(*argv) - strlen("context=")) / 2;
-      if (mlen > MAX_MSG_LENGTH ||
+      if (ctxlen > MAX_CTX_LENGTH ||
           decode_hex("context", context, ctxlen, *argv) != 0)
       {
         goto sigver_usage;


### PR DESCRIPTION
Three places in acvp_mldsa.c validated the context argument length using `mlen > MAX_MSG_LENGTH` instead of `ctxlen > MAX_CTX_LENGTH`, meaning an oversized context would not be caught before being written into a MAX_CTX_LENGTH-sized stack buffer.