### PR TITLE
Test: Use Wycheproof signing tests to validate pk_from_sk

### DIFF
--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -85,16 +85,16 @@ def detect_supported_modes():
             err(
                 f"Warning: {wycheproof_call} failed (rc={result.returncode}), assuming all modes supported"
             )
-            return {"keyGen", "sigGen", "sigVer"}
+            return {"keyGen", "sigGen", "sigVer", "pkFromSk"}
         modes = set()
         for line in result.stdout.splitlines():
             line = line.strip()
-            if line in ("keyGen", "sigGen", "sigVer"):
+            if line in ("keyGen", "sigGen", "sigVer", "pkFromSk"):
                 modes.add(line)
         return modes
     except FileNotFoundError:
         err(f"Warning: {wycheproof_bin} not found, assuming all modes supported")
-        return {"keyGen", "sigGen", "sigVer"}
+        return {"keyGen", "sigGen", "sigVer", "pkFromSk"}
 
 
 # File-type → set of modes the binary must support to run those tests.
@@ -125,12 +125,16 @@ class TestResult(Enum):
 
 def check_sign_result(tc, out):
     if tc["result"] == "invalid":
-        # InvalidPrivateKey: implementation does not validate sk
-        if "InvalidPrivateKey" in tc.get("flags", []):
+        flags = tc.get("flags", [])
+        # InvalidPrivateKey: signing does not validate sk; tested via pk_from_sk
+        if "InvalidPrivateKey" in flags:
             return TestResult.SKIPPED
