### PR TITLE
x86_64: Fix wrong qbound 87*q -> 31*q in use_hint_32

### DIFF
--- a/dev/x86_64/src/poly_use_hint_32_avx2.c
+++ b/dev/x86_64/src/poly_use_hint_32_avx2.c
@@ -39,7 +39,7 @@ void mld_poly_use_hint_32_avx2(int32_t *b, const int32_t *a,
 {
   unsigned int i;
   __m256i f, f0, f1, h, t;
-  const __m256i q_bound = _mm256_set1_epi32(87 * ((MLDSA_Q - 1) / 32));
+  const __m256i q_bound = _mm256_set1_epi32(31 * ((MLDSA_Q - 1) / 32));
   /* check-magic: 1025 == floor(2**22 / 4092) */
   const __m256i v = _mm256_set1_epi32(1025);
   const __m256i alpha = _mm256_set1_epi32(2 * ((MLDSA_Q - 1) / 32));

--- a/mldsa/src/native/x86_64/src/poly_use_hint_32_avx2.c
+++ b/mldsa/src/native/x86_64/src/poly_use_hint_32_avx2.c
@@ -39,7 +39,7 @@ void mld_poly_use_hint_32_avx2(int32_t *b, const int32_t *a,
 {
   unsigned int i;
   __m256i f, f0, f1, h, t;
-  const __m256i q_bound = _mm256_set1_epi32(87 * ((MLDSA_Q - 1) / 32));
+  const __m256i q_bound = _mm256_set1_epi32(31 * ((MLDSA_Q - 1) / 32));
   /* check-magic: 1025 == floor(2**22 / 4092) */
   const __m256i v = _mm256_set1_epi32(1025);
   const __m256i alpha = _mm256_set1_epi32(2 * ((MLDSA_Q - 1) / 32));


### PR DESCRIPTION
use_hint_32 in the AVX2 backend contains a wrong constant that was copied from use_hint_88.
This disabled the check if w1=16 after the decompose step. Luckily, this cancels out later on in the use_hint for non-trivial reasons. We have also exhaustively tested that this code produces correct results for all inputs.

We will be able to optimize this away in a follow-up commit. For now, this commit just corrects the constant to avoid confusion.

- Fixes https://github.com/pq-code-package/mldsa-native/issues/1074