### PR TITLE
CodeQL: Add mldsa/ declaration visibility check

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -32,6 +32,10 @@ inputs:
     required: false
     description: Determine how to install nix ('installer' | 'apt')
     default: 'installer'
+  impure:
+    required: false
+    description: Pass --impure to nix develop (needed for NIXPKGS_ALLOW_UNFREE)
+    default: 'false'
 
 runs:
   using: composite
@@ -124,6 +128,7 @@ runs:
 
         echo NIX_SHELL="${{ inputs.devShell }}" >> $GITHUB_ENV
         nix_extra_flags="${{ inputs.verbose == 'false' && '--quiet' || '' }}"
+        nix_extra_flags="${nix_extra_flags} ${{ inputs.impure == 'true' && '--impure' || '' }}"
         if [[ ${{ inputs.install }} == 'apt' && ! -f /.dockerenv ]]; then
           echo SHELL="sudo $(which nix) develop $nix_extra_flags .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
         else

--- a/.github/actions/setup-shell/action.yml
+++ b/.github/actions/setup-shell/action.yml
@@ -27,6 +27,9 @@ inputs:
   gh_token:
     description: Github access token to use
     required: true
+  impure:
+    description: Pass --impure to nix develop (needed for NIXPKGS_ALLOW_UNFREE)
+    default: 'false'
 
 runs:
   using: composite
@@ -41,6 +44,7 @@ runs:
         cache: ${{ inputs.nix-cache }}
         script: ${{ inputs.script }}
         cache_prefix: ${{ inputs.nix-cache-prefix }}
+        impure: ${{ inputs.impure }}
     - name: Set custom shell
       shell: bash
       if: ${{ inputs.nix-shell == '' }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -109,3 +109,11 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/isabelle.yml
     secrets: inherit
+  codeql:
+    name: CodeQL
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base, nix ]
+    uses: ./.github/workflows/codeql.yml
+    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,25 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: CodeQL
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  mldsa-declarations:
+    name: mldsa-declarations
+    runs-on: ubuntu-latest
+    env:
+      NIXPKGS_ALLOW_UNFREE: 1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-shell
+        with:
+          nix-shell: codeql
+          impure: 'true'
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            scripts/ql run mldsa-declarations

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test/build
 .direnv
 # Downloaded ACVP test data
 test/acvp/.acvp-data/
+# CodeQL database built by scripts/ql
+.codeql-db/

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,9 @@
           devShells.cbmc = util.mkShell {
             packages = builtins.attrValues { inherit (config.packages) cbmc toolchains_native; } ++ [ pkgs.gh ];
           };
+          devShells.codeql = util.mkShell {
+            packages = [ pkgs.codeql ];
+          };
           devShells.slothy = util.mkShell {
             packages = builtins.attrValues { inherit (config.packages) slothy linters toolchains_native; };
           };

--- a/mldsa/src/poly_kl.c
+++ b/mldsa/src/poly_kl.c
@@ -716,6 +716,7 @@ void mld_polyeta_pack(uint8_t r[MLDSA_POLYETA_PACKEDBYTES], const mld_poly *a)
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API */
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) || !defined(MLD_CONFIG_NO_SIGN_API)
+MLD_INTERNAL_API
 void mld_polyeta_unpack(mld_poly *r, const uint8_t a[MLDSA_POLYETA_PACKEDBYTES])
 {
   unsigned int i;

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -1438,6 +1438,7 @@ static int mld_validate_hash_length(int hashalg, size_t len)
   return -1;
 }
 
+MLD_EXTERNAL_API
 size_t mld_prepare_domain_separation_prefix(
     uint8_t prefix[MLD_DOMAIN_SEPARATION_MAX_BYTES], const uint8_t *ph,
     size_t phlen, const uint8_t *ctx, size_t ctxlen, int hashalg)

