### PR TITLE
Test: Add Wycheproof tests for ML-DSA

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -45,6 +45,9 @@ inputs:
   acvp:
     description: Determine whether to run acvp test or not
     default: "true"
+  wycheproof:
+    description: Determine whether to run wycheproof test or not
+    default: "true"
   examples:
     description: Determine whether to run examples or not
     default: "true"
@@ -81,6 +84,7 @@ runs:
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
           echo UNIT="${{ inputs.unit == 'true' && 'unit' || 'no-unit' }}" >> $GITHUB_ENV
           echo ACVP="${{ inputs.acvp == 'true' && 'acvp' || 'no-acvp' }}" >> $GITHUB_ENV
+          echo WYCHEPROOF="${{ inputs.wycheproof == 'true' && 'wycheproof' || 'no-wycheproof' }}" >> $GITHUB_ENV
           echo EXAMPLES="${{ inputs.examples == 'true' && 'examples' || 'no-examples' }}" >> $GITHUB_ENV
           echo STACK="${{ inputs.stack == 'true' && 'stack' || 'no-stack' }}" >> $GITHUB_ENV
           echo ALLOC="${{ inputs.alloc == 'true' && 'alloc' || 'no-alloc' }}" >> $GITHUB_ENV
@@ -119,7 +123,7 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.RNGFAIL }} -v ${{ inputs.extra_args }}
+          ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.WYCHEPROOF }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.RNGFAIL }} -v ${{ inputs.extra_args }}
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -42,6 +42,9 @@ inputs:
   acvp:
     description: Determine whether to run acvp test or not
     default: "true"
+  wycheproof:
+    description: Determine whether to run wycheproof test or not
+    default: "true"
   examples:
     description: Determine whether to run examples or not
     default: "true"
@@ -85,6 +88,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -110,6 +114,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -135,6 +140,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -160,6 +166,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -185,6 +192,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -210,6 +218,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -234,6 +243,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -258,6 +268,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -282,6 +293,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -307,6 +319,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}

--- a/.github/workflows/baremetal.yml
+++ b/.github/workflows/baremetal.yml
@@ -22,6 +22,7 @@ jobs:
            func: true
            kat: true
            acvp: true
+           wycheproof: false
            alloc: true
            bench: true
            opt: all
@@ -32,6 +33,7 @@ jobs:
            func: true
            kat: true
            acvp: true
+           wycheproof: false
            alloc: true
            bench: true
            opt: no_opt
@@ -49,6 +51,7 @@ jobs:
           func: ${{ matrix.target.func }}
           kat: ${{ matrix.target.kat }}
           acvp: ${{ matrix.target.acvp }}
+          wycheproof: ${{ matrix.target.wycheproof }}
           examples: false
           stack: false
           alloc: ${{ matrix.target.alloc }}
@@ -91,6 +94,7 @@ jobs:
           func: true
           kat: true
           acvp: true
+          wycheproof: false
           examples: false
           stack: false
           alloc: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -364,6 +365,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -377,6 +379,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -390,6 +393,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -404,6 +408,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -418,6 +423,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -456,6 +462,7 @@ jobs:
           func: false
           kat: false
           acvp: false
+          wycheproof: false
           examples: false
           stack: true
           check_namespace: false

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test/build
 .direnv
 # Downloaded ACVP test data
 test/acvp/.acvp-data/
+# Downloaded Wycheproof test data
+test/wycheproof/.wycheproof-data/

--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -382,3 +382,12 @@ source code and documentation.
 * Referenced from:
   - [mldsa/src/fips202/fips202.c](mldsa/src/fips202/fips202.c)
   - [mldsa/src/fips202/keccakf1600.c](mldsa/src/fips202/keccakf1600.c)
+
+### `wycheproof`
+
+* Project Wycheproof
+* Author(s):
+  - Community Cryptography Specification Project
+* URL: https://github.com/C2SP/wycheproof
+* Referenced from:
+  - [README.md](README.md)

--- a/BIBLIOGRAPHY.yml
+++ b/BIBLIOGRAPHY.yml
@@ -165,3 +165,8 @@
   name: Cycle counting on Apple M1
   author: Johnson, Dougall
   url: https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155#file-m1_robsize-c-L390
