### PR TITLE
poly_ntt_c add --slice-formula to stabilize proof

### DIFF
--- a/proofs/cbmc/poly_ntt_c/Makefile
+++ b/proofs/cbmc/poly_ntt_c/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --slice-formula
 
 FUNCTION_NAME = mld_poly_ntt_c
 


### PR DESCRIPTION
Add --slice-formula in proof of poly_ntt_c() to stabilize proof performance on both macOS and Linux platforms.
