### PR TITLE
Remove --slice-formula from all Makefiles and set in Makefile.common

### DIFF
--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -543,9 +543,27 @@ SPACE :=$() $()
 COMMA :=,
 
 ################################################################
-# Set C compiler defines
+# CBMC team recommend that --no-array-field-sensitivity should never be used
+# with CBMC 6.9.0 and above when --slice-formula has been specified
+ifeq ($(findstring --no-array-field-sensitivity,$(CBMCFLAGS)),--no-array-field-sensitivity)
+$(error CBMC option --no-array-field-sensitivity is believed to be detrimental to performance in CBMC v6.9.0 and has been removed from the CBMC Makefiles -- do you really want this?)
+endif
 
+################################################################
+# CBMC team recommend that --slice-formula should _always_ be used
+# so we reject it here if it is already specified in a per-function Makefile
+ifeq ($(findstring --slice-formula,$(CBMCFLAGS)),--slice-formula)
+$(error CBMC option --slice-formula is set by default in Makefile.common, so should not be specified in a function-specific Makefile)
+endif
+
+################################################################
+# CBMC flags common to all proofs
+CBMCFLAGS += $(CBMC_FLAG_FLUSH)
 CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+CBMCFLAGS += --slice-formula
+
+################################################################
+# Set C compiler defines
 
 DEFINES += -DCBMC=1
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)

--- a/proofs/cbmc/attempt_signature_generation/Makefile
+++ b/proofs/cbmc/attempt_signature_generation/Makefile
@@ -48,7 +48,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mld_attempt_signature_generation
 

--- a/proofs/cbmc/compute_pack_z/Makefile
+++ b/proofs/cbmc/compute_pack_z/Makefile
@@ -34,7 +34,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mld_compute_pack_z
 

--- a/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--bitwuzla
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mld_keccak_squeezeblocks_x4
 

--- a/proofs/cbmc/keccakf1600x4_permute/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute/Makefile
@@ -28,7 +28,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mld_keccakf1600x4_permute
 

--- a/proofs/cbmc/keccakf1600x4_permute_native/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute_native/Makefile
@@ -28,7 +28,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mld_keccakf1600x4_permute_native
 

--- a/proofs/cbmc/pack_pk/Makefile
+++ b/proofs/cbmc/pack_pk/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = pack_pk
 

--- a/proofs/cbmc/pack_sig_h_poly/Makefile
+++ b/proofs/cbmc/pack_sig_h_poly/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS+=--slice-formula
 
 FUNCTION_NAME = pack_sig_h_poly
 

--- a/proofs/cbmc/pack_sig_z/Makefile
+++ b/proofs/cbmc/pack_sig_z/Makefile
@@ -26,7 +26,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS+=--slice-formula
 
 FUNCTION_NAME = pack_sig_z
 

--- a/proofs/cbmc/poly_add/Makefile
+++ b/proofs/cbmc/poly_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = poly_add
 

--- a/proofs/cbmc/poly_challenge/Makefile
+++ b/proofs/cbmc/poly_challenge/Makefile
@@ -32,7 +32,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = poly_challenge
 

--- a/proofs/cbmc/poly_invntt_tomont_c/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont_c/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_smt_only --z3
 
 FUNCTION_NAME = mld_poly_invntt_tomont_c
 

--- a/proofs/cbmc/poly_ntt_c/Makefile
+++ b/proofs/cbmc/poly_ntt_c/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = mld_poly_ntt_c
 

--- a/proofs/cbmc/poly_uniform/Makefile
+++ b/proofs/cbmc/poly_uniform/Makefile
@@ -33,7 +33,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = poly_uniform
 

--- a/proofs/cbmc/poly_uniform_gamma1_4x/Makefile
+++ b/proofs/cbmc/poly_uniform_gamma1_4x/Makefile
@@ -30,7 +30,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = poly_uniform_gamma1_4x
 

--- a/proofs/cbmc/polyvec_matrix_expand_eager/Makefile
+++ b/proofs/cbmc/polyvec_matrix_expand_eager/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvec_matrix_expand_eager
 

--- a/proofs/cbmc/polyvec_matrix_expand_eager_serial/Makefile
+++ b/proofs/cbmc/polyvec_matrix_expand_eager_serial/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = polyvec_matrix_expand_eager_serial
 

--- a/proofs/cbmc/polyvec_matrix_pointwise_montgomery_eager/Makefile
+++ b/proofs/cbmc/polyvec_matrix_pointwise_montgomery_eager/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = polyvec_matrix_pointwise_montgomery_eager
 

--- a/proofs/cbmc/polyveck_add/Makefile
+++ b/proofs/cbmc/polyveck_add/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = polyveck_add
 

--- a/proofs/cbmc/polyveck_chknorm/Makefile
+++ b/proofs/cbmc/polyveck_chknorm/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_chknorm
 

--- a/proofs/cbmc/polyveck_decompose/Makefile
+++ b/proofs/cbmc/polyveck_decompose/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_decompose
 

--- a/proofs/cbmc/polyveck_pack_eta/Makefile
+++ b/proofs/cbmc/polyveck_pack_eta/Makefile
@@ -26,7 +26,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_pack_eta
 