--- a/scripts/ql
+++ b/scripts/ql
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#
+# Convenience driver for running the custom CodeQL queries in test/codeql/
+# against the mldsa-native tree.
+#
+# Usage:
+#   scripts/ql list                 List available queries
+#   scripts/ql run <name> [flags]   Run a query, building the DB if needed
+#   scripts/ql build-db [flags]     (Re)build the CodeQL database
+#
+# Database management:
+#   The CodeQL database is cached at .codeql-db/ and reused across runs.
+#   Before reuse, the driver runs `CC=cc make -n` to detect whether any
+#   source has changed since the last build; if so, the database is
+#   automatically rebuilt.  Pass --rebuild to force a rebuild regardless.
+#   A `make clean` is always run before creating a new database so that
+#   CodeQL's build tracer sees every compilation.
+#
+# Query dispatch:
+#   Queries with @kind problem / path-problem are run via
+#   `codeql database analyze` (SARIF or CSV alerts).  All other queries
+#   (@kind table or no @kind) are run via `codeql query run`, which
+#   produces a binary result file (.bqrs) that is then decoded to the
+#   requested output format (CSV, JSON, or text).
+#
+# Per-query post-processing:
+#   Tabular queries can register a post-processor function in
+#   _QUERY_POST_PROCESSORS (keyed by query name) to add custom rendering
+#   and pass/fail logic.  Queries without a post-processor get a plain
+#   table and always succeed.
+#
+# mldsa-declarations post-processing (_post_mldsa_declarations):
+#   A row is a violation when linkage is "extern" and the annotation is
+#   wrong or missing:
+#     - functions need MLD_INTERNAL_API, MLD_EXTERNAL_API, or MLD_API_QUALIFIER
+#     - variable definitions need MLD_INTERNAL_DATA_DEFINITION
+#     - variable declarations need MLD_INTERNAL_DATA_DECLARATION
+#   Static declarations are never violations.  Violations cause a non-zero
+#   exit code.
+#
+
+import argparse
+import csv
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+QUERY_DIR = REPO_ROOT / "test" / "codeql"
+DEFAULT_DB = REPO_ROOT / ".codeql-db"
+DEFAULT_BUILD = "make -j"
+
+
+def _use_color() -> bool:
+    """Honour NO_COLOR, respect FORCE_COLOR, otherwise only colour TTYs."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return sys.stdout.isatty()
+
+
+# ANSI SGR codes; populated lazily so tests / pipes stay clean.
+_COLOR = _use_color()
+C_RESET = "\033[0m" if _COLOR else ""
+C_BOLD = "\033[1m" if _COLOR else ""
+C_DIM = "\033[2m" if _COLOR else ""
+C_RED = "\033[31m" if _COLOR else ""
+C_GREEN = "\033[32m" if _COLOR else ""
+C_YELLOW = "\033[33m" if _COLOR else ""
+C_BLUE = "\033[34m" if _COLOR else ""
+C_MAGENTA = "\033[35m" if _COLOR else ""
+C_CYAN = "\033[36m" if _COLOR else ""
+
+_SEVERITY_COLOR = {
+    "error": C_RED,
+    "warning": C_MAGENTA,
+    "recommendation": C_BLUE,
+    "note": C_CYAN,
+}
+
+
+def _log(msg: str) -> None:
+    print(f"{C_DIM}[ql]{C_RESET} {msg}")
+
+
+def discover_queries():
+    """Return {short_name: path} for every .ql in test/codeql/."""
+    return {p.stem: p for p in sorted(QUERY_DIR.glob("*.ql"))}
+
+
+def require_codeql():
+    if shutil.which("codeql") is None:
+        sys.exit(
+            "error: 'codeql' not found on PATH.\n"
+            "       Enter the nix dev shell first:  nix develop .#codeql"
+        )
+
+
+def _source_is_stale() -> bool:
+    """Return True if 'make -n' would recompile anything."""
+    try:
+        env = {**os.environ, "CC": "cc"}
+        result = subprocess.run(
+            ["make", "-n"],
+            capture_output=True, text=True, cwd=REPO_ROOT, env=env,
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("cc ") or line.startswith("cc\t"):
+                return True
+        return False
+    except Exception:
+        return True
+
+
+def build_db(db_path: pathlib.Path, build_cmd: str, rebuild: bool):
+    require_codeql()
+    if db_path.exists():
+        if not rebuild and not _source_is_stale():
+            _log(f"reusing existing database at {C_CYAN}{db_path}{C_RESET}")
+            return
+        if not rebuild:
+            _log("source changed since last DB build — rebuilding")
+        _log(f"removing existing database at {db_path}")
+        shutil.rmtree(db_path)
+
+    _log("running 'make clean' before build")
+    subprocess.run(["make", "clean"], check=False, cwd=REPO_ROOT)
+
+    _log(f"building database at {C_CYAN}{db_path}{C_RESET} (build: {build_cmd!r})")
+    subprocess.run(
+        [
+            "codeql",
+            "database",
+            "create",
+            str(db_path),
+            "--language=cpp",
+            f"--command={build_cmd}",
+            f"--source-root={REPO_ROOT}",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def install_pack():
+    require_codeql()
+    subprocess.run(
+        ["codeql", "pack", "install", str(QUERY_DIR)],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+ALERT_KINDS = {"problem", "path-problem"}
+
+
+def _query_kind(path: pathlib.Path) -> str | None:
+    """Extract the @kind tag from a query's metadata block, if any."""
+    in_block = False
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("/**"):
+            in_block = True
+            continue
+        if in_block and line.startswith("*/"):
+            break
+        if in_block:
+            line = line.lstrip("* ").rstrip()
+            if line.startswith("@kind"):
+                return line[len("@kind") :].strip()
+    return None
+
+
+def run_query(
+    name: str,
+    db_path: pathlib.Path,
+    build_cmd: str,
+    rebuild: bool,
+    output: pathlib.Path | None,
+    fmt: str,
+):
+    queries = discover_queries()
+    if name not in queries:
+        sys.exit(
+            f"error: unknown query '{name}'.\n"
+            f"       available: {', '.join(sorted(queries)) or '(none)'}"
+        )
+
+    build_db(db_path, build_cmd, rebuild)
+    install_pack()
+
+    query_path = queries[name]
+    kind = _query_kind(query_path)
+
+    if kind in ALERT_KINDS:
+        _run_analyze(query_path, name, db_path, output, fmt)
+    else:
+        _run_bqrs(query_path, name, db_path, output, fmt)
+
+
+def _run_analyze(
+    query_path: pathlib.Path,
+    name: str,
+    db_path: pathlib.Path,
+    output: pathlib.Path | None,
+    fmt: str,
+):
+    """Run a @kind problem / path-problem query via 'codeql database analyze'."""
+    if fmt not in {"csv", "sarif-latest", "sarifv2.1.0"}:
+        sys.exit(
+            f"error: format {fmt!r} is only supported for @kind table queries. "
+            f"Pick one of: csv, sarif-latest, sarifv2.1.0."
+        )
+    ext = _ext_for(fmt)
+    tmp = tempfile.NamedTemporaryFile(
+        prefix=f"{name}-", suffix=f".{ext}", delete=False
+    )
+    tmp.close()
+    out = pathlib.Path(tmp.name)
+    try:
+        _log(f"analyzing {C_CYAN}{query_path.relative_to(REPO_ROOT)}{C_RESET}")
+        subprocess.run(
+            [
+                "codeql",
+                "database",
+                "analyze",
+                str(db_path),
+                str(query_path),
+                f"--format={fmt}",
+                f"--output={out}",
+                "--rerun",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+        )
+
+        if fmt == "csv":
+            n = _pretty_alerts_csv(out)
+        else:
+            n = _count_sarif(out)
+
+        if output:
+            shutil.copy2(out, output)
+            _log(f"wrote results to {output}")
+    finally:
+        out.unlink(missing_ok=True)
+
+    if n == 0:
+        _log(f"{C_GREEN}no findings{C_RESET}")
+        return
+    sev_color = C_RED
+    _log(f"{C_BOLD}{sev_color}{n} finding(s){C_RESET} reported by {C_CYAN}{name}{C_RESET}")
+    sys.exit(1)
+
+
+def _pretty_alerts_csv(out: pathlib.Path) -> int:
+    """Render codeql's alert CSV as gcc-style diagnostics to stdout.
+
+    codeql database analyze --format=csv produces 9 columns without a header:
+    (name, description, severity, message, path, sl, sc, el, ec).
+    The message column may contain newline-separated sub-messages when
+    multiple result tuples share a source location; each sub-message is
+    printed as its own diagnostic line.
+    """
+    if not out.exists():
+        return 0
+    count = 0
+    print()  # separate from the [ql] log lines
+    with out.open(newline="") as fh:
+        for row in csv.reader(fh):
+            if len(row) < 9:
+                continue
+            _name, _desc, severity, message, path, sl, sc, _el, _ec = row[:9]
+            path = path.lstrip("/")
+            sev_color = _SEVERITY_COLOR.get(severity, C_YELLOW)
+            loc = f"{C_BOLD}{path}:{sl}:{sc}:{C_RESET}"
+            sev = f"{C_BOLD}{sev_color}{severity}{C_RESET}"
+            for sub in message.splitlines():
+                sub = sub.strip()
+                if not sub:
+                    continue
+                print(f"{loc} {sev}: {C_BOLD}{sub}{C_RESET}")
+                count += 1
+    if count:
+        print()
+    return count
+
+
+def _count_sarif(out: pathlib.Path) -> int:
+    if not out.exists():
+        return 0
+    with out.open() as fh:
+        sarif = json.load(fh)
+    return sum(len(run.get("results", [])) for run in sarif.get("runs", []))
+
+
+def _run_bqrs(
+    query_path: pathlib.Path,
+    name: str,
+    db_path: pathlib.Path,
+    output: pathlib.Path | None,
+    fmt: str,
+):
+    """Run a tabular query via 'codeql query run' + 'codeql bqrs decode'."""
+    if fmt in {"sarif-latest", "sarifv2.1.0"}:
+        sys.exit(
+            f"error: SARIF output requires @kind problem or path-problem. "
+            f"Query {query_path.name} is tabular — use --format csv, text, or json."
+        )
+    if fmt not in {"csv", "text", "json"}:
+        sys.exit(f"error: unknown --format {fmt!r} for tabular query.")
+
+    ext = _ext_for(fmt)
+    tmp_bqrs = tempfile.NamedTemporaryFile(
+        prefix=f"{name}-", suffix=".bqrs", delete=False
+    )
+    tmp_bqrs.close()
+    tmp_out = tempfile.NamedTemporaryFile(
+        prefix=f"{name}-", suffix=f".{ext}", delete=False
+    )
+    tmp_out.close()
+    bqrs = pathlib.Path(tmp_bqrs.name)
+    out = pathlib.Path(tmp_out.name)
+    try:
+        _log(f"running {C_CYAN}{query_path.relative_to(REPO_ROOT)}{C_RESET}")
+        subprocess.run(
+            [
+                "codeql",
+                "query",
+                "run",
+                f"--database={db_path}",
+                f"--output={bqrs}",
+                "--",
+                str(query_path),
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+        )
+        _log(f"decoding results (format={fmt})")
+        subprocess.run(
+            [
+                "codeql",
+                "bqrs",
+                "decode",
+                f"--format={fmt}",
+                f"--output={out}",
+                "--",
+                str(bqrs),
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+        )
+
+        if output:
+            shutil.copy2(out, output)
+            _log(f"wrote results to {output}")
+
+        post = _QUERY_POST_PROCESSORS.get(name)
+        if post:
+            failed = post(out, fmt)
+        else:
+            if fmt == "csv":
+                _print_csv_table(out)
+            _log(
+                f"{C_YELLOW}no post-processor registered for "
+                f"'{name}' — no post-processing performed{C_RESET}"
+            )
+            failed = False
+    finally:
+        bqrs.unlink(missing_ok=True)
+        out.unlink(missing_ok=True)
+    if failed:
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Generic CSV table printing
+# ---------------------------------------------------------------------------
+
+def _read_csv(out: pathlib.Path) -> tuple[list[str], list[list[str]]]:
+    """Read a CSV file and return (header, data_rows)."""
+    if not out.exists():
+        return [], []
+    with out.open(newline="") as fh:
+        rows = list(csv.reader(fh))
+    if not rows:
+        return [], []
+    return rows[0], rows[1:]
+
+
+def _print_csv_table(out: pathlib.Path) -> None:
+    """Print a CSV file as a plain aligned table."""
+    header, data = _read_csv(out)
+    if not header:
+        return
+    if not data:
+        _log("(no rows)")
+        return
+    _print_aligned(header, data, row_styles_fn=None)
+    _log(f"{len(data)} row(s)")
+
+
+def _print_aligned(
+    header: list[str],
+    data: list[list[str]],
+    row_styles_fn=None,
+) -> None:
+    """Print header + data as an aligned table with optional per-row styling."""
+    widths = [len(h) for h in header]
+    for row in data:
+        for i, cell in enumerate(row):
+            if i < len(widths) and len(cell) > widths[i]:
+                widths[i] = len(cell)
+
+    def fmt_row(cells, styles):
+        parts = []
+        for i, cell in enumerate(cells):
+            pad = cell.ljust(widths[i]) if i < len(widths) else cell
+            parts.append(f"{styles[i]}{pad}{C_RESET}" if styles[i] else pad)
+        return "  ".join(parts)
+
+    header_styles = [C_BOLD + C_CYAN] * len(header)
+    print()
+    print(fmt_row(header, header_styles))
+    print(fmt_row(["-" * w for w in widths], [C_DIM] * len(widths)))
+    for row in data:
+        styles = row_styles_fn(row) if row_styles_fn else [""] * len(row)
+        print(fmt_row(row, styles))
+    print()
+
+
+# ---------------------------------------------------------------------------
+# mldsa-declarations: query-specific post-processing
+# ---------------------------------------------------------------------------
+
+_MLDSA_DECL_ANNOTATION_COLORS = {
+    "MLD_EXTERNAL_API": C_CYAN,
+    "MLD_INTERNAL_API": C_MAGENTA,
+    "MLD_API_QUALIFIER": C_GREEN,
+    "MLD_INTERNAL_DATA_DECLARATION": C_BLUE,
+    "MLD_INTERNAL_DATA_DEFINITION": C_BLUE,
+}
+
+
+def _mldsa_decl_is_violation(row: list[str], header: list[str]) -> bool:
+    try:
+        ann = row[header.index("annotation")]
+        link = row[header.index("linkage")]
+        kind = row[header.index("kind")]
+        dod = row[header.index("def_or_decl")]
+    except (ValueError, IndexError):
+        return False
+    if link != "extern":
+        return False
+    if kind == "variable":
+        if dod == "definition":
+            return ann != "MLD_INTERNAL_DATA_DEFINITION"
+        return ann != "MLD_INTERNAL_DATA_DECLARATION"
+    return ann not in ("MLD_INTERNAL_API", "MLD_EXTERNAL_API", "MLD_API_QUALIFIER")
+
+
+def _mldsa_decl_row_style(
+    row: list[str], header: list[str], violation: bool,
+) -> list[str]:
+    styles = [""] * len(row)
+    ann_idx = header.index("annotation") if "annotation" in header else -1
+    link_idx = header.index("linkage") if "linkage" in header else -1
+    if 0 <= ann_idx < len(row):
+        ann = row[ann_idx]
+        color = _MLDSA_DECL_ANNOTATION_COLORS.get(ann)
+        if color:
+            styles[ann_idx] = color
+        elif ann == "(none)":
+            styles[ann_idx] = C_BOLD + C_RED if violation else C_DIM
+    if 0 <= link_idx < len(row):
+        styles[link_idx] = C_YELLOW if row[link_idx] == "extern" else C_DIM
+    return styles
+
+
+def _post_mldsa_declarations(out: pathlib.Path, fmt: str) -> bool:
+    if fmt != "csv":
+        _log("mldsa-declarations post-processing requires CSV format")
+        return False
+    header, data = _read_csv(out)
+    if not header or not data:
+        _log("(no rows)")
+        return False
+
+    violations = [r for r in data if _mldsa_decl_is_violation(r, header)]
+
+    _print_aligned(header, data, row_styles_fn=lambda r: _mldsa_decl_row_style(
+        r, header, _mldsa_decl_is_violation(r, header),
+    ))
+    _log(f"{len(data)} row(s)")
+
+    if violations:
+        print()
+        _log(
+            f"{C_BOLD}{C_RED}{len(violations)} unannotated extern "
+            f"declaration(s){C_RESET}:"
+        )
+        _print_aligned(header, violations, row_styles_fn=lambda r: _mldsa_decl_row_style(
+            r, header, True,
+        ))
+    return len(violations) > 0
+
+
+# Post-processor registry: query name -> function(out, fmt) -> bool
+_QUERY_POST_PROCESSORS: dict[str, callable] = {
+    "mldsa-declarations": _post_mldsa_declarations,
+}
+
+
+def _ext_for(fmt: str) -> str:
+    return {
+        "csv": "csv",
+        "sarif-latest": "sarif",
+        "sarifv2.1.0": "sarif",
+        "text": "txt",
+        "json": "json",
+    }.get(fmt, "out")
+
+
+def cmd_list(_args):
+    queries = discover_queries()
+    if not queries:
+        print(f"(no .ql files found in {QUERY_DIR.relative_to(REPO_ROOT)})")
+        return
+    print(f"queries in {C_CYAN}{QUERY_DIR.relative_to(REPO_ROOT)}{C_RESET}:")
+    for name, path in queries.items():
+        desc = _first_description(path) or ""
+        print(f"  {C_BOLD}{name:40s}{C_RESET}  {C_DIM}{desc}{C_RESET}")
+
+
+def _first_description(path: pathlib.Path) -> str | None:
+    """Pull the @description line from the query header, if present."""
+    in_block = False
+    desc_lines: list[str] = []
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("/**"):
+            in_block = True
+            continue
+        if in_block and line.startswith("*/"):
+            break
+        if in_block:
+            line = line.lstrip("* ").rstrip()
+            if line.startswith("@description"):
+                desc_lines = [line[len("@description") :].strip()]
+            elif desc_lines and line.startswith("@"):
+                break
+            elif desc_lines and line:
+                desc_lines.append(line)
+    return " ".join(desc_lines) if desc_lines else None
+
+
+def cmd_run(args):
+    run_query(
+        args.name,
+        pathlib.Path(args.db).resolve(),
+        args.build,
+        args.rebuild,
+        pathlib.Path(args.output).resolve() if args.output else None,
+        args.format,
+    )
+
+
+def cmd_build_db(args):
+    build_db(pathlib.Path(args.db).resolve(), args.build, args.rebuild)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Run mldsa-native CodeQL queries.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="list available queries")
+    p_list.set_defaults(func=cmd_list)
+
+    def add_db_args(p):
+        p.add_argument(
+            "--db",
+            default=str(DEFAULT_DB),
+            help=f"path to CodeQL database (default: {DEFAULT_DB.relative_to(REPO_ROOT)})",
+        )
+        p.add_argument(
+            "--build",
+            default=DEFAULT_BUILD,
+            help=f"build command for DB creation (default: {DEFAULT_BUILD!r})",
+        )
+        p.add_argument(
+            "--rebuild",
+            action="store_true",
+            help="force rebuild of the database",
+        )
+
+    p_run = sub.add_parser("run", help="run a query by name")
+    p_run.add_argument("name", help="query name (see 'ql list')")
+    add_db_args(p_run)
+    p_run.add_argument(
+        "--format",
+        default="csv",
+        choices=["csv", "text", "json", "sarif-latest", "sarifv2.1.0"],
+        help=(
+            "output format (default: csv). 'sarif-*' only applies to @kind "
+            "problem queries; 'text' and 'json' only apply to tabular queries."
+        ),
+    )
+    p_run.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="output file (default: <name>.<ext> in repo root)",
+    )
+    p_run.set_defaults(func=cmd_run)
+
+    p_db = sub.add_parser("build-db", help="(re)build the CodeQL database")
+    add_db_args(p_db)
+    p_db.set_defaults(func=cmd_build_db)
+
+    args = ap.parse_args()
+    try:
+        args.func(args)
+    except subprocess.CalledProcessError as e:
+        sys.exit(e.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/codeql/mldsa-declarations.ql
+++ b/test/codeql/mldsa-declarations.ql
@@ -1,0 +1,88 @@
+/* Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT */
+
+/**
+ * @name All declarations under mldsa/
+ * @description Enumerates every function and (file-scope) variable declaration
+ *              located under the mldsa/ source tree, together with its linkage.
+ * @kind table
+ * @id mldsa/all-declarations
+ */
+
+import cpp
+
+/* A declaration is "in mldsa/" if its location's file path contains /mldsa/. */
+predicate inMldsaTree(Declaration d) {
+  exists(string path | path = d.getFile().getAbsolutePath() |
+    path.matches("%/mldsa/%")
+  )
+}
+
+predicate isVisibilityMacro(string name) {
+  name = "MLD_INTERNAL_API" or
+  name = "MLD_EXTERNAL_API" or
+  name = "MLD_INTERNAL_DATA_DECLARATION" or
+  name = "MLD_INTERNAL_DATA_DEFINITION" or
+  name = "MLD_API_QUALIFIER"
+}
+
+/* Visibility macro invocation sitting on (or up to 4 lines above) this
+ * declaration entry, with no intervening declaration entry in between. */
+string visibilityMacro(DeclarationEntry e) {
+  result =
+    min(MacroInvocation mi, string name, int line |
+      name = mi.getMacroName() and
+      isVisibilityMacro(name) and
+      mi.getFile() = e.getFile() and
+      line = mi.getLocation().getEndLine() and
+      line <= e.getLocation().getStartLine() and
+      line >= e.getLocation().getStartLine() - 4 and
+      /* No other declaration entry sits between the macro and e. */
+      not exists(DeclarationEntry other |
+        other != e and
+        other.getFile() = e.getFile() and
+        other.getLocation().getStartLine() > line and
+        other.getLocation().getStartLine() < e.getLocation().getStartLine()
+      )
+    |
+      name order by line desc
+    )
+}
+
+/* Functions: one row per declaration entry (prototype in a .h, definition in
+ * a .c) so we can check *each* site individually. */
+from
+  DeclarationEntry e, Declaration d, string kind, string linkage,
+  string annotation, string def_or_decl
+where
+  d = e.getDeclaration() and
+  inMldsaTree(d) and
+  not d.getName().matches("%empty_cu_%") and
+  not d.getName().matches("%_asm") and
+  (
+    d instanceof Function and kind = "function"
+    or
+    d instanceof GlobalOrNamespaceVariable and kind = "variable"
+  ) and
+  (
+    if e.hasSpecifier("static")
+    then linkage = "static"
+    else linkage = "extern"
+  ) and
+  (
+    annotation = visibilityMacro(e)
+    or
+    not exists(visibilityMacro(e)) and annotation = "(none)"
+  ) and
+  (
+    if e.isDefinition()
+    then def_or_decl = "definition"
+    else def_or_decl = "declaration"
+  )
+select
+  e.getFile().getRelativePath() + ":" + e.getLocation().getStartLine() as location,
+  kind,
+  def_or_decl,
+  linkage,
+  annotation,
+  d.getName() as name

--- a/test/codeql/qlpack.yml
+++ b/test/codeql/qlpack.yml
@@ -1,0 +1,9 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+name: mldsa-native/queries
+version: 0.0.1
+library: false
+dependencies:
+  # Pinned to the version shipped with the CodeQL CLI currently packaged in
+  # nixpkgs (2.23.3). Bump together with the CLI.
+  codeql/cpp-all: "6.0.0"


### PR DESCRIPTION
CodeQL is GitHub's semantic code analysis engine: it builds a typed AST database from a build trace, then answers queries written in QL (a Datalog-flavoured language) against it.

This commit adds a custom query that flags any externally-linked declaration under mldsa/ lacking the appropriate visibility annotation (MLD_INTERNAL_API, MLD_EXTERNAL_API, MLD_API_QUALIFIER for functions; MLD_INTERNAL_DATA_DECLARATION / MLD_INTERNAL_DATA_DEFINITION for variables), catching new cross-TU symbols that miss the macro required for single-CU builds. Assembly symbols (*_asm) and empty-CU placeholders (*empty_cu_*) are excluded.

A scripts/ql driver wraps the CLI: it manages the CodeQL database (auto-rebuilding when sources change), dispatches queries, and runs query-specific post-processors that add colored output and pass/fail logic. The mldsa-declarations post-processor is registered for the visibility check; other queries get plain table output.

A codeql.yml workflow invoked from all.yml runs the check in CI.

The new query flagged two missing annotations:
mld_polyeta_unpack in poly_kl.c and mld_prepare_domain_separation_prefix in sign.c lacked MLD_INTERNAL_API / MLD_EXTERNAL_API, respectively. Both are fixed in this commit, too.

Licensing: CodeQL uses a GitHub-specific license and is marked 'unfree' in nixpkgs. It is free for open-source analysis and GitHub code scanning, covering our use case. The nix flake does not globally allowlist the package; developers opt in via
    NIXPKGS_ALLOW_UNFREE=1 nix develop --impure .#codeql
to avoid silent acceptance of the non-OSS license.