### PR TITLE
Update s2n-bignum and HOL Light pins

### DIFF
--- a/nix/hol_light/default.nix
+++ b/nix/hol_light/default.nix
@@ -9,12 +9,12 @@ hol_light.overrideAttrs (old: {
     export HOLLIGHT_DIR="$1/lib/hol_light"
     export PATH="$1/lib/hol_light:$PATH"
   '';
-  version = "unstable-2026-03-20";
+  version = "unstable-2026-04-17";
   src = fetchFromGitHub {
     owner = "jrh13";
     repo = "hol-light";
-    rev = "6df9b2115135fd3321e3975827f89e7ea03ffaa0";
-    hash = "sha256-qOKksOUq9lfMn5gWdLJqDvvD5FY68k+9wJ9KbdBg0LE=";
+    rev = "af5d20e033025a9f30a490d9c39edace632405a3";
+    hash = "sha256-R5hSHguVu7YPP7bnFJQ1Prc8Yy3L41LAB20LfEr/RUw=";
   };
   patches = [
     ./0005-Configure-hol-sh-for-mldsa-native.patch

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -4,12 +4,12 @@
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";
-  version = "ca6ec31a225aaac11813d4055bbc55a0251b9452";
+  version = "b70f1349bdc930769dbe5fee070044c27395e70a";
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "s2n-bignum";
     rev = "${version}";
-    hash = "sha256-60gaEW0Afkn/Ukd4wZAab0Nz7XkbWvN4+Q+LgqUv0Ho=";
+    hash = "sha256-zZYIOp3bL/Asr4RdDYDFH804EJoRB4CKFmjKZepKEvA=";
   };
   setupHook = writeText "setup-hook.sh" ''
     export S2N_BIGNUM_DIR="$1"


### PR DESCRIPTION
## Summary

- Update s2n-bignum pin from `ca6ec31a` to `b70f1349` (latest main), adding `word_2smulh`, `word_ishr_round` and other instruction definitions needed by upcoming poly_use_hint proofs
- Update HOL Light pin from `6df9b211` to `af5d20e0` to include `word_pmul` in `Library/words.ml`, needed for compatibility with the updated s2n-bignum