-        # _error: non-zero exit code; decode_error: explicit validation failure
-        assert "_error" in out or "decode_error" in out, (
-            f"binary success on invalid tcId={tc['tcId']}"
+        # If new invalid-flag classes appear, fail loudly so we can handle them.
+        assert "IncorrectPrivateKeyLength" in flags or "InvalidContext" in flags, (
+            f"unhandled invalid flag(s) {flags} for tcId={tc['tcId']}"
+        )
+        assert "decode_error" in out, (
+            f"expected decode_error on invalid tcId={tc['tcId']}"
         )
     elif tc["result"] == "valid":
         assert out["signature"].upper() == tc["sig"].upper(), (
@@ -259,6 +263,40 @@ def run_verify_test(data_file):
     info(f"  {count} verify tests passed")
 
 
+def check_pk_from_sk_result(tc, tg, out):
+    flags = tc.get("flags", [])
+    if "IncorrectPrivateKeyLength" in flags:
+        assert "decode_error" in out, (
+            f"expected decode_error for IncorrectPrivateKeyLength tcId={tc['tcId']}"
+        )
+    elif "InvalidPrivateKey" in flags:
+        assert "_error" in out, f"pk_from_sk accepted invalid SK for tcId={tc['tcId']}"
+    else:
+        assert "pk" in out, f"pk_from_sk failed on valid SK for tcId={tc['tcId']}"
+        assert out["pk"].upper() == tg["publicKey"].upper(), (
+            f"pk_from_sk derived wrong PK for tcId={tc['tcId']}"
+        )
+
+
+def run_pk_from_sk_noseed_test(data_file):
+    """Run pk_from_sk on all noseed signing test groups."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running pk_from_sk tests from {data_file}")
+    binary = get_binary(ALGORITHM_TO_LEVEL[data["algorithm"]])
+    count = 0
+    for tg in data["testGroups"]:
+        sk_hex = tg["privateKey"]
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            out = run_binary([binary, "pkFromSk", f"sk={sk_hex}"])
+            check_pk_from_sk_result(tc, tg, out)
+            info("ok")
+            count += 1
+    info(f"  {count} pk_from_sk tests passed")
+
+
 def run_all(data_dir, supported_modes):
     """Run all Wycheproof test vector files."""
     data_dir = Path(data_dir)
@@ -276,6 +314,10 @@ def run_all(data_dir, supported_modes):
                 break
             runner(filepath)
             break
+
+        if "sign_noseed_test" in filename and "pkFromSk" in supported_modes:
+            run_pk_from_sk_noseed_test(filepath)
+
     info("ALL GOOD!")
 
 
@@ -307,6 +349,11 @@ parser.add_argument(
     help="Skip tests requiring sigVer",
 )
 parser.add_argument(
+    "--no-pkfromsk",
+    action="store_true",
+    help="Skip tests requiring pkFromSk",
+)
+parser.add_argument(
     "--auto-detect",
     action="store_true",
     default=True,
@@ -319,7 +366,7 @@ if args.auto_detect and args.file is None:
     supported_modes = detect_supported_modes()
     info(f"Auto-detected supported modes: {sorted(supported_modes)}")
 else:
-    supported_modes = {"keyGen", "sigGen", "sigVer"}
+    supported_modes = {"keyGen", "sigGen", "sigVer", "pkFromSk"}
 
 # Apply explicit --no-* flags
 if args.no_keygen:
@@ -328,6 +375,8 @@ if args.no_sign:
     supported_modes.discard("sigGen")
 if args.no_verify:
     supported_modes.discard("sigVer")
+if args.no_pkfromsk:
+    supported_modes.discard("pkFromSk")
 
 if args.file:
     # Run a single file
@@ -336,6 +385,8 @@ if args.file:
         run_sign_seed_test(args.file)
     elif "sign_noseed_test" in filename:
         run_sign_noseed_test(args.file)
+        if "pkFromSk" in supported_modes:
+            run_pk_from_sk_noseed_test(args.file)
     elif "verify_test" in filename:
         run_verify_test(args.file)
     else:

--- a/test/wycheproof/wycheproof_mldsa.c
+++ b/test/wycheproof/wycheproof_mldsa.c
@@ -12,6 +12,7 @@
  * message=HEX context=HEX sk=HEX wycheproof_mldsa{lvl}
  * sigGenInternalDeterministic message=HEX sk=HEX externalMu=0/1
  *   wycheproof_mldsa{lvl} sigVer message=HEX context=HEX signature=HEX pk=HEX
+ *   wycheproof_mldsa{lvl} pkFromSk sk=HEX
  */
 
 #include <stddef.h>
@@ -25,6 +26,7 @@
 /* Additional SUPERCOP-style macros for functions not in the standard set */
 #define crypto_sign_keypair_internal MLD_API_NAMESPACE(keypair_internal)
 #define crypto_sign_signature_internal MLD_API_NAMESPACE(signature_internal)
+#define crypto_sign_pk_from_sk MLD_API_NAMESPACE(pk_from_sk)
 
 /* maximum message length used in the Wycheproof tests */
 #define MAX_MSG_LENGTH 8192
@@ -36,6 +38,7 @@ static void print_info(void)
 {
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
   printf("keyGen\n");
+  printf("pkFromSk\n");
 #endif
 #if !defined(MLD_CONFIG_NO_SIGN_API)
   printf("sigGen\n");
@@ -57,7 +60,8 @@ static void print_info(void)
     }                                                         \
   } while (0)
 
-#if !defined(MLD_CONFIG_NO_SIGN_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
+#if !defined(MLD_CONFIG_NO_SIGN_API) || !defined(MLD_CONFIG_NO_VERIFY_API) || \
+    !defined(MLD_CONFIG_NO_KEYPAIR_API)
 static unsigned char decode_hex_char(char hex)
 {
   if (hex >= '0' && hex <= '9')
@@ -111,9 +115,10 @@ static int decode_hex(const char *prefix, unsigned char *out, size_t out_len,
   }
   return 0;
 }
-#endif /* !MLD_CONFIG_NO_SIGN_API || !MLD_CONFIG_NO_VERIFY_API */
+#endif /* !MLD_CONFIG_NO_SIGN_API || !MLD_CONFIG_NO_VERIFY_API || \
+          !MLD_CONFIG_NO_KEYPAIR_API */
 
-#if !defined(MLD_CONFIG_NO_SIGN_API)
+#if !defined(MLD_CONFIG_NO_SIGN_API) || !defined(MLD_CONFIG_NO_KEYPAIR_API)
 static void print_hex(const char *name, const unsigned char *raw, size_t len)
 {
   if (name != NULL)
@@ -126,7 +131,7 @@ static void print_hex(const char *name, const unsigned char *raw, size_t len)
   }
   printf("\n");
 }
-#endif /* !MLD_CONFIG_NO_SIGN_API */
+#endif /* !MLD_CONFIG_NO_SIGN_API || !MLD_CONFIG_NO_KEYPAIR_API */
 
 int main(int argc, char *argv[])
 {
@@ -365,6 +370,32 @@ int main(int argc, char *argv[])
   }
   else
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+      if (strcmp(argv[1], "pkFromSk") == 0)
+  {
+    /* pkFromSk sk=HEX */
+    unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+
+    if (argc != 3)
+    {
+      goto usage;
+    }
+
+    if (decode_hex("sk", sk, sizeof(sk), argv[2]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    if (crypto_sign_pk_from_sk(pk, sk) != 0)
+    {
+      return 1;
+    }
+    print_hex("pk", pk, sizeof(pk));
+  }
+  else
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API */
   {
     goto usage;
   }
@@ -381,6 +412,7 @@ usage:
           "  wycheproof_mldsa{lvl} sigGenInternalDeterministic message=HEX "
           "sk=HEX externalMu=0/1\n"
           "  wycheproof_mldsa{lvl} sigVer message=HEX context=HEX "
-          "signature=HEX pk=HEX\n");
+          "signature=HEX pk=HEX\n"
+          "  wycheproof_mldsa{lvl} pkFromSk sk=HEX\n");
   return 1;
 }


### PR DESCRIPTION
Add a pkFromSk command to the Wycheproof C driver and a corresponding test runner in the Python client. This runs pk_from_sk on every test group from the noseed signing tests:

- InvalidPrivateKey: assert pk_from_sk rejects (non-zero exit)
- IncorrectPrivateKeyLength: assert decode_error from the driver
- Valid SK: assert pk_from_sk succeeds and derived PK matches expected

Also tighten check_sign_result to assert the exact expected failure mode per flag, rather than accepting any error. Unrecognised invalid flags now fail loudly.

Resolves #1078.