--- a/proofs/cbmc/polyveck_pack_t0/Makefile
+++ b/proofs/cbmc/polyveck_pack_t0/Makefile
@@ -26,7 +26,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyveck_pack_t0
 

--- a/proofs/cbmc/polyveck_pointwise_poly_montgomery/Makefile
+++ b/proofs/cbmc/polyveck_pointwise_poly_montgomery/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = polyveck_pointwise_poly_montgomery
 

--- a/proofs/cbmc/polyveck_power2round/Makefile
+++ b/proofs/cbmc/polyveck_power2round/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = polyveck_power2round
 

--- a/proofs/cbmc/polyvecl_chknorm/Makefile
+++ b/proofs/cbmc/polyvecl_chknorm/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvecl_chknorm
 

--- a/proofs/cbmc/polyvecl_pack_eta/Makefile
+++ b/proofs/cbmc/polyvecl_pack_eta/Makefile
@@ -26,7 +26,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvecl_pack_eta
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_smt_only --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvecl_pointwise_acc_montgomery
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mld_polyvecl_pointwise_acc_montgomery_c
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery_native/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery_native/Makefile
@@ -34,7 +34,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_smt_only --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = polyvecl_pointwise_acc_montgomery_native
 

--- a/proofs/cbmc/prepare_domain_separation_prefix/Makefile
+++ b/proofs/cbmc/prepare_domain_separation_prefix/Makefile
@@ -26,7 +26,6 @@ FUNCTION_NAME = prepare_domain_separation_prefix
 
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 CBMC_OBJECT_BITS = 8
 

--- a/proofs/cbmc/sign/Makefile
+++ b/proofs/cbmc/sign/Makefile
@@ -28,7 +28,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign
 

--- a/proofs/cbmc/sign_keypair/Makefile
+++ b/proofs/cbmc/sign_keypair/Makefile
@@ -30,7 +30,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_keypair
 

--- a/proofs/cbmc/sign_keypair_internal/Makefile
+++ b/proofs/cbmc/sign_keypair_internal/Makefile
@@ -42,7 +42,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_keypair_internal
 

--- a/proofs/cbmc/sign_open/Makefile
+++ b/proofs/cbmc/sign_open/Makefile
@@ -28,7 +28,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_open
 

--- a/proofs/cbmc/sign_pk_from_sk/Makefile
+++ b/proofs/cbmc/sign_pk_from_sk/Makefile
@@ -45,7 +45,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_pk_from_sk
 

--- a/proofs/cbmc/sign_signature/Makefile
+++ b/proofs/cbmc/sign_signature/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_signature
 

--- a/proofs/cbmc/sign_signature_extmu/Makefile
+++ b/proofs/cbmc/sign_signature_extmu/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_signature_extmu
 

--- a/proofs/cbmc/sign_signature_internal/Makefile
+++ b/proofs/cbmc/sign_signature_internal/Makefile
@@ -32,7 +32,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_signature_internal
 

--- a/proofs/cbmc/sign_signature_pre_hash_internal/Makefile
+++ b/proofs/cbmc/sign_signature_pre_hash_internal/Makefile
@@ -28,7 +28,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_signature_pre_hash_internal
 

--- a/proofs/cbmc/sign_signature_pre_hash_shake256/Makefile
+++ b/proofs/cbmc/sign_signature_pre_hash_shake256/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_signature_pre_hash_shake256
 

--- a/proofs/cbmc/sign_verify/Makefile
+++ b/proofs/cbmc/sign_verify/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_verify
 

--- a/proofs/cbmc/sign_verify_extmu/Makefile
+++ b/proofs/cbmc/sign_verify_extmu/Makefile
@@ -28,7 +28,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_verify_extmu
 

--- a/proofs/cbmc/sign_verify_internal/Makefile
+++ b/proofs/cbmc/sign_verify_internal/Makefile
@@ -47,7 +47,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_verify_internal
 

--- a/proofs/cbmc/sign_verify_pre_hash_internal/Makefile
+++ b/proofs/cbmc/sign_verify_pre_hash_internal/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_verify_pre_hash_internal
 

--- a/proofs/cbmc/sign_verify_pre_hash_shake256/Makefile
+++ b/proofs/cbmc/sign_verify_pre_hash_shake256/Makefile
@@ -29,7 +29,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = sign_verify_pre_hash_shake256
 

--- a/proofs/cbmc/unpack_hints/Makefile
+++ b/proofs/cbmc/unpack_hints/Makefile
@@ -26,7 +26,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS+=--slice-formula
 
 FUNCTION_NAME = mld_unpack_hints
 

--- a/proofs/cbmc/unpack_sig/Makefile
+++ b/proofs/cbmc/unpack_sig/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS+=--slice-formula
 
 FUNCTION_NAME = unpack_sig
 


### PR DESCRIPTION
Remove --slice-formula from all Makefiles and set in Makefile.common

Also, use SMT-only Z3 tactic for proof of poly_invntt_tomont_c() which is faster with --slice-formula