### PR TITLE
HOL-Light: Prefix imports to separate mldsa-native from s2n-bignum

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,12 @@
           holLightShellHook = ''
             export PATH=$PWD/scripts:$PATH
             export PROOF_DIR="$PWD/proofs/hol_light"
+            # Namespaced imports root for HOL-Light proofs.
+            # See scripts/check-hol-light-imports for the enforced rule.
+            export IMPORTS_DIR="$PROOF_DIR/.imports"
+            mkdir -p "$IMPORTS_DIR"
+            ln -sfn "$S2N_BIGNUM_DIR" "$IMPORTS_DIR/s2n_bignum"
+            ln -sfn "$PROOF_DIR"      "$IMPORTS_DIR/mldsa_native"
           '';
         in
         {
@@ -87,7 +93,7 @@
           packages.toolchain_aarch64_be = util.toolchain_aarch64_be;
           packages.gcc-arm-embedded = pkgs.gcc-arm-embedded;
 
-          devShells.default = util.mkShell {
+          devShells.default = (util.mkShell {
             packages = builtins.attrValues
               {
                 inherit (config.packages) linters cbmc hol_light s2n_bignum slothy toolchains_native hol_server;
@@ -96,7 +102,7 @@
                   nix-direnv
                   zig_0_13;
               } ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ config.packages.valgrind_varlat ];
-          };
+          }).overrideAttrs (old: { shellHook = holLightShellHook; });
 
           packages.hol_server = util.hol_server.hol_server_start;
           devShells.hol_light = (util.mkShell {

--- a/nix/hol_light/0005-Configure-hol-sh-for-mldsa-native.patch
+++ b/nix/hol_light/0005-Configure-hol-sh-for-mldsa-native.patch
@@ -2,20 +2,19 @@
 diff --git a/hol_4.14.sh b/hol_4.14.sh
 --- a/hol_4.14.sh
 +++ b/hol_4.14.sh
-@@ -57,4 +57,13 @@ if [ "${HOL_ML_PATH}" == "" ]; then
+@@ -57,4 +57,12 @@ if [ "${HOL_ML_PATH}" == "" ]; then
    HOL_ML_PATH="${HOLLIGHT_DIR}/hol.ml"
  fi
 
 -${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR}
 +# Add site-lib directory for topfind
 +SITELIB=$(dirname $(ocamlfind query findlib 2>/dev/null) 2>/dev/null)
-+
-+# Set HOLLIGHT_LOAD_PATH to include S2N_BIGNUM_DIR and mldsa-native proofs
-+export HOLLIGHT_LOAD_PATH="${S2N_BIGNUM_DIR}:${PROOF_DIR}:${HOLLIGHT_LOAD_PATH}"
-+
-+# Change to mldsa-native proofs directory if set, so define_from_elf can find object files
++# Resolve namespace-prefixed imports via $IMPORTS_DIR (populated by the
++# nix shellHook). The $S2N_BIGNUM_DIR fallback is retained only so
++# s2n-bignum's own internal `needs "common/..."` directives still resolve
++# during transitive loads; mldsa-native code never produces a bare path.
++export HOLLIGHT_LOAD_PATH="${IMPORTS_DIR}:${S2N_BIGNUM_DIR}:${HOLLIGHT_LOAD_PATH}"
 +[ -n "${PROOF_DIR}" ] && cd "${PROOF_DIR}"
-+
 +${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR} ${SITELIB:+-I "$SITELIB"}
 diff --git a/hol_4.sh b/hol_4.sh
 --- a/hol_4.sh

--- a/proofs/cbmc/run-cbmc-proofs.py
+++ b/proofs/cbmc/run-cbmc-proofs.py
@@ -58,8 +58,8 @@ additional jobs that you want to execute with `litani add-job`; and
 finally run `litani run-build`.
 
 The litani dashboard will be written under the `output` directory; the
-cbmc-viewer reports remain in the `$PROOF_DIR/report` directory. The
-HTML dashboard from the latest Litani run will always be symlinked to
+cbmc-viewer reports remain in the `report` directory. The HTML dashboard
+from the latest Litani run will always be symlinked to
 `output/latest/html/index.html`, so you can keep that page open in
 your browser and reload the page whenever you re-run this script.
 """

--- a/proofs/hol_light/.gitignore
+++ b/proofs/hol_light/.gitignore
@@ -2,3 +2,4 @@
 **/*.o
 **/*.native
 **/*.correct
+.imports/

--- a/proofs/hol_light/aarch64/proofs/aarch64_utils.ml
+++ b/proofs/hol_light/aarch64/proofs/aarch64_utils.ml
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  *)
 
-needs "common/mldsa_specs.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
 
 let ENSURES_STRENGTHEN_POST = prove(
   `!P (Q:armstate->bool) Q' R.

--- a/proofs/hol_light/aarch64/proofs/build-proof.sh
+++ b/proofs/hol_light/aarch64/proofs/build-proof.sh
@@ -56,7 +56,10 @@ echo "Generating a template .ml that loads the file...: ${template_ml}"
 inlined_prefix="$(mktemp)"
 inlined_ml="${inlined_prefix}.ml"
 inlined_cmx="${inlined_prefix}.cmx"
-(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH=${ROOT} ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
+# The $S2N_BIGNUM_DIR fallback on HOLLIGHT_LOAD_PATH is kept solely so
+# s2n-bignum's own internal `needs "common/..."` directives still resolve
+# during transitive loads. mldsa-native code never produces a bare path.
+(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH="${IMPORTS_DIR}:${S2N_BIGNUM_DIR}" ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
 
 # Give a large stack size.
 OCAMLRUNPARAM=l=2000000000 \

--- a/proofs/hol_light/aarch64/proofs/dump_bytecode.ml
+++ b/proofs/hol_light/aarch64/proofs/dump_bytecode.ml
@@ -4,7 +4,7 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
 print_string "=== bytecode start: aarch64/mldsa/mldsa_ntt.o ===\n";;
 print_literal_from_elf "aarch64/mldsa/mldsa_ntt.o";;

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_scalar.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_scalar.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/keccak_spec.ml";;
+needs "mldsa_native/common/keccak_spec.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/keccak_f1600_x1_scalar.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_v84a.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_v84a.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/keccak_spec.ml";;
+needs "mldsa_native/common/keccak_spec.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/keccak_f1600_x1_v84a.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x2_v84a.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x2_v84a.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/keccak_spec.ml";;
+needs "mldsa_native/common/keccak_spec.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/keccak_f1600_x2_v84a.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_scalar.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_scalar.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mldsa_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/keccak_f1600_x4_v8a_scalar.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_v84a_scalar.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_v84a_scalar.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mldsa_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/keccak_f1600_x4_v8a_v84a_scalar.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/keccak_utils.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_utils.ml
@@ -7,7 +7,7 @@
 (* Keccak utilities for AArch64 proofs.                                      *)
 (* ========================================================================= *)
 
-needs "common/keccak_spec.ml";;
+needs "mldsa_native/common/keccak_spec.ml";;
 
 (* ------------------------------------------------------------------------- *)
 (* Some custom normalization for logical equivalence and conjunction, which  *)

--- a/proofs/hol_light/aarch64/proofs/mldsa_ntt.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_ntt.ml
@@ -8,10 +8,10 @@
 (* Forward number theoretic transform.                                       *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
-needs "aarch64/proofs/mldsa_zetas.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
+needs "mldsa_native/aarch64/proofs/mldsa_zetas.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_ntt.o";;
  ****)
@@ -813,8 +813,8 @@ let MLDSA_NTT_SUBROUTINE_CORRECT = prove
 (* ------------------------------------------------------------------------- *)
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/mldsa_pointwise.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_pointwise.ml
@@ -8,9 +8,9 @@
 (* Pointwise multiplication of polynomials in NTT domain for ML-DSA.         *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 (*** print_literal_from_elf "aarch64/mldsa/mldsa_pointwise.o";;
  ***)
@@ -240,8 +240,8 @@ let MLDSA_POINTWISE_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/mldsa_pointwise_acc_l4.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_pointwise_acc_l4.ml
@@ -8,9 +8,9 @@
 (* Pointwise multiplication and accumulation of polynomials in ML-DSA NTT    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_pointwise_acc_l4.o";;
  ****)
@@ -325,8 +325,8 @@ let MLDSA_POINTWISE_ACC_L4_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/mldsa_pointwise_acc_l5.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_pointwise_acc_l5.ml
@@ -8,9 +8,9 @@
 (* Pointwise multiplication and accumulation of polynomials in ML-DSA NTT    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_pointwise_acc_l5.o";;
  ****)
@@ -351,8 +351,8 @@ let MLDSA_POINTWISE_ACC_L5_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/mldsa_pointwise_acc_l7.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_pointwise_acc_l7.ml
@@ -8,9 +8,9 @@
 (* Pointwise multiplication and accumulation of polynomials in ML-DSA NTT    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_pointwise_acc_l7.o";;
  ****)
@@ -384,8 +384,8 @@ let MLDSA_POINTWISE_ACC_L7_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/mldsa_poly_caddq.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_poly_caddq.ml
@@ -9,8 +9,8 @@
 (* Modular reduction of polynomial coefficients from (-q, q) to [0, q)       *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_poly_caddq.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/mldsa_poly_chknorm.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_poly_chknorm.ml
@@ -10,8 +10,8 @@
 (* Returns 1 if norm check fails (|coeff| >= bound), 0 otherwise             *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_poly_chknorm.o";;
  ****)

--- a/proofs/hol_light/aarch64/proofs/mldsa_polyz_unpack_17.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_polyz_unpack_17.ml
@@ -10,9 +10,9 @@
 (* Maps packed [0, 2^18-1] to signed [-(2^17-1), 2^17] via GAMMA1 - x       *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
-needs "aarch64/proofs/mldsa_polyz_unpack_consts.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
+needs "mldsa_native/aarch64/proofs/mldsa_polyz_unpack_consts.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_polyz_unpack_17.o";;
  ****)
@@ -343,8 +343,8 @@ let MLDSA_POLYZ_UNPACK_17_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/mldsa_polyz_unpack_19.ml
+++ b/proofs/hol_light/aarch64/proofs/mldsa_polyz_unpack_19.ml
@@ -10,9 +10,9 @@
 (* Maps packed [0, 2^20-1] to signed [-(2^19-1), 2^19] via GAMMA1 - x       *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
-needs "aarch64/proofs/mldsa_polyz_unpack_consts.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
+needs "mldsa_native/aarch64/proofs/mldsa_polyz_unpack_consts.ml";;
 
 (**** print_literal_from_elf "aarch64/mldsa/mldsa_polyz_unpack_19.o";;
  ****)
@@ -260,8 +260,8 @@ let MLDSA_POLYZ_UNPACK_19_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml
@@ -8,9 +8,9 @@
 (* Use hint to correct high bits of decomposition (ML-DSA, param 65/87).     *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 
 (**** print_literal_from_elf "aarch64/mldsa/poly_use_hint_32_aarch64_asm.o";;
@@ -910,8 +910,8 @@ let POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 
 let full_spec,public_vars = mk_safety_spec

--- a/proofs/hol_light/aarch64/proofs/poly_use_hint_88_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_use_hint_88_aarch64_asm.ml
@@ -8,9 +8,9 @@
 (* Use hint to correct high bits of decomposition (ML-DSA, param 44).        *)
 (* ========================================================================= *)
 
-needs "arm/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "aarch64/proofs/aarch64_utils.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/aarch64/proofs/aarch64_utils.ml";;
 
 
 (**** print_literal_from_elf "aarch64/mldsa/poly_use_hint_88_aarch64_asm.o";;
@@ -980,8 +980,8 @@ let POLY_USE_HINT_88_AARCH64_ASM_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 
 
 let full_spec,public_vars = mk_safety_spec

--- a/proofs/hol_light/common/keccak_spec.ml
+++ b/proofs/hol_light/common/keccak_spec.ml
@@ -8,7 +8,7 @@
 (* ========================================================================= *)
 
 needs "Library/words.ml";;
-needs "common/keccak_constants.ml";;
+needs "mldsa_native/common/keccak_constants.ml";;
 
 (*** Some abbreviations on top of the word library ***)
 

--- a/proofs/hol_light/s2n_bignum_allowlist.txt
+++ b/proofs/hol_light/s2n_bignum_allowlist.txt
@@ -1,0 +1,19 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Allowlist of s2n-bignum files that mldsa-native HOL-Light proofs may import.
+#
+# Each entry is the path *inside* s2n-bignum; in proof files it appears as
+# `needs "s2n_bignum/<entry>"`. Adding a new cross-repository dependency
+# requires adding the file here (surfacing the decision in code review).
+#
+# Keep the list limited to generic verification infrastructure: ELF loading,
+# relational reasoning, ARM/x86 base semantics, and the constant-time
+# framework. Do NOT add mldsa-specific proofs or specs from s2n-bignum --
+# those must live in proofs/hol_light/common/ so that mldsa-native remains
+# standalone-reproducible.
+
+arm/proofs/base.ml
+arm/proofs/consttime.ml
+x86/proofs/base.ml
+x86/proofs/consttime.ml

--- a/proofs/hol_light/x86_64/proofs/build-proof.sh
+++ b/proofs/hol_light/x86_64/proofs/build-proof.sh
@@ -56,7 +56,10 @@ echo "Generating a template .ml that loads the file...: ${template_ml}"
 inlined_prefix="$(mktemp)"
 inlined_ml="${inlined_prefix}.ml"
 inlined_cmx="${inlined_prefix}.cmx"
-(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH=${ROOT} ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
+# The $S2N_BIGNUM_DIR fallback on HOLLIGHT_LOAD_PATH is kept solely so
+# s2n-bignum's own internal `needs "common/..."` directives still resolve
+# during transitive loads. mldsa-native code never produces a bare path.
+(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH="${IMPORTS_DIR}:${S2N_BIGNUM_DIR}" ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
 
 # Give a large stack size.
 OCAMLRUNPARAM=l=2000000000 \

--- a/proofs/hol_light/x86_64/proofs/dump_bytecode.ml
+++ b/proofs/hol_light/x86_64/proofs/dump_bytecode.ml
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)
 
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
 print_string "=== bytecode start: x86_64/mldsa/mldsa_ntt.o ================\n";;
 print_literal_from_elf "x86_64/mldsa/mldsa_ntt.o";;

--- a/proofs/hol_light/x86_64/proofs/keccak_f1600_x4_avx2.ml
+++ b/proofs/hol_light/x86_64/proofs/keccak_f1600_x4_avx2.ml
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)
 
- needs "x86/proofs/base.ml";;
+ needs "s2n_bignum/x86/proofs/base.ml";;
 
- needs "x86_64/proofs/keccak_utils.ml";;
+ needs "mldsa_native/x86_64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "x86/sha3/keccak_f1600_x4_avx2.o";;
 ****)
@@ -1117,8 +1117,8 @@ let KECCAK_F1600_X4_AVX2_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mldsa_native/x86_64/proofs/subroutine_signatures.ml";;
 
 
 let full_spec,public_vars = mk_safety_spec

--- a/proofs/hol_light/x86_64/proofs/keccak_utils.ml
+++ b/proofs/hol_light/x86_64/proofs/keccak_utils.ml
@@ -7,8 +7,8 @@
 (* Keccak utilities for x86_64 proofs.                                       *)
 (* ========================================================================= *)
 
-needs "common/keccak_spec.ml";;
-needs "x86_64/proofs/keccak_f1600_x4_avx2_constants.ml";;
+needs "mldsa_native/common/keccak_spec.ml";;
+needs "mldsa_native/x86_64/proofs/keccak_f1600_x4_avx2_constants.ml";;
 
 (* ------------------------------------------------------------------------- *)
 (* Some custom normalization for logical equivalence and conjunction, which  *)

--- a/proofs/hol_light/x86_64/proofs/mldsa_intt.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_intt.ml
@@ -7,10 +7,10 @@
 (* ML-DSA Inverse number theoretic transform.                                *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "x86_64/proofs/mldsa_utils.ml";;
-needs "x86_64/proofs/mldsa_zetas.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_utils.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_zetas.ml";;
 
 (*** print_literal_from_elf "x86_64/mldsa/mldsa_intt.o";;
  ***)

--- a/proofs/hol_light/x86_64/proofs/mldsa_ntt.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_ntt.ml
@@ -7,10 +7,10 @@
 (* ML-DSA Forward number theoretic transform.                                *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "x86_64/proofs/mldsa_utils.ml";;
-needs "x86_64/proofs/mldsa_zetas.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_utils.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_zetas.ml";;
 
 (*** print_literal_from_elf "x86_64/mldsa/mldsa_ntt.o";;
  ***)

--- a/proofs/hol_light/x86_64/proofs/mldsa_nttunpack.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_nttunpack.ml
@@ -7,8 +7,8 @@
 (* NTT unpack for ML-DSA: 8x8 transpose within 4 blocks                      *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
 
 (**** print_literal_from_elf "x86/mldsa/mldsa_nttunpack.o";;
  ****)

--- a/proofs/hol_light/x86_64/proofs/mldsa_pointwise.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_pointwise.ml
@@ -8,10 +8,10 @@
 (* Pointwise multiplication of polynomials in NTT domain for ML-DSA.         *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "x86_64/proofs/mldsa_zetas.ml";;
-needs "x86_64/proofs/mldsa_utils.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_zetas.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_utils.ml";;
 
 (*** print_literal_from_elf "x86_64/mldsa/mldsa_pointwise.o";;
  ***)
@@ -457,8 +457,8 @@ let MLDSA_POINTWISE_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mldsa_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/mldsa_pointwise_acc_l4.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_pointwise_acc_l4.ml
@@ -8,10 +8,10 @@
 (* Pointwise multiplication and accumulation of polynomials in ML-DSA NTT    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "x86_64/proofs/mldsa_zetas.ml";;
-needs "x86_64/proofs/mldsa_utils.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_zetas.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_utils.ml";;
 
 (*** print_literal_from_elf "x86_64/mldsa/mldsa_pointwise_acc_l4.o";;
  ***)
@@ -488,8 +488,8 @@ let MLDSA_POINTWISE_ACC_L4_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mldsa_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/mldsa_pointwise_acc_l5.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_pointwise_acc_l5.ml
@@ -8,10 +8,10 @@
 (* Pointwise multiplication and accumulation of polynomials in ML-DSA NTT    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "x86_64/proofs/mldsa_zetas.ml";;
-needs "x86_64/proofs/mldsa_utils.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_zetas.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_utils.ml";;
 
 (*** print_literal_from_elf "x86_64/mldsa/mldsa_pointwise_acc_l5.o";;
  ***)
@@ -515,8 +515,8 @@ let MLDSA_POINTWISE_ACC_L5_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mldsa_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/mldsa_pointwise_acc_l7.ml
+++ b/proofs/hol_light/x86_64/proofs/mldsa_pointwise_acc_l7.ml
@@ -8,10 +8,10 @@
 (* Pointwise multiplication and accumulation of polynomials in ML-DSA NTT    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/base.ml";;
-needs "common/mldsa_specs.ml";;
-needs "x86_64/proofs/mldsa_zetas.ml";;
-needs "x86_64/proofs/mldsa_utils.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
+needs "mldsa_native/common/mldsa_specs.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_zetas.ml";;
+needs "mldsa_native/x86_64/proofs/mldsa_utils.ml";;
 
 (*** print_literal_from_elf "x86_64/mldsa/mldsa_pointwise_acc_l7.o";;
  ***)
@@ -571,8 +571,8 @@ let MLDSA_POINTWISE_ACC_L7_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mldsa_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/scripts/check-hol-light-imports
+++ b/scripts/check-hol-light-imports
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+"""Lint HOL-Light import directives.
+
+Every `needs`, `loadt`, or `loads` directive in proofs/hol_light/**/*.ml
+must have a namespace-prefixed target:
+
+  - `mldsa_native/...`  for local files
+  - `s2n_bignum/...`    for s2n-bignum files (must also be on the allowlist)
+  - `Library/...`       for HOL-Light standard library
+
+This guarantees that every cross-repository import is declared explicitly
+at the call site and that no s2n-bignum file can silently shadow a local
+file through load-path ordering (the namespace prefixes are disjoint).
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PROOF_ROOT = ROOT / "proofs" / "hol_light"
+ALLOWLIST = PROOF_ROOT / "s2n_bignum_allowlist.txt"
+
+DIRECTIVE = re.compile(r'^\s*(needs|loadt|loads)\s+"([^"]+)"')
+
+
+def load_allowlist():
+    if not ALLOWLIST.exists():
+        return set()
+    entries = set()
+    for raw in ALLOWLIST.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def main():
+    allowlist = load_allowlist()
+    violations = []
+
+    for path in sorted(PROOF_ROOT.rglob("*.ml")):
+        rel = path.relative_to(ROOT)
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            m = DIRECTIVE.match(line)
+            if not m:
+                continue
+            target = m.group(2)
+            if target.startswith("mldsa_native/") or target.startswith("Library/"):
+                continue
+            if target.startswith("s2n_bignum/"):
+                rest = target[len("s2n_bignum/"):]
+                if rest not in allowlist:
+                    violations.append(
+                        (rel, lineno,
+                         f"s2n-bignum import '{target}' is not on the allowlist "
+                         f"({ALLOWLIST.relative_to(ROOT)})")
+                    )
+                continue
+            violations.append(
+                (rel, lineno,
+                 f"unqualified import '{target}' -- expected prefix "
+                 "'mldsa_native/', 's2n_bignum/', or 'Library/'")
+            )
+
+    for rel, lineno, msg in violations:
+        print(f"{rel}:{lineno}: {msg}", file=sys.stderr)
+
+    if violations:
+        print(f"\n{len(violations)} violation(s)", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lint
+++ b/scripts/lint
@@ -297,6 +297,22 @@ gh_group_start "Check contracts"
 check-contracts
 gh_group_end
 
+check-hol-light-imports()
+{
+  if python3 "$ROOT"/scripts/check-hol-light-imports; then
+    info "Check HOL-Light imports"
+    gh_summary_success "Check HOL-Light imports"
+  else
+    error "Check HOL-Light imports"
+    gh_summary_failure "Check HOL-Light imports"
+    SUCCESS=false
+  fi
+}
+
+gh_group_start "Check HOL-Light imports"
+check-hol-light-imports
+gh_group_end
+
 if ! $SUCCESS; then
   if $IN_GITHUB_CONTEXT; then
     printf "%b%s%b\n" "${RED}" "The following checks failed, expand each for more details." "${NORMAL}"


### PR DESCRIPTION
* Fixes https://github.com/pq-code-package/mldsa-native/issues/1086

**Issue**: every `needs` directive in mldsa-native proof files resolved ambiguously against both $PROOF_DIR and $S2N_BIGNUM_DIR, so a file with the same relative path in either tree could silently shadow the other.

**Proposed resolution:** Every import now declares its source at the call site with a namespace prefix.

```
  needs "mldsa_native/common/mldsa_specs.ml";;   (* local *)
  needs "s2n_bignum/arm/proofs/base.ml";;        (* external *)
  needs "Library/words.ml";;                     (* HOL-Light stdlib *)
```

The nix shellHook creates a temporary .imports directory with symlinks `mldsa_native` and `s2n_bignum` pointing to the local resp. s2n-bignum directories, and HOLLIGHT_LOAD_PATH points at that import directory. The `mldsa_native/` and `s2n_bignum/` namespaces are disjoint by prefix, so path collisions become structurally impossible.

A new scripts/check-hol-light-imports enforces the rule across proofs/hol_light/**/*.ml and is wired into scripts/lint and both build-proof.sh scripts. s2n-bignum imports must additionally appear on proofs/hol_light/s2n_bignum_allowlist.txt, so new cross-repo dependencies surface in review.

A side-benefit of exposing proofs/hol_light/.imports is that it is easier to navigate to the nix-imported s2n-bignum sources for inspection.