+
+- id: wycheproof
+  name: Project Wycheproof
+  author: Community Cryptography Specification Project
+  url: https://github.com/C2SP/wycheproof

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 # Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-.PHONY: func kat acvp stack unit alloc rng_fail \
-	func_44 kat_44 acvp_44 stack_44 unit_44 alloc_44 rng_fail_44 \
-	func_65 kat_65 acvp_65 stack_65 unit_65 alloc_65 rng_fail_65 \
-	func_87 kat_87 acvp_87 stack_87 unit_87 alloc_87 rng_fail_87 \
-	run_func run_kat run_acvp run_stack run_unit run_alloc run_rng_fail \
+.PHONY: func kat acvp wycheproof stack unit alloc rng_fail \
+	func_44 kat_44 acvp_44 wycheproof_44 stack_44 unit_44 alloc_44 rng_fail_44 \
+	func_65 kat_65 acvp_65 wycheproof_65 stack_65 unit_65 alloc_65 rng_fail_65 \
+	func_87 kat_87 acvp_87 wycheproof_87 stack_87 unit_87 alloc_87 rng_fail_87 \
+	run_func run_kat run_acvp run_wycheproof run_stack run_unit run_alloc run_rng_fail \
 	run_func_44 run_kat_44 run_stack_44 run_unit_44 run_alloc_44 run_rng_fail_44 \
 	run_func_65 run_kat_65 run_stack_65 run_unit_65 run_alloc_65 run_rng_fail_65 \
 	run_func_87 run_kat_87 run_stack_87 run_unit_87 run_alloc_87 run_rng_fail_87 \
@@ -44,10 +44,10 @@ endif
 
 quickcheck: test
 
-build: func kat acvp
+build: func kat acvp wycheproof
 	$(Q)echo "  Everything builds fine!"
 
-test: run_kat run_func run_acvp run_unit run_alloc run_rng_fail
+test: run_kat run_func run_acvp run_wycheproof run_unit run_alloc run_rng_fail
 	$(Q)echo "  Everything checks fine!"
 
 run_kat_44: kat_44
@@ -108,6 +108,17 @@ acvp_65:  $(MLDSA65_DIR)/bin/acvp_mldsa65
 acvp_87: $(MLDSA87_DIR)/bin/acvp_mldsa87
 	$(Q)echo "  ACVP       ML-DSA-87:  $^"
 acvp: acvp_44 acvp_65 acvp_87
+
+wycheproof_44:  $(MLDSA44_DIR)/bin/wycheproof_mldsa44
+	$(Q)echo "  WYCHEPROOF ML-DSA-44:   $^"
+wycheproof_65:  $(MLDSA65_DIR)/bin/wycheproof_mldsa65
+	$(Q)echo "  WYCHEPROOF ML-DSA-65:   $^"
+wycheproof_87: $(MLDSA87_DIR)/bin/wycheproof_mldsa87
+	$(Q)echo "  WYCHEPROOF ML-DSA-87:  $^"
+wycheproof: wycheproof_44 wycheproof_65 wycheproof_87
+
+run_wycheproof: wycheproof
+	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/wycheproof/wycheproof_client.py
 
 ifeq ($(HOST_PLATFORM),Linux-aarch64)
 # valgrind does not work with the AArch64 SHA3 extension

--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ mldsa-native currently offers the following backends:
 
 If you'd like contribute new backends, please reach out!
 
-## ACVP Testing
+## Test Vectors
 
-mldsa-native is tested against all official ACVP ML-DSA test vectors[^ACVP].
+mldsa-native is tested against all official ACVP ML-DSA test vectors[^ACVP] and the
+Wycheproof[^wycheproof] ML-DSA test vectors.
+
+### ACVP
 
 You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP client](./test/acvp/acvp_client.py) directly:
 
@@ -120,6 +123,18 @@ python3 ./test/acvp/acvp_client.py --version v1.1.0.41
 python3 ./test/acvp/acvp_client.py \
   -p ./test/acvp/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/prompt.json \
   -e ./test/acvp/.acvp-data/v1.1.0.41/files/ML-DSA-sigVer-FIPS204/expectedResults.json
