### PR TITLE
CBMC: Run proofs with MLD_CONFIG_REDUCE_RAM in CI

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -21,6 +21,9 @@ inputs:
   mldsa_parameter_set:
     description: "Security level for ML-DSA (2,3,5)"
     default: "2"
+  reduce_ram:
+    description: "Run CBMC proofs with MLD_CONFIG_REDUCE_RAM enabled"
+    default: "false"
   gh_token:
     description: Github access token to use
     required: true
@@ -50,13 +53,21 @@ runs:
               - Cadical Version $(cadical --version)
               - $(bash --version | grep -m1 "")
             EOF
-      - name: Run CBMC proofs (MLD_CONFIG_PARAMETER_SET=${{ inputs.mldsa_parameter_set }})
+      - name: Run CBMC proofs (MLD_CONFIG_PARAMETER_SET=${{ inputs.mldsa_parameter_set }}, reduce_ram=${{ inputs.reduce_ram }})
         shell: ${{ env.SHELL }}
         env:
           GH_TOKEN: ${{ inputs.gh_token }}
         run: |
           echo "::group::cbmc_${{ inputs.mldsa_parameter_set }}"
-          tests cbmc --mldsa-parameter-set ${{ inputs.mldsa_parameter_set }} --per-proof-timeout 1800 --output-result-json ${{ github.workspace }}/cbmc_result_${{ inputs.mldsa_parameter_set }}.json || cbmc_failed=true
+          reduce_ram_flag=""
+          data_dir="dev/cbmc"
+          variant=""
+          if [ "${{ inputs.reduce_ram }}" = "true" ]; then
+            reduce_ram_flag="--reduce-ram"
+            data_dir="dev/cbmc-reduce-ram"
+            variant="reduce-ram"
+          fi
+          tests cbmc --mldsa-parameter-set ${{ inputs.mldsa_parameter_set }} --per-proof-timeout 1800 --output-result-json ${{ github.workspace }}/cbmc_result_${{ inputs.mldsa_parameter_set }}.json $reduce_ram_flag || cbmc_failed=true
           echo "::endgroup::"
           python3 ${{ github.action_path }}/report.py \
             --results-json "${{ github.workspace }}/cbmc_result_${{ inputs.mldsa_parameter_set }}.json" \
@@ -64,5 +75,6 @@ runs:
             --min-runtime 20 \
             --regression-threshold 1.5 \
             --gh-pages-branch gh-pages \
-            --data-dir dev/cbmc
+            --data-dir "$data_dir" \
+            --variant "$variant"
           if [ "$cbmc_failed" = "true" ]; then exit 1; fi

--- a/.github/actions/cbmc/report.py
+++ b/.github/actions/cbmc/report.py
@@ -39,6 +39,12 @@ def get_args():
     parser.add_argument("--regression-threshold", type=float, default=1.5)
     parser.add_argument("--gh-pages-branch", default="gh-pages")
     parser.add_argument("--data-dir", default="dev/cbmc")
+    parser.add_argument(
+        "--variant",
+        default="",
+        help="Optional label distinguishing a build variant (e.g. 'reduce-ram'). "
+        "Used in PR comment tag/title so variants don't overwrite each other.",
+    )
     return parser.parse_args()
 
 
@@ -155,8 +161,8 @@ def build_comment(current, baseline, cfg):
         alerts.insert(0, total_row)
 
     lines = [
-        f"<!-- {COMMENT_TAG}(start): mldsa-{cfg.param_set} -->",
-        f"## CBMC Results (ML-DSA-{cfg.param_set})",
+        f"<!-- {COMMENT_TAG}(start): mldsa-{cfg.param_set}{cfg.tag_suffix} -->",
+        f"## CBMC Results (ML-DSA-{cfg.param_set}{cfg.title_suffix})",
         "",
     ]
 
@@ -175,7 +181,7 @@ def build_comment(current, baseline, cfg):
             "",
             "</details>",
             "",
