### PR TITLE
CI: Bump ACVP, liboqs, expo, and AWS-LC versions

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/integration-awslc.yml
     with:
-      commit: v1.67.0
+      commit: v1.72.0
     secrets: inherit
   ct-test:
     name: Constant-time

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -77,7 +77,7 @@ jobs:
          # via https://riseproject-dev.github.io/riscv-runner/
          # - runner: ubuntu-24.04-riscv
          #   name: 'riscv'
-        acvp-version: [v1.1.0.39, v1.1.0.40, v1.1.0.41]
+        acvp-version: [v1.1.0.40, v1.1.0.41, v1.1.0.42]
         exclude:
           - {external: true,
              target: {

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -41,7 +41,7 @@ jobs:
           packages: 'cmake python3-jinja2 python3-tabulate python3-git python3-pytest valgrind'
       - uses: ./.github/actions/setup-oqs
         with:
-          commit: '2959f1a4c717d7af1c4ebb52f1c6d3560b2957b7'
+          commit: 'd8509387febc9e32466c86aab544d225d60c8e3c' # main (2026-04-21)
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           repository: 'open-quantum-safe/liboqs'
       - name: Apply patch

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ./.github/actions/setup-opentitan
         with:
           expo-repository: https://github.com/zerorisc/expo
-          expo-commit: 375803409deee1f5f7965f0757e316670b13f544
+          expo-commit: 53619a73e64cb96ee6e61a4b4b992f7250ab7477 # master (2026-04-21)
 
       - name: Patch mldsa-native dependency
         run: |


### PR DESCRIPTION
- ACVP: slide window to [v1.1.0.40, v1.1.0.41, v1.1.0.42]
- liboqs: bump to main (2026-04-21, d8509387)
- expo: bump to master (2026-04-21, 53619a73)
- AWS-LC: bump v1.67.0 -> v1.72.0

Port of https://github.com/pq-code-package/mlkem-native/pull/1662.