+```
+
+### Wycheproof
+
+You can run Wycheproof[^wycheproof] tests using the [`tests`](./scripts/tests) script or the [Wycheproof client](./test/wycheproof/wycheproof_client.py) directly:
+
+```bash
+# Using the tests script
+./scripts/tests wycheproof
+
+# Using the Wycheproof client directly
+python3 ./test/wycheproof/wycheproof_client.py
 ```
 
 ## Benchmarking
@@ -219,3 +234,4 @@ through the [PQCA Discord](https://discord.com/invite/xyVnwzfg5R). See also [CON
 [^NIST_FIPS204_SEC6]: National Institute of Standards and Technology: FIPS 204 Section 6 Guidance, [https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf](https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf)
 [^REF]: Bai, Ducas, Kiltz, Lepoint, Lyubashevsky, Schwabe, Seiler, Stehlé: CRYSTALS-Dilithium reference implementation, [https://github.com/pq-crystals/dilithium/tree/master/ref](https://github.com/pq-crystals/dilithium/tree/master/ref)
 [^tiny_sha3]: Markku-Juhani O. Saarinen: tiny_sha3, [https://github.com/mjosaarinen/tiny_sha3](https://github.com/mjosaarinen/tiny_sha3)
+[^wycheproof]: Community Cryptography Specification Project: Project Wycheproof, [https://github.com/C2SP/wycheproof](https://github.com/C2SP/wycheproof)

--- a/scripts/tests
+++ b/scripts/tests
@@ -215,6 +215,7 @@ class TEST_TYPES(Enum):
     ALLOC = 20
     BASIC_LOWRAM = 21
     RNG_FAIL = 22
+    WYCHEPROOF = 23
 
     def is_benchmark(self):
         return self in [TEST_TYPES.BENCH, TEST_TYPES.BENCH_COMPONENTS]
@@ -262,6 +263,8 @@ class TEST_TYPES(Enum):
             return "Kat Test"
         if self == TEST_TYPES.ACVP:
             return "ACVP Test"
+        if self == TEST_TYPES.WYCHEPROOF:
+            return "Wycheproof Test"
         if self == TEST_TYPES.STACK:
             return "Stack Usage Test"
         if self == TEST_TYPES.BRING_YOUR_OWN_FIPS202:
@@ -335,6 +338,8 @@ class TEST_TYPES(Enum):
             return "kat"
         if self == TEST_TYPES.ACVP:
             return "acvp"
+        if self == TEST_TYPES.WYCHEPROOF:
+            return "wycheproof"
         if self == TEST_TYPES.STACK:
             return "stack"
         if self == TEST_TYPES.BRING_YOUR_OWN_FIPS202:
@@ -707,6 +712,19 @@ class Tests:
 
         self.check_fail()
 
+    def wycheproof(self):
+        def _wycheproof(opt):
+            self._compile_schemes(TEST_TYPES.WYCHEPROOF, opt)
+            if self.args.run:
+                self._run_scheme(TEST_TYPES.WYCHEPROOF, opt, None)
+
+        if self.do_no_opt():
+            _wycheproof(False)
+        if self.do_opt():
+            _wycheproof(True)
+
+        self.check_fail()
+
     def examples(self):
         if self.args.l is None:
             items = TEST_TYPES.examples()
@@ -824,6 +842,7 @@ class Tests:
         func = self.args.func
         kat = self.args.kat
         acvp = self.args.acvp
+        wycheproof = self.args.wycheproof
         examples = self.args.examples
         stack = self.args.stack
         unit = self.args.unit
@@ -837,6 +856,8 @@ class Tests:
                 self._compile_schemes(TEST_TYPES.KAT, opt)
             if acvp is True:
                 self._compile_schemes(TEST_TYPES.ACVP, opt)
+            if wycheproof is True:
+                self._compile_schemes(TEST_TYPES.WYCHEPROOF, opt)
             if stack is True:
                 self._compile_schemes(TEST_TYPES.STACK, opt)
             if unit is True:
@@ -864,6 +885,8 @@ class Tests:
                 self._run_schemes(TEST_TYPES.KAT, opt)
             if acvp is True:
                 self._run_scheme(TEST_TYPES.ACVP, opt, None)
+            if wycheproof is True:
+                self._run_scheme(TEST_TYPES.WYCHEPROOF, opt, None)
             if stack is True:
                 self._run_schemes(TEST_TYPES.STACK, opt, suppress_output=False)
             if unit is True:
@@ -1230,6 +1253,21 @@ def cli():
         "--no-acvp", action="store_false", dest="acvp", help="Do not run acvp test"
     )
 
+    wycheproof_group = all_parser.add_mutually_exclusive_group()
+    wycheproof_group.add_argument(
+        "--wycheproof",
+        action="store_true",
+        dest="wycheproof",
+        help="Run wycheproof test",
+        default=True,
+    )
+    wycheproof_group.add_argument(
+        "--no-wycheproof",
+        action="store_false",
+        dest="wycheproof",
+        help="Do not run wycheproof test",
+    )
+
     unit_group = all_parser.add_mutually_exclusive_group()
     unit_group.add_argument(
         "--unit", action="store_true", dest="unit", help="Run unit test", default=True
@@ -1327,6 +1365,11 @@ def cli():
         "--version",
         default="v1.1.0.41",
         help="ACVP test vector version (default: v1.1.0.41)",
+    )
+
+    # wycheproof arguments
+    cmd_subparsers.add_parser(
+        "wycheproof", help="Run Wycheproof client", parents=[common_parser]
     )
 
     # examples arguments
@@ -1568,6 +1611,8 @@ def cli():
         Tests(args).examples()
     elif args.cmd == "acvp":
         Tests(args).acvp()
+    elif args.cmd == "wycheproof":
+        Tests(args).wycheproof()
     elif args.cmd == "bench":
         Tests(args).bench()
     elif args.cmd == "cbmc":

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -16,11 +16,12 @@ endif
 
 BASIC_TESTS = test_mldsa gen_KAT test_stack
 ACVP_TESTS = acvp_mldsa
+WYCHEPROOF_TESTS = wycheproof_mldsa
 BENCH_TESTS = bench_mldsa bench_components_mldsa
 UNIT_TESTS = test_unit
 ALLOC_TESTS = test_alloc
 RNG_FAIL_TESTS = test_rng_fail
-ALL_TESTS = $(BASIC_TESTS) $(ACVP_TESTS) $(BENCH_TESTS) $(UNIT_TESTS) $(ALLOC_TESTS) $(RNG_FAIL_TESTS)
+ALL_TESTS = $(BASIC_TESTS) $(ACVP_TESTS) $(WYCHEPROOF_TESTS) $(BENCH_TESTS) $(UNIT_TESTS) $(ALLOC_TESTS) $(RNG_FAIL_TESTS)
 
 MLDSA44_DIR = $(BUILD_DIR)/mldsa44
 MLDSA65_DIR = $(BUILD_DIR)/mldsa65
@@ -125,6 +126,9 @@ endef
 $(foreach scheme,mldsa44 mldsa65 mldsa87, \
 	$(foreach test,$(ACVP_TESTS), \
 		$(eval $(call ADD_SOURCE,$(scheme),$(test),acvp)) \
+	) \
+	$(foreach test,$(WYCHEPROOF_TESTS), \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),wycheproof)) \
 	) \
 	$(foreach test,$(BENCH_TESTS), \
 		$(eval $(call ADD_SOURCE,$(scheme),$(test),bench)) \

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# Wycheproof test client for ML-DSA
+# See https://github.com/C2SP/wycheproof
+# Invokes `wycheproof_mldsa{lvl}` under the hood.
+
+import argparse
+import os
+import json
+import sys
+import subprocess
+import urllib.request
+from enum import Enum, auto
+from pathlib import Path
+
+exec_prefix = os.environ.get("EXEC_WRAPPER", "")
+exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
+
+# Pinned to a specific commit (2026-04-21).
+WYCHEPROOF_COMMIT = "744697a257d41941320b4ea10987b85b25f8c8bc"
+WYCHEPROOF_BASE_URL = f"https://raw.githubusercontent.com/C2SP/wycheproof/{WYCHEPROOF_COMMIT}/testvectors_v1"
+
+WYCHEPROOF_FILES = [
+    "mldsa_44_sign_seed_test.json",
+    "mldsa_44_sign_noseed_test.json",
+    "mldsa_44_verify_test.json",
+    "mldsa_65_sign_seed_test.json",
+    "mldsa_65_sign_noseed_test.json",
+    "mldsa_65_verify_test.json",
+    "mldsa_87_sign_seed_test.json",
+    "mldsa_87_sign_noseed_test.json",
+    "mldsa_87_verify_test.json",
+]
+
+ALGORITHM_TO_LEVEL = {
+    "ML-DSA-44": 44,
+    "ML-DSA-65": 65,
+    "ML-DSA-87": 87,
+}
+
+
+def err(msg, **kwargs):
+    print(msg, file=sys.stderr, **kwargs)
+
+
+def info(msg, **kwargs):
+    print(msg, **kwargs)
+
+
+def download_wycheproof_files(data_dir):
+    """Download Wycheproof test vector files if not present."""
+    data_dir = Path(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename in WYCHEPROOF_FILES:
+        local_file = data_dir / filename
+        if not local_file.exists():
+            url = f"{WYCHEPROOF_BASE_URL}/{filename}"
+            print(f"Downloading {filename}...", file=sys.stderr)
+            try:
+                urllib.request.urlretrieve(url, local_file)
+                with open(local_file, "r", encoding="utf-8") as f:
+                    json.load(f)
+            except (json.JSONDecodeError, Exception) as e:
+                print(f"Error downloading {filename}: {e}", file=sys.stderr)
+                local_file.unlink(missing_ok=True)
+                return False
+    return True
+
+
+def get_binary(level):
+    basedir = f"./test/build/mldsa{level}/bin"
+    return f"{basedir}/wycheproof_mldsa{level}"
+
+
+def detect_supported_modes():
+    """Run wycheproof_mldsa44 --info to detect which modes are supported."""
+    wycheproof_bin = "./test/build/mldsa44/bin/wycheproof_mldsa44"
+    wycheproof_call = exec_prefix + [wycheproof_bin, "--info"]
+    try:
+        result = subprocess.run(wycheproof_call, encoding="utf-8", capture_output=True)
+        if result.returncode != 0:
+            err(
+                f"Warning: {wycheproof_call} failed (rc={result.returncode}), assuming all modes supported"
+            )
+            return {"keyGen", "sigGen", "sigVer"}
+        modes = set()
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line in ("keyGen", "sigGen", "sigVer"):
+                modes.add(line)
+        return modes
+    except FileNotFoundError:
+        err(f"Warning: {wycheproof_bin} not found, assuming all modes supported")
+        return {"keyGen", "sigGen", "sigVer"}
+
+
+# File-type → set of modes the binary must support to run those tests.
+FILE_REQUIRED_MODES = {
+    "sign_seed_test": {"keyGen", "sigGen"},
+    "sign_noseed_test": {"sigGen"},
+    "verify_test": {"sigVer"},
+}
+
+
+def run_binary(args_list):
+    result = subprocess.run(
+        exec_prefix + args_list, encoding="utf-8", capture_output=True
+    )
+    if result.returncode != 0:
+        return {"_error": str(result.returncode)}
+    out = {}
+    for line in result.stdout.strip().splitlines():
+        k, v = line.split("=", 1)
+        out[k] = v
+    return out
+
+
+class TestResult(Enum):
+    OK = auto()
+    SKIPPED = auto()
+
+
+def check_sign_result(tc, out):
+    if tc["result"] == "invalid":
+        # InvalidPrivateKey: implementation does not validate sk
+        if "InvalidPrivateKey" in tc.get("flags", []):
+            return TestResult.SKIPPED
+        # _error: non-zero exit code; decode_error: explicit validation failure
+        assert "_error" in out or "decode_error" in out, (
+            f"binary success on invalid tcId={tc['tcId']}"
+        )
+    elif tc["result"] == "valid":
+        assert out["signature"].upper() == tc["sig"].upper(), (
+            f"signature mismatch tcId={tc['tcId']}"
+        )
+    else:
+        assert False, f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+    return TestResult.OK
+
+
+def run_sign_seed_test(data_file):
+    """Run mldsa_*_sign_seed_test.json tests."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running sign_seed tests from {data_file}")
+    binary = get_binary(ALGORITHM_TO_LEVEL[data["algorithm"]])
+    count = 0
+    for tg in data["testGroups"]:
+        seed_hex = tg["privateSeed"]
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            if "Internal" in tc.get("flags", []):
+                out = run_binary(
+                    [
+                        binary,
+                        "sigGenSeedDeterministic",
+                        f"seed={seed_hex}",
+                        f"message={tc['mu']}",
+                        "context=",
+                        "externalMu=1",
+                    ]
+                )
+            else:
+                out = run_binary(
+                    [
+                        binary,
+                        "sigGenSeedDeterministic",
+                        f"seed={seed_hex}",
+                        f"message={tc['msg']}",
+                        f"context={tc.get('ctx', '')}",
+                        "externalMu=0",
+                    ]
+                )
+            result = check_sign_result(tc, out)
+            info("skipped" if result == TestResult.SKIPPED else "ok")
+            count += 1
+    info(f"  {count} sign_seed tests passed")
+
+
+def run_sign_noseed_test(data_file):
+    """Run mldsa_*_sign_noseed_test.json tests."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running sign_noseed tests from {data_file}")
+    binary = get_binary(ALGORITHM_TO_LEVEL[data["algorithm"]])
+    count = 0
+    for tg in data["testGroups"]:
+        sk_hex = tg["privateKey"]
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            if "Internal" in tc.get("flags", []):
+                out = run_binary(
+                    [
+                        binary,
+                        "sigGenInternalDeterministic",
+                        f"message={tc['mu']}",
+                        f"sk={sk_hex}",
+                        "externalMu=1",
+                    ]
+                )
+            else:
+                out = run_binary(
+                    [
+                        binary,
+                        "sigGenDeterministic",
+                        f"message={tc['msg']}",
+                        f"context={tc.get('ctx', '')}",
+                        f"sk={sk_hex}",
+                    ]
+                )
+            result = check_sign_result(tc, out)
+            info("skipped" if result == TestResult.SKIPPED else "ok")
+            count += 1
+    info(f"  {count} sign_noseed tests passed")
+
+
+def run_verify_test(data_file):
+    """Run mldsa_*_verify_test.json tests."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running verify tests from {data_file}")
+    binary = get_binary(ALGORITHM_TO_LEVEL[data["algorithm"]])
+    count = 0
+    for tg in data["testGroups"]:
+        pk_hex = tg["publicKey"]
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            out = run_binary(
+                [
+                    binary,
+                    "sigVer",
+                    f"message={tc['msg']}",
+                    f"context={tc.get('ctx', '')}",
+                    f"signature={tc['sig']}",
+                    f"pk={pk_hex}",
+                ]
+            )
+            if tc["result"] == "invalid":
+                # _error: non-zero exit code; decode_error: explicit validation failure
+                assert "_error" in out or "decode_error" in out, (
+                    f"binary success on invalid tcId={tc['tcId']}"
+                )
+            elif tc["result"] == "valid":
+                assert "_error" not in out and "decode_error" not in out, (
+                    f"binary failure on valid tcId={tc['tcId']}"
+                )
+            else:
+                assert False, (
+                    f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                )
+            info("ok")
+            count += 1
+    info(f"  {count} verify tests passed")
+
+
+def run_all(data_dir, supported_modes):
+    """Run all Wycheproof test vector files."""
+    data_dir = Path(data_dir)
+    for filename in WYCHEPROOF_FILES:
+        filepath = data_dir / filename
+        for kind, runner in (
+            ("sign_seed_test", run_sign_seed_test),
+            ("sign_noseed_test", run_sign_noseed_test),
+            ("verify_test", run_verify_test),
+        ):
+            if kind not in filename:
+                continue
+            if not FILE_REQUIRED_MODES[kind].issubset(supported_modes):
+                info(f"Skipping {filename} (modes not supported in this build)")
+                break
+            runner(filepath)
+            break
+    info("ALL GOOD!")
+
+
+parser = argparse.ArgumentParser(description="Wycheproof ML-DSA test client")
+parser.add_argument(
+    "-f",
+    "--file",
+    help="Path to a specific Wycheproof test vector JSON file",
+    required=False,
+)
+parser.add_argument(
+    "--data-dir",
+    default="test/wycheproof/.wycheproof-data",
+    help="Directory for downloaded test vectors (default: test/wycheproof/.wycheproof-data)",
+)
+parser.add_argument(
+    "--no-keygen",
+    action="store_true",
+    help="Skip tests requiring keyGen",
+)
+parser.add_argument(
+    "--no-sign",
+    action="store_true",
+    help="Skip tests requiring sigGen",
+)
+parser.add_argument(
+    "--no-verify",
+    action="store_true",
+    help="Skip tests requiring sigVer",
+)
+parser.add_argument(
+    "--auto-detect",
+    action="store_true",
+    default=True,
+    help="Auto-detect supported modes by running wycheproof_mldsa44 --info (default: True)",
+)
+args = parser.parse_args()
+
+# Determine supported modes
+if args.auto_detect and args.file is None:
+    supported_modes = detect_supported_modes()
+    info(f"Auto-detected supported modes: {sorted(supported_modes)}")
+else:
+    supported_modes = {"keyGen", "sigGen", "sigVer"}
+
+# Apply explicit --no-* flags
+if args.no_keygen:
+    supported_modes.discard("keyGen")
+if args.no_sign:
+    supported_modes.discard("sigGen")
+if args.no_verify:
+    supported_modes.discard("sigVer")
+
+if args.file:
+    # Run a single file
+    filename = os.path.basename(args.file)
+    if "sign_seed_test" in filename:
+        run_sign_seed_test(args.file)
+    elif "sign_noseed_test" in filename:
+        run_sign_noseed_test(args.file)
+    elif "verify_test" in filename:
+        run_verify_test(args.file)
+    else:
+        err(f"Unknown test file type: {filename}")
+        sys.exit(1)
+    info("ALL GOOD!")
+else:
+    # Download and run all
+    if not download_wycheproof_files(args.data_dir):
+        err("Failed to download Wycheproof test files")
+        sys.exit(1)
+    run_all(args.data_dir, supported_modes)

--- a/test/wycheproof/wycheproof_mldsa.c
+++ b/test/wycheproof/wycheproof_mldsa.c
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/*
+ * Wycheproof test driver for ML-DSA.
+ *
+ * Usage:
+ *   wycheproof_mldsa{lvl} sigGenSeedDeterministic seed=HEX message=HEX
+ * context=HEX externalMu=0/1 wycheproof_mldsa{lvl} sigGenDeterministic
+ * message=HEX context=HEX sk=HEX wycheproof_mldsa{lvl}
+ * sigGenInternalDeterministic message=HEX sk=HEX externalMu=0/1
+ *   wycheproof_mldsa{lvl} sigVer message=HEX context=HEX signature=HEX pk=HEX
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../mldsa/src/common.h"
+
+#include "../../mldsa/mldsa_native.h"
+
+/* Additional SUPERCOP-style macros for functions not in the standard set */
+#define crypto_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
+#define crypto_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+
+/* maximum message length used in the Wycheproof tests */
+#define MAX_MSG_LENGTH 8192
+/* maximum context length according to FIPS-204 */
+#define MAX_CTX_LENGTH 255
+
+/* Print supported API modes and exit (used by wycheproof_client.py) */
+static void print_info(void)
+{
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+  printf("keyGen\n");
+#endif
+#if !defined(MLD_CONFIG_NO_SIGN_API)
+  printf("sigGen\n");
+#endif
+#if !defined(MLD_CONFIG_NO_VERIFY_API)
+  printf("sigVer\n");
+#endif
+}
+
+#define CHECK(x)                                              \
+  do                                                          \
+  {                                                           \
+    int rc;                                                   \
+    rc = (x);                                                 \
+    if (!rc)                                                  \
+    {                                                         \
+      fprintf(stderr, "ERROR (%s,%d)\n", __FILE__, __LINE__); \
+      exit(1);                                                \
+    }                                                         \
+  } while (0)
+
+#if !defined(MLD_CONFIG_NO_SIGN_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
+static unsigned char decode_hex_char(char hex)
+{
+  if (hex >= '0' && hex <= '9')
+  {
+    return (unsigned char)(hex - '0');
+  }
+  else if (hex >= 'A' && hex <= 'F')
+  {
+    return (unsigned char)(10 + (unsigned char)(hex - 'A'));
+  }
+  else if (hex >= 'a' && hex <= 'f')
+  {
+    return (unsigned char)(10 + (unsigned char)(hex - 'a'));
+  }
+  else
+  {
+    return 0xFF;
+  }
+}
+
+static int decode_hex(const char *prefix, unsigned char *out, size_t out_len,
+                      const char *hex)
+{
+  size_t i;
+  size_t hex_len = strlen(hex);
+  size_t prefix_len = strlen(prefix);
+
+  if (hex_len < prefix_len + 1 || memcmp(prefix, hex, prefix_len) != 0 ||
+      hex[prefix_len] != '=')
+  {
+    return 1;
+  }
+
+  hex += prefix_len + 1;
+  hex_len -= prefix_len + 1;
+
+  if (hex_len != 2 * out_len)
+  {
+    return 1;
+  }
+
+  for (i = 0; i < out_len; i++, hex += 2, out++)
+  {
+    unsigned hex0 = decode_hex_char(hex[0]);
+    unsigned hex1 = decode_hex_char(hex[1]);
+    if (hex0 == 0xFF || hex1 == 0xFF)
+    {
+      return 1;
+    }
+    *out = (unsigned char)((hex0 << 4) | hex1);
+  }
+  return 0;
+}
+#endif /* !MLD_CONFIG_NO_SIGN_API || !MLD_CONFIG_NO_VERIFY_API */
+
+#if !defined(MLD_CONFIG_NO_SIGN_API)
+static void print_hex(const char *name, const unsigned char *raw, size_t len)
+{
+  if (name != NULL)
+  {
+    printf("%s=", name);
+  }
+  for (; len > 0; len--, raw++)
+  {
+    printf("%02X", *raw);
+  }
+  printf("\n");
+}
+#endif /* !MLD_CONFIG_NO_SIGN_API */
+
+int main(int argc, char *argv[])
+{
+  if (argc < 2)
+  {
+    goto usage;
+  }
+
+  if (strcmp(argv[1], "--info") == 0)
+  {
+    print_info();
+    return 0;
+  }
+
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API) && !defined(MLD_CONFIG_NO_SIGN_API)
+  if (strcmp(argv[1], "sigGenSeedDeterministic") == 0)
+  {
+    /* sigGenSeedDeterministic seed=HEX message=HEX context=HEX externalMu=0/1
+     *
+     * Derives sk from seed, then deterministically signs message.
+     * If externalMu=1, message is the 64-byte mu and context is ignored. */
+    unsigned char seed[MLDSA_SEEDBYTES];
+    unsigned char message[MAX_MSG_LENGTH + MAX_CTX_LENGTH + 2];
+    unsigned char context[MAX_CTX_LENGTH];
+    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+    unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    unsigned char sig[CRYPTO_BYTES];
+    unsigned char pre[MAX_CTX_LENGTH + 2];
+    unsigned char rnd[MLDSA_RNDBYTES] = {0};
+    size_t mlen, ctxlen, siglen;
+    int externalMu;
+
+    if (argc != 6)
+    {
+      goto usage;
+    }
+
+    if (decode_hex("seed", seed, sizeof(seed), argv[2]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    mlen = (strlen(argv[3]) - strlen("message=")) / 2;
+    if (mlen > sizeof(message) ||
+        decode_hex("message", message, mlen, argv[3]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    ctxlen = (strlen(argv[4]) - strlen("context=")) / 2;
+    if (ctxlen > MAX_CTX_LENGTH ||
+        decode_hex("context", context, ctxlen, argv[4]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (strcmp(argv[5], "externalMu=0") == 0)
+    {
+      externalMu = 0;
+    }
+    else if (strcmp(argv[5], "externalMu=1") == 0)
+    {
+      externalMu = 1;
+    }
+    else
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    CHECK(crypto_sign_keypair_internal(pk, sk, seed) == 0);
+
+    if (externalMu)
+    {
+      CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0,
+                                           rnd, sk, 1) == 0);
+    }
+    else
+    {
+      pre[0] = 0;
+      /* Safety: Truncation is safe due to the check above. */
+      pre[1] = (uint8_t)ctxlen;
+      memcpy(pre + 2, context, ctxlen);
+      CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, pre,
+                                           ctxlen + 2, rnd, sk, 0) == 0);
+    }
+    print_hex("signature", sig, siglen);
+  }
+  else
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API */
+#if !defined(MLD_CONFIG_NO_SIGN_API)
+      if (strcmp(argv[1], "sigGenDeterministic") == 0)
+  {
+    /* sigGenDeterministic message=HEX context=HEX sk=HEX */
+    unsigned char message[MAX_MSG_LENGTH];
+    unsigned char context[MAX_CTX_LENGTH];
+    unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    unsigned char sig[CRYPTO_BYTES];
+    unsigned char pre[MAX_CTX_LENGTH + 2];
+    unsigned char rnd[MLDSA_RNDBYTES] = {0};
+    size_t mlen, ctxlen, siglen;
+
+    if (argc != 5)
+    {
+      goto usage;
+    }
+
+    mlen = (strlen(argv[2]) - strlen("message=")) / 2;
+    if (mlen > MAX_MSG_LENGTH ||
+        decode_hex("message", message, mlen, argv[2]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    ctxlen = (strlen(argv[3]) - strlen("context=")) / 2;
+    if (ctxlen > MAX_CTX_LENGTH ||
+        decode_hex("context", context, ctxlen, argv[3]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (decode_hex("sk", sk, sizeof(sk), argv[4]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    pre[0] = 0;
+    /* Safety: Truncation is safe due to the check above. */
+    pre[1] = (uint8_t)ctxlen;
+    memcpy(pre + 2, context, ctxlen);
+
+    CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, pre,
+                                         ctxlen + 2, rnd, sk, 0) == 0);
+    print_hex("signature", sig, siglen);
+  }
+  else if (strcmp(argv[1], "sigGenInternalDeterministic") == 0)
+  {
+    /* sigGenInternalDeterministic message=HEX sk=HEX externalMu=0/1 */
+    unsigned char message[MAX_MSG_LENGTH + MAX_CTX_LENGTH + 2];
+    unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    unsigned char sig[CRYPTO_BYTES];
+    unsigned char rnd[MLDSA_RNDBYTES] = {0};
+    size_t mlen, siglen;
+    int externalMu;
+
+    if (argc != 5)
+    {
+      goto usage;
+    }
+
+    mlen = (strlen(argv[2]) - strlen("message=")) / 2;
+    if (mlen > sizeof(message) ||
+        decode_hex("message", message, mlen, argv[2]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (decode_hex("sk", sk, sizeof(sk), argv[3]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (strcmp(argv[4], "externalMu=0") == 0)
+    {
+      externalMu = 0;
+    }
+    else if (strcmp(argv[4], "externalMu=1") == 0)
+    {
+      externalMu = 1;
+    }
+    else
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    CHECK(crypto_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0,
+                                         rnd, sk, externalMu) == 0);
+    print_hex("signature", sig, siglen);
+  }
+  else
+#endif /* !MLD_CONFIG_NO_SIGN_API */
+#if !defined(MLD_CONFIG_NO_VERIFY_API)
+      if (strcmp(argv[1], "sigVer") == 0)
+  {
+    /* sigVer message=HEX context=HEX signature=HEX pk=HEX */
+    unsigned char message[MAX_MSG_LENGTH];
+    unsigned char context[MAX_CTX_LENGTH];
+    unsigned char signature[CRYPTO_BYTES];
+    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+    size_t mlen, ctxlen;
+
+    if (argc != 6)
+    {
+      goto usage;
+    }
+
+    mlen = (strlen(argv[2]) - strlen("message=")) / 2;
+    if (mlen > MAX_MSG_LENGTH ||
+        decode_hex("message", message, mlen, argv[2]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    ctxlen = (strlen(argv[3]) - strlen("context=")) / 2;
+    if (ctxlen > MAX_CTX_LENGTH ||
+        decode_hex("context", context, ctxlen, argv[3]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (decode_hex("signature", signature, sizeof(signature), argv[4]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (decode_hex("pk", pk, sizeof(pk), argv[5]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    return crypto_sign_verify(signature, sizeof(signature), message, mlen,
+                              context, ctxlen, pk);
+  }
+  else
+#endif /* !MLD_CONFIG_NO_VERIFY_API */
+  {
+    goto usage;
+  }
+
+  return 0;
+
+usage:
+  fprintf(stderr,
+          "Usage:\n"
+          "  wycheproof_mldsa{lvl} sigGenSeedDeterministic seed=HEX "
+          "message=HEX context=HEX externalMu=0/1\n"
+          "  wycheproof_mldsa{lvl} sigGenDeterministic message=HEX context=HEX "
+          "sk=HEX\n"
+          "  wycheproof_mldsa{lvl} sigGenInternalDeterministic message=HEX "
+          "sk=HEX externalMu=0/1\n"
+          "  wycheproof_mldsa{lvl} sigVer message=HEX context=HEX "
+          "signature=HEX pk=HEX\n");
+  return 1;
+}


### PR DESCRIPTION
Ports the Wycheproof test driver from mlkem-native (pq-code-package/mlkem-native#1588). InvalidPrivateKey vectors are reported as `skipped` since mldsa-native does not validate secret-key coefficient bounds.