### PR TITLE
CBMC: Restore polyvecl_pointwise_acc_montgomery_c proof flags

### DIFF
--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
@@ -27,6 +27,7 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
+CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 
 FUNCTION_NAME = mld_polyvecl_pointwise_acc_montgomery_c
@@ -38,7 +39,7 @@ FUNCTION_NAME = mld_polyvecl_pointwise_acc_montgomery_c
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 14
+CBMC_OBJECT_BITS = 13
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
Hoisted from @mkannwischer's PR https://github.com/pq-code-package/mldsa-native/pull/1011/