-            f"<!-- {COMMENT_TAG}(end): mldsa-{cfg.param_set} -->",
+            f"<!-- {COMMENT_TAG}(end): mldsa-{cfg.param_set}{cfg.tag_suffix} -->",
         ]
     )
     return "\n".join(lines)
@@ -183,7 +189,7 @@ def build_comment(current, baseline, cfg):
 
 def post_or_update_comment(pr_number, body, cfg):
     """Post or update PR comment."""
-    tag = f"<!-- {COMMENT_TAG}(start): mldsa-{cfg.param_set} -->"
+    tag = f"<!-- {COMMENT_TAG}(start): mldsa-{cfg.param_set}{cfg.tag_suffix} -->"
     result = subprocess.run(
         [
             "gh",
@@ -279,6 +285,8 @@ def push_to_gh_pages(current, cfg):
 def main():
     args = get_args()
     args.param_set = args.mldsa_parameter_set
+    args.tag_suffix = f"-{args.variant}" if args.variant else ""
+    args.title_suffix = f", {args.variant.upper()}" if args.variant else ""
 
     with open(args.results_json) as f:
         current = json.load(f)

--- a/.github/actions/cbmc/report.py
+++ b/.github/actions/cbmc/report.py
@@ -23,6 +23,7 @@ COMMENT_TAG = "cbmc-report"
 OK = "✅"
 WARN = "⚠️"
 FAIL = "❌"
+SKIP = "⏭️"
 
 ProofResult = namedtuple(
     "ProofResult", ["name", "status", "current", "previous", "change"]
@@ -134,8 +135,26 @@ def build_comment(current, baseline, cfg):
         if is_alert:
             alerts.append(result)
 
+    skipped = sorted(current.get("skipped", []))
+    skipped_rows = []
+    for name in skipped:
+        base = baseline_runtimes.get(name, {})
+        if base.get("status") == "failed":
+            prev = "failed"
+        elif base.get("value") is not None:
+            prev = f"{base['value']}s"
+        else:
+            prev = "-"
+        skipped_rows.append(ProofResult(name, SKIP, "skipped", prev, "-"))
+    alerts.extend(skipped_rows)
+    all_rows.extend(skipped_rows)
+
     def sort_key(r):
-        return -1 if r.current == "-" else -int(r.current.rstrip("s"))
+        if r.current == "skipped":
+            return 1  # skipped proofs sink below any timed row
+        if r.current == "-":
+            return -1
+        return -int(r.current.rstrip("s"))
 
     all_rows.sort(key=sort_key)
 
@@ -166,10 +185,17 @@ def build_comment(current, baseline, cfg):
         "",
     ]
 
+    if skipped:
+        lines += [
+            f"{SKIP} **{len(skipped)} proof(s) skipped** "
+            f"(see `proofs/cbmc/reduce_ram_skip.txt`)",
+            "",
+        ]
+
     if alerts:
         lines += [f"{WARN} **Attention Required**", ""] + render_table(alerts) + [""]
 
-    total = current.get("summary", {}).get("total", len(all_rows))
+    total = current.get("summary", {}).get("total", len(all_rows)) + len(skipped)
     lines += (
         [
             "<details>",

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -35,9 +35,10 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
+         # TODO: RISE riscv runner currently fails during apt install — re-enable once fixed.
          # via https://riseproject-dev.github.io/riscv-runner/
-         - runner: ubuntu-24.04-riscv
-           name: 'riscv'
+         # - runner: ubuntu-24.04-riscv
+         #   name: 'riscv'
          - runner: macos-latest
            name: 'macos (aarch64)'
          - runner: macos-15-intel
@@ -72,9 +73,10 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
+         # TODO: RISE riscv runner currently fails during apt install — re-enable once fixed.
          # via https://riseproject-dev.github.io/riscv-runner/
-         - runner: ubuntu-24.04-riscv
-           name: 'riscv'
+         # - runner: ubuntu-24.04-riscv
+         #   name: 'riscv'
         acvp-version: [v1.1.0.39, v1.1.0.40, v1.1.0.41]
         exclude:
           - {external: true,

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -9,16 +9,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  cbmc_44:
-    name: CBMC (ML-DSA-44)
+  cbmc:
+    name: CBMC (ML-DSA-${{ matrix.parameter_set }}${{ matrix.reduce_ram && ', REDUCE_RAM' || '' }})
     if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: 'read'
       id-token: 'write'
       pull-requests: 'write'
+    strategy:
+      fail-fast: false
+      matrix:
+        parameter_set: [44, 65, 87]
+        reduce_ram: [false, true]
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
-      name: CBMC (ML-DSA-44)
+      name: CBMC (ML-DSA-${{ matrix.parameter_set }}${{ matrix.reduce_ram && ', REDUCE_RAM' || '' }})
       ec2_instance_type: c7g.4xlarge
       ec2_ami: ubuntu-latest (aarch64)
       ec2_volume_size: 20
@@ -30,51 +35,6 @@ jobs:
       kattest: false
       acvptest: false
       cbmc: true
-      cbmc_mldsa_parameter_set: 44
-    secrets: inherit
-  cbmc_65:
-    name: CBMC (ML-DSA-65)
-    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-      pull-requests: 'write'
-    uses: ./.github/workflows/ci_ec2_reusable.yml
-    with:
-      name: CBMC (ML-DSA-65)
-      ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (aarch64)
-      ec2_volume_size: 20
-      compile_mode: native
-      opt: no_opt
-      lint: false
-      verbose: true
-      functest: true
-      kattest: false
-      acvptest: false
-      cbmc: true
-      cbmc_mldsa_parameter_set: 65
-    secrets: inherit
-  cbmc_87:
-    name: CBMC (ML-DSA-87)
-    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-      pull-requests: 'write'
-    uses: ./.github/workflows/ci_ec2_reusable.yml
-    with:
-      name: CBMC (ML-DSA-87)
-      ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (aarch64)
-      ec2_volume_size: 20
-      compile_mode: native
-      opt: no_opt
-      lint: false
-      verbose: true
-      functest: true
-      kattest: false
-      acvptest: false
-      cbmc: true
-      cbmc_mldsa_parameter_set: 87
+      cbmc_mldsa_parameter_set: ${{ matrix.parameter_set }}
+      cbmc_reduce_ram: ${{ matrix.reduce_ram }}
     secrets: inherit

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -71,6 +71,9 @@ on:
       cbmc_mldsa_parameter_set:
         type: string
         default: 44
+      cbmc_reduce_ram:
+        type: boolean
+        default: false
 env:
   AWS_ROLE: arn:aws:iam::904233116199:role/mldsa-native-ci
   AWS_REGION: us-east-1
@@ -201,6 +204,7 @@ jobs:
           nix-shell: cbmc
           nix-verbose: ${{ inputs.verbose }}
           mldsa_parameter_set: ${{ inputs.cbmc_mldsa_parameter_set }}
+          reduce_ram: ${{ inputs.cbmc_reduce_ram }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
       - name: SLOTHY
         if: ${{ inputs.slothy }}

--- a/mldsa/src/cbmc.h
+++ b/mldsa/src/cbmc.h
@@ -5,6 +5,7 @@
 
 #ifndef MLD_CBMC_H
 #define MLD_CBMC_H
+
 /***************************************************
  * Basic replacements for __CPROVER_XXX contracts
  ***************************************************/
@@ -19,6 +20,15 @@
 
 #define __contract__(x) x
 #define __loop__(x) x
+
+/* Conditionally expand to __VA_ARGS__ depending on MLD_CONFIG_REDUCE_RAM. */
+#if defined(MLD_CONFIG_REDUCE_RAM)
+#define MLD_IF_REDUCE_RAM(...) __VA_ARGS__
+#define MLD_IF_NOT_REDUCE_RAM(...)
+#else
+#define MLD_IF_REDUCE_RAM(...)
+#define MLD_IF_NOT_REDUCE_RAM(...) __VA_ARGS__
+#endif
 
 /* https://diffblue.github.io/cbmc/contracts-assigns.html */
 #define assigns(...) __CPROVER_assigns(__VA_ARGS__)

--- a/mldsa/src/packing.h
+++ b/mldsa/src/packing.h
@@ -220,12 +220,14 @@ __contract__(
   assigns(memory_slice(t0, sizeof(mld_sk_t0hat)))
   assigns(memory_slice(s1, sizeof(mld_sk_s1hat)))
   assigns(memory_slice(s2, sizeof(mld_sk_s2hat)))
-  ensures(forall(k0, 0, MLDSA_K,
-    array_abs_bound(t0->vec.vec[k0].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
-  ensures(forall(k1, 0, MLDSA_L,
-    array_abs_bound(s1->vec.vec[k1].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
-  ensures(forall(k2, 0, MLDSA_K,
-    array_abs_bound(s2->vec.vec[k2].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  MLD_IF_NOT_REDUCE_RAM(
+    ensures(forall(k0, 0, MLDSA_K,
+      array_abs_bound(t0->vec.vec[k0].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+    ensures(forall(k1, 0, MLDSA_L,
+      array_abs_bound(s1->vec.vec[k1].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+    ensures(forall(k2, 0, MLDSA_K,
+      array_abs_bound(s2->vec.vec[k2].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  )
 );
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -479,7 +479,9 @@ __contract__(
   requires(array_abs_bound(cp->coeffs, 0, MLDSA_N, MLD_NTT_BOUND))
   requires(forall(k0, 0, MLDSA_L,
     array_bound(y->vec[k0].coeffs, 0, MLDSA_N, -(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1 + 1)))
-  requires(forall(k1, 0, MLDSA_L, array_abs_bound(s1hat->vec.vec[k1].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  MLD_IF_NOT_REDUCE_RAM(
+    requires(forall(k1, 0, MLDSA_L, array_abs_bound(s1hat->vec.vec[k1].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  )
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
   assigns(memory_slice(z, sizeof(mld_poly)))
   assigns(memory_slice(tmp, sizeof(mld_poly)))
@@ -579,11 +581,13 @@ __contract__(
   requires(memory_no_alias(s2hat, sizeof(mld_sk_s2hat)))
   requires(memory_no_alias(t0hat, sizeof(mld_sk_t0hat)))
   requires(nonce <= MLD_NONCE_UB)
-  requires(forall(k1, 0, MLDSA_K, forall(l1, 0, MLDSA_L,
-                                         array_bound(mat->vec[k1].vec[l1].coeffs, 0, MLDSA_N, 0, MLDSA_Q))))
-  requires(forall(k2, 0, MLDSA_K, array_abs_bound(t0hat->vec.vec[k2].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
-  requires(forall(k3, 0, MLDSA_L, array_abs_bound(s1hat->vec.vec[k3].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
-  requires(forall(k4, 0, MLDSA_K, array_abs_bound(s2hat->vec.vec[k4].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  MLD_IF_NOT_REDUCE_RAM(
+    requires(forall(k1, 0, MLDSA_K, forall(l1, 0, MLDSA_L,
+                                           array_bound(mat->vec[k1].vec[l1].coeffs, 0, MLDSA_N, 0, MLDSA_Q))))
+    requires(forall(k2, 0, MLDSA_K, array_abs_bound(t0hat->vec.vec[k2].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+    requires(forall(k3, 0, MLDSA_L, array_abs_bound(s1hat->vec.vec[k3].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+    requires(forall(k4, 0, MLDSA_K, array_abs_bound(s2hat->vec.vec[k4].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+  )
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
   ensures(return_value == 0 || return_value == MLD_ERR_FAIL ||
           return_value == MLD_ERR_OUT_OF_MEMORY)
@@ -832,11 +836,13 @@ int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
     /* t0, s1, s2, and mat are initialized above and are NOT changed by this */
     /* loop. We can therefore re-assert their bounds here as part of the     */
     /* loop invariant. This makes proof noticeably faster with CBMC          */
-    invariant(forall(k1, 0, MLDSA_K, forall(l1, 0, MLDSA_L,
-              array_bound(mat->vec[k1].vec[l1].coeffs, 0, MLDSA_N, 0, MLDSA_Q))))
-    invariant(forall(k2, 0, MLDSA_K, array_abs_bound(t0hat->vec.vec[k2].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
-    invariant(forall(k3, 0, MLDSA_L, array_abs_bound(s1hat->vec.vec[k3].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
-    invariant(forall(k4, 0, MLDSA_K, array_abs_bound(s2hat->vec.vec[k4].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+    MLD_IF_NOT_REDUCE_RAM(
+      invariant(forall(k1, 0, MLDSA_K, forall(l1, 0, MLDSA_L,
+                array_bound(mat->vec[k1].vec[l1].coeffs, 0, MLDSA_N, 0, MLDSA_Q))))
+      invariant(forall(k2, 0, MLDSA_K, array_abs_bound(t0hat->vec.vec[k2].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+      invariant(forall(k3, 0, MLDSA_L, array_abs_bound(s1hat->vec.vec[k3].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+      invariant(forall(k4, 0, MLDSA_K, array_abs_bound(s2hat->vec.vec[k4].coeffs, 0, MLDSA_N, MLD_NTT_BOUND)))
+    )
     invariant(ret == MLD_ERR_FAIL)
     decreases(MLD_NONCE_UB - nonce)
   )

--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -575,6 +575,11 @@ endif
 
 DEFINES += -DMLD_CONFIG_FILE="\"mldsa_native_config_cbmc.h\""
 DEFINES += -DMLD_CONFIG_PARAMETER_SET=$(MLD_CONFIG_PARAMETER_SET)
+
+ifdef MLD_CONFIG_REDUCE_RAM
+DEFINES += -DMLD_CONFIG_REDUCE_RAM
+endif
+
 # Give visibility to all static functions
 DEFINES += -Dstatic=
 

--- a/proofs/cbmc/reduce_ram_skip.txt
+++ b/proofs/cbmc/reduce_ram_skip.txt
@@ -1,0 +1,21 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Proofs to skip when CBMC is run with --reduce-ram. One name per line.
+# TODO(REDUCE_RAM): remove once all proofs cover the REDUCE_RAM configuration.
+poly_uniform_4x
+polyvec_matrix_expand_eager
+polyvec_matrix_expand_eager_serial
+polyvec_matrix_pointwise_montgomery_eager
+polyvecl_pointwise_acc_montgomery
+polyvecl_pointwise_acc_montgomery_c
+polyvecl_pointwise_acc_montgomery_native
+shake128x4_absorb_once
+shake128x4_squeezeblocks
+attempt_signature_generation
+compute_pack_z
+unpack_sk
+sign_keypair_internal
+sign_pk_from_sk
+sign_signature_internal
+sign_verify_internal

--- a/scripts/tests
+++ b/scripts/tests
@@ -890,6 +890,17 @@ class Tests:
             proofs = filter(lambda s: s.strip() != "", p.stdout.decode().split("\n"))
             return list(proofs)
 
+        def load_reduce_ram_skiplist():
+            path = "proofs/cbmc/reduce_ram_skip.txt"
+            if not os.path.exists(path):
+                return set()
+            with open(path) as f:
+                return {
+                    line.strip()
+                    for line in f
+                    if line.strip() and not line.lstrip().startswith("#")
+                }
+
         if self.args.list_functions:
             for p in list_proofs():
                 print(p)
@@ -897,6 +908,8 @@ class Tests:
 
         def run_cbmc_single_step(mldsa_parameter_set, proofs):
             envvars = {"MLD_CONFIG_PARAMETER_SET": mldsa_parameter_set}
+            if self.args.reduce_ram:
+                envvars["MLD_CONFIG_REDUCE_RAM"] = "1"
             scheme = SCHEME.from_mode(mldsa_parameter_set)
             num_proofs = len(proofs)
             for i, func in enumerate(proofs):
@@ -962,10 +975,26 @@ class Tests:
                     proofs += list(filter(lambda x: re.match(pat, x), all_proofs))
                 proofs = sorted(set(proofs))
 
+            # TODO(REDUCE_RAM): remove once all proofs cover the REDUCE_RAM configuration.
+            if self.args.reduce_ram:
+                skip = load_reduce_ram_skiplist()
+                dropped = [p for p in proofs if p in skip]
+                proofs = [p for p in proofs if p not in skip]
+                if dropped:
+                    log.info(
+                        f"Skipping {len(dropped)} proof(s) under --reduce-ram: "
+                        f"{', '.join(dropped)}"
+                    )
+                if not proofs:
+                    log.info("No proofs left to run after --reduce-ram skiplist")
+                    return
+
             if self.args.single_step:
                 run_cbmc_single_step(mldsa_parameter_set, proofs)
                 return
             envvars = {"MLD_CONFIG_PARAMETER_SET": mldsa_parameter_set}
+            if self.args.reduce_ram:
+                envvars["MLD_CONFIG_REDUCE_RAM"] = "1"
             cmd = (
                 [
                     "python3",
@@ -1422,6 +1451,13 @@ def cli():
         "--output-result-json",
         help="Path to export result JSON",
         default=None,
+    )
+
+    cbmc_parser.add_argument(
+        "--reduce-ram",
+        help="Run CBMC proofs with MLD_CONFIG_REDUCE_RAM enabled",
+        action="store_true",
+        default=False,
     )
 
     # hol_light arguments

--- a/scripts/tests
+++ b/scripts/tests
@@ -976,9 +976,10 @@ class Tests:
                 proofs = sorted(set(proofs))
 
             # TODO(REDUCE_RAM): remove once all proofs cover the REDUCE_RAM configuration.
+            dropped = []
             if self.args.reduce_ram:
                 skip = load_reduce_ram_skiplist()
-                dropped = [p for p in proofs if p in skip]
+                dropped = sorted(p for p in proofs if p in skip)
                 proofs = [p for p in proofs if p not in skip]
                 if dropped:
                     log.info(
@@ -1015,6 +1016,17 @@ class Tests:
                 cwd="proofs/cbmc",
                 env=os.environ.copy() | envvars,
             )
+
+            if dropped and self.args.output_result_json:
+                try:
+                    with open(self.args.output_result_json) as f:
+                        data = json.load(f)
+                    data["skipped"] = dropped
+                    data["summary"]["skipped"] = len(dropped)
+                    with open(self.args.output_result_json, "w") as f:
+                        json.dump(data, f, indent=2)
+                except (OSError, json.JSONDecodeError) as e:
+                    log.error(f"Could not annotate result JSON with skiplist: {e}")
 
             if p.returncode != 0:
                 self.fail(f"CBMC proofs for parameter set={mldsa_parameter_set}")


### PR DESCRIPTION
Extend the CBMC test harness and CI to exercise proofs under MLD_CONFIG_REDUCE_RAM in addition to the default configuration.

- scripts/tests: new --reduce-ram flag on the cbmc subcommand that exports MLD_CONFIG_REDUCE_RAM=1 to run-cbmc-proofs.py.
- proofs/cbmc/Makefile.common: propagate MLD_CONFIG_REDUCE_RAM from the environment into -DMLD_CONFIG_REDUCE_RAM.
- .github/workflows/cbmc.yml: collapse the per-parameter-set jobs into a single matrix over parameter_set x reduce_ram, yielding six runs.
- .github/workflows/ci_ec2_reusable.yml, .github/actions/cbmc/action.yml: thread reduce_ram through to the action; use dev/cbmc-reduce-ram as a separate baseline directory so runtime-regression data does not collide with the default-config baseline.
- .github/actions/cbmc/report.py: new --variant option that suffixes the PR comment tag/title so default and reduce_ram variants don't overwrite each other's comments.
- proofs/cbmc/reduce_ram_skip.txt: skiplist of proofs that currently to not work - either because the taret function does not exist in REDUCE_RAM builds or because the proof needs to be adapted.