### PR TITLE
CI: Add zig 0.16 compiler tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,9 @@ jobs:
          #
          # We omit all examples since there is currently no way to run
          # only those examples not involving native code.
+         #
+         # zig 0.16 still appears affected on Linux (CPU-feature
+         # predefines look to be dropped in assembler-with-cpp mode).
          - name: zig-0.12
            shell: zig0_12
            darwin: True
@@ -324,6 +327,13 @@ jobs:
            opt: no_opt
          - name: zig-0.15
            shell: zig0_15
+           darwin: True
+           c17: True
+           c23: True
+           examples: False
+           opt: no_opt
+         - name: zig-0.16
+           shell: zig0_16
            darwin: True
            c17: True
            c23: True

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
             overlays = [
               (_:_: {
                 clang_22 = pkgs-unstable.clang_22;
+                zig_0_16 = pkgs-unstable.zig;
 
                 # From 24.05 (dropped in 25.11)
                 gcc48 = pkgs-2405.gcc48;
@@ -191,6 +192,7 @@
           devShells.zig0_13 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_13);
           devShells.zig0_14 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_14);
           devShells.zig0_15 = util.mkShellWithCC' (zigWrapCC pkgs.zig);
+          devShells.zig0_16 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_16);
 
           devShells.gcc48 = util.mkShellWithCC' pkgs.gcc48;
           devShells.gcc49 = util.mkShellWithCC' pkgs.gcc49;


### PR DESCRIPTION
Adds a zig-0.16 entry to the compiler matrix, sourced from the unstable nixpkgs overlay. zig 0.16 still appears affected on Linux by ziglang/zig#23576, so we only test the C backend (matching the existing zig 0.12-0.15 entries).

 - Ported from pq-code-package/mlkem-native#1670.