### PR TITLE
Use heap allocation + valgrind in backend unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,45 @@ jobs:
           examples: false
           stack: true
           check_namespace: false
+  unit_valgrind:
+    name: Unit tests + valgrind (${{ matrix.target.name }}, ${{ matrix.cflags }})
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+          - runner: ubuntu-latest
+            name: x86_64
+          - runner: ubuntu-24.04-arm
+            name: aarch64
+        cflags: ['-O3', '-Os']
+        exclude:
+          - external: true
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Unit tests under valgrind
+        uses: ./.github/actions/functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: valgrind-varlat_gcc15
+          nix-cache: false
+          opt: opt
+          cflags: "${{ matrix.cflags }} -std=c11 -D_GNU_SOURCE -DMLD_CONFIG_FILE=\\\\\\\"../test/configs/custom_heap_alloc_config.h\\\\\\\""
+          func: false
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: false
+          stack: false
+          unit: true
+          alloc: false
+          rng_fail: false
+          check_namespace: false
+          # Disable AArch64 SHA3 extension: valgrind cannot emulate it
+          extra_env: "MK_COMPILER_SUPPORTS_SHA3=0"
+          exec_wrapper: "valgrind --error-exitcode=1"
   config_variations:
     name: "Config: ${{ matrix.test.name }} (${{ matrix.target.name }})"
     strategy:

--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -97,6 +97,7 @@ source code and documentation.
   - [mldsa/src/sign.h](mldsa/src/sign.h)
   - [proofs/cbmc/mldsa_native_config_cbmc.h](proofs/cbmc/mldsa_native_config_cbmc.h)
   - [test/configs/break_pct_config.h](test/configs/break_pct_config.h)
+  - [test/configs/custom_heap_alloc_config.h](test/configs/custom_heap_alloc_config.h)
   - [test/configs/custom_memcpy_config.h](test/configs/custom_memcpy_config.h)
   - [test/configs/custom_memset_config.h](test/configs/custom_memset_config.h)
   - [test/configs/custom_native_capability_config_0.h](test/configs/custom_native_capability_config_0.h)

--- a/dev/aarch64_clean/src/rej_uniform_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm.S
@@ -307,10 +307,10 @@ rej_uniform_loop48_end:
         tbl     val0.16b, {val0.16b}, table0.16b
         tbl     val1.16b, {val1.16b}, table1.16b
 
-        str     val0q, [output_tmp]
+        st1     {val0.4s}, [output_tmp]
         add     output_tmp, output_tmp, ctr0, lsl #2
 
-        str     val1q, [output_tmp]
+        st1     {val1.4s}, [output_tmp]
         add     output_tmp, output_tmp, ctr1, lsl #2
 
         add     count, count, ctr0

--- a/dev/aarch64_opt/src/rej_uniform_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm.S
@@ -307,10 +307,10 @@ rej_uniform_loop48_end:
         tbl     val0.16b, {val0.16b}, table0.16b
         tbl     val1.16b, {val1.16b}, table1.16b
 
-        str     val0q, [output_tmp]
+        st1     {val0.4s}, [output_tmp]
         add     output_tmp, output_tmp, ctr0, lsl #2
 
-        str     val1q, [output_tmp]
+        st1     {val1.4s}, [output_tmp]
         add     output_tmp, output_tmp, ctr1, lsl #2
 
         add     count, count, ctr0

--- a/mldsa/src/native/aarch64/src/rej_uniform_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_asm.S
@@ -146,9 +146,9 @@ Lrej_uniform_loop48_end:
         fmov x13, d21
         tbl v16.16b, { v16.16b }, v24.16b
         tbl v17.16b, { v17.16b }, v25.16b
-        str q16, [x7]
+        st1 { v16.4s }, [x7]
         add x7, x7, x12, lsl #2
-        str q17, [x7]
+        st1 { v17.4s }, [x7]
         add x7, x7, x13, lsl #2
         add x9, x9, x12
         add x9, x9, x13

--- a/test/configs/configs.yml
+++ b/test/configs/configs.yml
@@ -413,6 +413,36 @@ configs:
       MLD_CONFIG_FILE:
         comment: "/* No need to set this -- we _are_ already in a custom config */"
 
+  - path: test/configs/custom_heap_alloc_config.h
+    description: "Test configuration with heap-based allocation"
+    defines:
+      MLD_CONFIG_CUSTOM_ALLOC_FREE:
+        content: |
+          /* In practice, one could just use aligned_alloc here. However, this
+           * requires aligning up the size to a multiple of the alignment, which
+           * weakens some of the memory-safety tests we run using this config. */
+          #define MLD_CONFIG_CUSTOM_ALLOC_FREE
+          #if !defined(__ASSEMBLER__)
+          #if defined(_WIN32)
+          #include <malloc.h>
+          #define MLD_CUSTOM_ALLOC(v, T, N) \
+            T *v = (T *)_aligned_malloc(sizeof(T) * (N), MLD_DEFAULT_ALIGN)
+          #define MLD_CUSTOM_FREE(v, T, N) _aligned_free(v)
+          #else
+          #include <stdlib.h>
+          static inline void *mld_posix_memalign(size_t align, size_t sz)
+          {
+            void *ptr = NULL;
+            if (posix_memalign(&ptr, align, sz) != 0)
+              return NULL;
+            return ptr;
+          }
+          #define MLD_CUSTOM_ALLOC(v, T, N) \
+            T *v = (T *)mld_posix_memalign(MLD_DEFAULT_ALIGN, sizeof(T) * (N))
+          #define MLD_CUSTOM_FREE(v, T, N) free(v)
+          #endif /* _WIN32 */
+          #endif /* !__ASSEMBLER__ */
+
   - path: test/configs/test_alloc_config.h
     description: "Using custom allocation that can be made fail at specific invocation"
     defines:

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -11,6 +11,11 @@
  *   Validation Program
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-ig-announcements
+ *
+ * - [FIPS204]
+ *   FIPS 204 Module-Lattice-Based Digital Signature Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/204/final
  */
 
 /*
@@ -120,6 +125,57 @@
  *
  *****************************************************************************/
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_KEYPAIR_API
+ *
+ * Description: By default, mldsa-native includes support for generating key
+ *              pairs. If you don't need this, set MLD_CONFIG_NO_KEYPAIR_API
+ *              to exclude crypto_sign_keypair, crypto_sign_keypair_internal,
+ *              crypto_sign_pk_from_sk, and all internal APIs only needed by
+ *              those functions.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_KEYPAIR_API */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_SIGN_API
+ *
+ * Description: By default, mldsa-native includes support for creating
+ *              signatures. If you don't need this, set MLD_CONFIG_NO_SIGN_API
+ *              to exclude crypto_sign, crypto_sign_signature,
+ *              crypto_sign_signature_extmu, crypto_sign_signature_internal,
+ *              crypto_sign_signature_pre_hash_internal,
+ *              crypto_sign_signature_pre_hash_shake256, and all internal APIs
+ *              only needed by those functions.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_SIGN_API */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_VERIFY_API
+ *
+ * Description: By default, mldsa-native includes support for verifying
+ *              signatures. If you don't need this, set
+ *              MLD_CONFIG_NO_VERIFY_API to exclude crypto_sign_open,
+ *              crypto_sign_verify, crypto_sign_verify_extmu,
+ *              crypto_sign_verify_internal,
+ *              crypto_sign_verify_pre_hash_internal,
+ *              crypto_sign_verify_pre_hash_shake256, and all internal APIs
+ *              only needed by those functions.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_NO_VERIFY_API */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CORE_API_ONLY
+ *
+ * Description: Set this to remove all public APIs except
+ *              crypto_sign_keypair_internal, crypto_sign_signature_internal,
+ *              and crypto_sign_verify_internal.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CORE_API_ONLY */
 
 /******************************************************************************
  * Name:        MLD_CONFIG_NO_RANDOMIZED_API
@@ -352,6 +408,106 @@
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
 
 /******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_ZEROIZE
+ *
+ * Description: In compliance with @[FIPS204, Section 3.6.3], mldsa-native,
+ *              zeroizes intermediate stack buffers before returning from
+ *              function calls.
+ *
+ *              Set this option and define `mld_zeroize` if you want to
+ *              use a custom method to zeroize intermediate stack buffers.
+ *              The default implementation uses SecureZeroMemory on Windows
+ *              and a memset + compiler barrier otherwise. If neither of those
+ *              is available on the target platform, compilation will fail,
+ *              and you will need to use MLD_CONFIG_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mld_zeroize()`.
+ *
+ *              WARNING:
+ *              The explicit stack zeroization conducted by mldsa-native
+ *              reduces the likelihood of data leaking on the stack, but
+ *              does not eliminate it! The C standard makes no guarantee about
+ *              where a compiler allocates structures and whether/where it makes
+ *              copies of them. Also, in addition to entire structures, there
+ *              may also be potentially exploitable leakage of individual values
+ *              on the stack.
+ *
+ *              If you need bullet-proof zeroization of the stack, you need to
+ *              consider additional measures instead of what this feature
+ *              provides. In this case, you can set mld_zeroize to a
+ *              no-op.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_ZEROIZE
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "src/src.h"
+   static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mldsa-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mldsa-native expects a function
+ *              int randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mld_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "src/src.h"
+   static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+       return 0;
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
+ *
+ * Description: mldsa-native backends may rely on specific hardware features.
+ *              Those backends will only be included in an mldsa-native build
+ *              if support for the respective features is enabled at
+ *              compile-time. However, when building for a heteroneous set
+ *              of CPUs to run the resulting binary/library on, feature
+ *              detection at _runtime_ is needed to decided whether a backend
+ *              can be used or not.
+ *
+ *              Set this option and define `mld_sys_check_capability` if you
+ *              want to use a custom method to dispatch between implementations.
+ *
+ *              Return value 1 indicates that a capability is supported.
+ *              Return value 0 indicates that a capability is not supported.
+ *
+ *              If this option is not set, mldsa-native uses compile-time
+ *              feature detection only to decide which backend to use.
+ *
+ *              If you compile mldsa-native on a system with different
+ *              capabilities than the system that the resulting binary/library
+ *              will be run on, you must use this option.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
+   static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
+   {
+       ... your implementation ...
+   }
+*/
+
+/******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_ALLOC_FREE [EXPERIMENTAL]
  *
  * Description: Set this option and define `MLD_CUSTOM_ALLOC` and
@@ -386,69 +542,33 @@
  *              code will handle this case and invoke MLD_CUSTOM_FREE.
  *
  *****************************************************************************/
+/* In practice, one could just use aligned_alloc here. However, this
+ * requires aligning up the size to a multiple of the alignment, which
+ * weakens some of the memory-safety tests we run using this config. */
 #define MLD_CONFIG_CUSTOM_ALLOC_FREE
 #if !defined(__ASSEMBLER__)
-#include <stdlib.h>
+#if defined(_WIN32)
+#include <malloc.h>
 #define MLD_CUSTOM_ALLOC(v, T, N) \
-  T *v = (T *)aligned_alloc(MLD_DEFAULT_ALIGN, MLD_ALIGN_UP(sizeof(T) * (N)))
+  T *v = (T *)_aligned_malloc(sizeof(T) * (N), MLD_DEFAULT_ALIGN)
+#define MLD_CUSTOM_FREE(v, T, N) _aligned_free(v)
+#else /* _WIN32 */
+#include <stdlib.h>
+static inline void *mld_posix_memalign(size_t align, size_t sz)
+{
+  void *ptr = NULL;
+  if (posix_memalign(&ptr, align, sz) != 0)
+  {
+    return NULL;
+  }
+  return ptr;
+}
+#define MLD_CUSTOM_ALLOC(v, T, N) \
+  T *v = (T *)mld_posix_memalign(MLD_DEFAULT_ALIGN, sizeof(T) * (N))
 #define MLD_CUSTOM_FREE(v, T, N) free(v)
+#endif /* !_WIN32 */
 #endif /* !__ASSEMBLER__ */
 
-
-/******************************************************************************
- * Name:        MLD_CONFIG_CUSTOM_RANDOMBYTES
- *
- * Description: mldsa-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
- *              consumer.
- *
- *              If this option is not set, mldsa-native expects a function
- *              int randombytes(uint8_t *out, size_t outlen).
- *
- *              Set this option and define `mld_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
- *
- *****************************************************************************/
-/* #define MLD_CONFIG_CUSTOM_RANDOMBYTES
-   #if !defined(__ASSEMBLER__)
-   #include <stdint.h>
-   #include "src/src.h"
-   static MLD_INLINE void mld_randombytes(uint8_t *ptr, size_t len)
-   {
-       ... your implementation ...
-   }
-   #endif
-*/
-
-/******************************************************************************
- * Name:        MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
- *
- * Description: mldsa-native backends may rely on specific hardware features.
- *              Those backends will only be included in an mldsa-native build
- *              if support for the respective features is enabled at
- *              compile-time. However, when building for a heteroneous set
- *              of CPUs to run the resulting binary/library on, feature
- *              detection at _runtime_ is needed to decided whether a backend
- *              can be used or not.
- *
- *              Set this option and define `mld_sys_check_capability` if you
- *              want to use a custom method to dispatch between implementations.
- *
- *              If this option is not set, mldsa-native uses compile-time
- *              feature detection only to decide which backend to use.
- *
- *              If you compile mldsa-native on a system with different
- *              capabilities than the system that the resulting binary/library
- *              will be run on, you must use this option.
- *
- *****************************************************************************/
-/* #define MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
-   static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
-   {
-       ... your implementation ...
-   }
-*/
 
 /******************************************************************************
  * Name:        MLD_CONFIG_CUSTOM_MEMCPY
@@ -499,8 +619,8 @@
 /******************************************************************************
  * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
- * Description: If set, this option provides an additional function
- *              qualifier to be added to declarations of internal API.
+ * Description: If set, this option provides an additional qualifier
+ *              to be added to declarations of internal API functions and data.
  *
  *              The primary use case for this option are single-CU builds,
  *              in which case this option can be set to `static`.
@@ -572,6 +692,10 @@
  *              NOTE: This feature will drastically lower the performance of
  *              key generation.
  *
+ *              NOTE: This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ *              and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ *              requires crypto_sign_signature() and crypto_sign_verify().
+ *
  *****************************************************************************/
 /* #define MLD_CONFIG_KEYGEN_PCT */
 
@@ -617,6 +741,48 @@
  *
  *****************************************************************************/
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Description: Set this to add a context parameter that is provided to public
+ *              API functions and is then available in custom callbacks.
+ *
+ *              The type of the context parameter is configured via
+ *              MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Description: Set this to define the type for the context parameter used by
+ *              MLD_CONFIG_CONTEXT_PARAMETER.
+ *
+ *              This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ *
+ * Description: Set this to reduce RAM usage.
+ *              This trades memory for performance.
+ *
+ *              For expected memory usage, see the MLD_TOTAL_ALLOC_* constants
+ *              defined in mldsa_native.h.
+ *
+ *              This option is useful for embedded systems with tight RAM
+ *              constraints but relaxed performance requirements.
+ *
+ *              WARNING: This option is experimental!
+ *              CBMC proofs do not currently cover this configuration option.
+ *              Its scope and configuration may change at any time.
+ *
+ *****************************************************************************/
+/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -35,12 +35,14 @@ MLDSA87_OBJS = $(call MAKE_OBJS,$(MLDSA87_DIR),$(SOURCES) $(FIPS202_SRCS))
 $(MLDSA87_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=87
 
 # Unit test object files - same sources but with MLD_STATIC_TESTABLE=
+UNIT_CFLAGS = -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+
 MLDSA44_UNIT_OBJS = $(call MAKE_OBJS,$(MLDSA44_DIR)/unit,$(SOURCES) $(FIPS202_SRCS))
-$(MLDSA44_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA44_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=44 $(UNIT_CFLAGS)
 MLDSA65_UNIT_OBJS = $(call MAKE_OBJS,$(MLDSA65_DIR)/unit,$(SOURCES) $(FIPS202_SRCS))
-$(MLDSA65_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA65_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=65 $(UNIT_CFLAGS)
 MLDSA87_UNIT_OBJS = $(call MAKE_OBJS,$(MLDSA87_DIR)/unit,$(SOURCES) $(FIPS202_SRCS))
-$(MLDSA87_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA87_UNIT_OBJS): CFLAGS += -DMLD_CONFIG_PARAMETER_SET=87 $(UNIT_CFLAGS)
 
 # Alloc test object files - same sources but with custom alloc config
 MLDSA44_ALLOC_OBJS = $(call MAKE_OBJS,$(MLDSA44_DIR)/alloc,$(SOURCES) $(FIPS202_SRCS))
@@ -83,9 +85,13 @@ $(MLDSA44_DIR)/test/src/test_alloc.c.o: CFLAGS += -DMLD_CONFIG_FILE=\"../test/co
 $(MLDSA65_DIR)/test/src/test_alloc.c.o: CFLAGS += -DMLD_CONFIG_FILE=\"../test/configs/test_alloc_config.h\"
 $(MLDSA87_DIR)/test/src/test_alloc.c.o: CFLAGS += -DMLD_CONFIG_FILE=\"../test/configs/test_alloc_config.h\"
 
-$(MLDSA44_DIR)/bin/test_unit44: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
-$(MLDSA65_DIR)/bin/test_unit65: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
-$(MLDSA87_DIR)/bin/test_unit87: CFLAGS += -DMLD_STATIC_TESTABLE= -DMLD_UNIT_TEST -Wno-missing-prototypes
+$(MLDSA44_DIR)/test/src/test_unit.c.o: CFLAGS += $(UNIT_CFLAGS)
+$(MLDSA65_DIR)/test/src/test_unit.c.o: CFLAGS += $(UNIT_CFLAGS)
+$(MLDSA87_DIR)/test/src/test_unit.c.o: CFLAGS += $(UNIT_CFLAGS)
+
+$(MLDSA44_DIR)/bin/test_unit44: CFLAGS += $(UNIT_CFLAGS)
+$(MLDSA65_DIR)/bin/test_unit65: CFLAGS += $(UNIT_CFLAGS)
+$(MLDSA87_DIR)/bin/test_unit87: CFLAGS += $(UNIT_CFLAGS)
 
 # Unit library object files compiled with MLD_STATIC_TESTABLE=
 $(MLDSA44_DIR)/unit_%: CFLAGS += -DMLD_STATIC_TESTABLE= -Wno-missing-prototypes

--- a/test/src/test_unit.c
+++ b/test/src/test_unit.c
@@ -271,34 +271,52 @@ static int compare_i32_arrays(const int32_t *a, const int32_t *b, unsigned len,
 #ifdef MLD_USE_NATIVE_NTT
 static int test_ntt_core(const int32_t *input, const char *test_name)
 {
-  mld_poly test_poly, ref_poly;
+  int ret = 1;
+  MLD_ALLOC(test_poly, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_poly, mld_poly, 1, NULL);
 
-  memcpy(test_poly.coeffs, input, MLDSA_N * sizeof(int32_t));
-  memcpy(ref_poly.coeffs, input, MLDSA_N * sizeof(int32_t));
+  if (test_poly == NULL || ref_poly == NULL)
+  {
+    goto cleanup;
+  }
 
-  mld_poly_ntt(&test_poly);
-  mld_poly_ntt_c(&ref_poly);
+  memcpy(test_poly->coeffs, input, MLDSA_N * sizeof(int32_t));
+  memcpy(ref_poly->coeffs, input, MLDSA_N * sizeof(int32_t));
+
+  mld_poly_ntt(test_poly);
+  mld_poly_ntt_c(ref_poly);
 
 #ifdef MLD_USE_NATIVE_NTT_CUSTOM_ORDER
-  mld_poly_permute_bitrev_to_custom(ref_poly.coeffs);
+  mld_poly_permute_bitrev_to_custom(ref_poly->coeffs);
 #endif
 
   /* Normalize */
-  mld_poly_reduce(&ref_poly);
-  mld_poly_reduce(&test_poly);
+  mld_poly_reduce(ref_poly);
+  mld_poly_reduce(test_poly);
 
-  mld_poly_caddq_c(&ref_poly);
-  mld_poly_caddq_c(&test_poly);
+  mld_poly_caddq_c(ref_poly);
+  mld_poly_caddq_c(test_poly);
 
-  CHECK(compare_i32_arrays(test_poly.coeffs, ref_poly.coeffs, MLDSA_N,
+  CHECK(compare_i32_arrays(test_poly->coeffs, ref_poly->coeffs, MLDSA_N,
                            test_name, input));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_poly, mld_poly, 1, NULL);
+  MLD_FREE(test_poly, mld_poly, 1, NULL);
+  return ret;
 }
 
 static int test_native_ntt(void)
 {
-  int32_t test_data[MLDSA_N];
+  int ret = 1;
   int pos, i;
+  MLD_ALLOC(test_data, int32_t, MLDSA_N, NULL);
+
+  if (test_data == NULL)
+  {
+    goto cleanup;
+  }
 
   generate_i32_array_zeros(test_data, MLDSA_N);
   CHECK(test_ntt_core(test_data, "ntt_zeros") == 0);
@@ -315,41 +333,63 @@ static int test_native_ntt(void)
     CHECK(test_ntt_core(test_data, "ntt_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_data, int32_t, MLDSA_N, NULL);
+  return ret;
 }
 #endif /* MLD_USE_NATIVE_NTT */
 
 #ifdef MLD_USE_NATIVE_INTT
 static int test_invntt_tomont_core(const int32_t *input, const char *test_name)
 {
-  mld_poly test_poly, ref_poly;
+  int ret = 1;
+  MLD_ALLOC(test_poly, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_poly, mld_poly, 1, NULL);
 
-  memcpy(test_poly.coeffs, input, MLDSA_N * sizeof(int32_t));
-  memcpy(ref_poly.coeffs, input, MLDSA_N * sizeof(int32_t));
+  if (test_poly == NULL || ref_poly == NULL)
+  {
+    goto cleanup;
+  }
+
+  memcpy(test_poly->coeffs, input, MLDSA_N * sizeof(int32_t));
+  memcpy(ref_poly->coeffs, input, MLDSA_N * sizeof(int32_t));
 
 #ifdef MLD_USE_NATIVE_NTT_CUSTOM_ORDER
-  mld_poly_permute_bitrev_to_custom(test_poly.coeffs);
+  mld_poly_permute_bitrev_to_custom(test_poly->coeffs);
 #endif
 
-  mld_poly_invntt_tomont(&test_poly);
-  mld_poly_invntt_tomont_c(&ref_poly);
+  mld_poly_invntt_tomont(test_poly);
+  mld_poly_invntt_tomont_c(ref_poly);
 
   /* Normalize */
-  mld_poly_reduce(&ref_poly);
-  mld_poly_reduce(&test_poly);
+  mld_poly_reduce(ref_poly);
+  mld_poly_reduce(test_poly);
 
-  mld_poly_caddq_c(&ref_poly);
-  mld_poly_caddq_c(&test_poly);
+  mld_poly_caddq_c(ref_poly);
+  mld_poly_caddq_c(test_poly);
 
-  CHECK(compare_i32_arrays(test_poly.coeffs, ref_poly.coeffs, MLDSA_N,
+  CHECK(compare_i32_arrays(test_poly->coeffs, ref_poly->coeffs, MLDSA_N,
                            test_name, input));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_poly, mld_poly, 1, NULL);
+  MLD_FREE(test_poly, mld_poly, 1, NULL);
+  return ret;
 }
 
 static int test_native_invntt_tomont(void)
 {
-  int32_t test_data[MLDSA_N];
+  int ret = 1;
   int pos, i;
+  MLD_ALLOC(test_data, int32_t, MLDSA_N, NULL);
+
+  if (test_data == NULL)
+  {
+    goto cleanup;
+  }
 
   generate_i32_array_zeros(test_data, MLDSA_N);
   CHECK(test_invntt_tomont_core(test_data, "invntt_tomont_zeros") == 0);
@@ -366,7 +406,11 @@ static int test_native_invntt_tomont(void)
     CHECK(test_invntt_tomont_core(test_data, "invntt_tomont_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_data, int32_t, MLDSA_N, NULL);
+  return ret;
 }
 #endif /* MLD_USE_NATIVE_INTT */
 
@@ -376,35 +420,61 @@ static int test_native_invntt_tomont(void)
 static int test_poly_decompose_core(const mld_poly *input_poly,
                                     const char *test_name)
 {
-  mld_poly test_a1, test_a0, ref_a1, ref_a0;
+  int ret = 1;
+  MLD_ALLOC(test_a1, mld_poly, 1, NULL);
+  MLD_ALLOC(test_a0, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_a1, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_a0, mld_poly, 1, NULL);
 
-  mld_memcpy(&test_a0, input_poly, sizeof(mld_poly));
-  mld_memcpy(&ref_a0, input_poly, sizeof(mld_poly));
+  if (test_a1 == NULL || test_a0 == NULL || ref_a1 == NULL || ref_a0 == NULL)
+  {
+    goto cleanup;
+  }
 
-  mld_poly_decompose(&test_a1, &test_a0);
-  mld_poly_decompose_c(&ref_a1, &ref_a0);
+  mld_memcpy(test_a0, input_poly, sizeof(mld_poly));
+  mld_memcpy(ref_a0, input_poly, sizeof(mld_poly));
 
-  CHECK(compare_i32_arrays(test_a1.coeffs, ref_a1.coeffs, MLDSA_N, test_name,
+  mld_poly_decompose(test_a1, test_a0);
+  mld_poly_decompose_c(ref_a1, ref_a0);
+
+  CHECK(compare_i32_arrays(test_a1->coeffs, ref_a1->coeffs, MLDSA_N, test_name,
                            input_poly->coeffs));
-  CHECK(compare_i32_arrays(test_a0.coeffs, ref_a0.coeffs, MLDSA_N, test_name,
+  CHECK(compare_i32_arrays(test_a0->coeffs, ref_a0->coeffs, MLDSA_N, test_name,
                            input_poly->coeffs));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_a0, mld_poly, 1, NULL);
+  MLD_FREE(ref_a1, mld_poly, 1, NULL);
+  MLD_FREE(test_a0, mld_poly, 1, NULL);
+  MLD_FREE(test_a1, mld_poly, 1, NULL);
+  return ret;
 }
 static int test_native_decompose(void)
 {
-  mld_poly test_poly;
+  int ret = 1;
   int i;
+  MLD_ALLOC(test_poly, mld_poly, 1, NULL);
 
-  generate_i32_array_zeros(test_poly.coeffs, MLDSA_N);
-  CHECK(test_poly_decompose_core(&test_poly, "poly_decompose_zeros") == 0);
+  if (test_poly == NULL)
+  {
+    goto cleanup;
+  }
+
+  generate_i32_array_zeros(test_poly->coeffs, MLDSA_N);
+  CHECK(test_poly_decompose_core(test_poly, "poly_decompose_zeros") == 0);
 
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    generate_i32_array_ranged(test_poly.coeffs, MLDSA_N, 0, MLDSA_Q);
-    CHECK(test_poly_decompose_core(&test_poly, "poly_decompose_random") == 0);
+    generate_i32_array_ranged(test_poly->coeffs, MLDSA_N, 0, MLDSA_Q);
+    CHECK(test_poly_decompose_core(test_poly, "poly_decompose_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_poly, mld_poly, 1, NULL);
+  return ret;
 }
 #endif /* (MLD_USE_NATIVE_POLY_DECOMPOSE_32 || \
           MLD_USE_NATIVE_POLY_DECOMPOSE_88) && !MLD_CONFIG_NO_SIGN_API */
@@ -412,22 +482,40 @@ static int test_native_decompose(void)
 #if defined(MLD_USE_NATIVE_POLY_CADDQ)
 static int test_caddq_core(const int32_t *input, const char *test_name)
 {
-  mld_poly test_poly, ref_poly;
+  int ret = 1;
+  MLD_ALLOC(test_poly, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_poly, mld_poly, 1, NULL);
 
-  memcpy(test_poly.coeffs, input, MLDSA_N * sizeof(int32_t));
-  memcpy(ref_poly.coeffs, input, MLDSA_N * sizeof(int32_t));
+  if (test_poly == NULL || ref_poly == NULL)
+  {
+    goto cleanup;
+  }
 
-  mld_poly_caddq(&test_poly);
-  mld_poly_caddq_c(&ref_poly);
+  memcpy(test_poly->coeffs, input, MLDSA_N * sizeof(int32_t));
+  memcpy(ref_poly->coeffs, input, MLDSA_N * sizeof(int32_t));
 
-  CHECK(compare_i32_arrays(test_poly.coeffs, ref_poly.coeffs, MLDSA_N,
+  mld_poly_caddq(test_poly);
+  mld_poly_caddq_c(ref_poly);
+
+  CHECK(compare_i32_arrays(test_poly->coeffs, ref_poly->coeffs, MLDSA_N,
                            test_name, input));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_poly, mld_poly, 1, NULL);
+  MLD_FREE(test_poly, mld_poly, 1, NULL);
+  return ret;
 }
 static int test_native_caddq(void)
 {
-  int32_t test_data[MLDSA_N];
+  int ret = 1;
   int pos, i;
+  MLD_ALLOC(test_data, int32_t, MLDSA_N, NULL);
+
+  if (test_data == NULL)
+  {
+    goto cleanup;
+  }
 
   generate_i32_array_zeros(test_data, MLDSA_N);
   CHECK(test_caddq_core(test_data, "poly_caddq_zeros") == 0);
@@ -444,7 +532,11 @@ static int test_native_caddq(void)
     CHECK(test_caddq_core(test_data, "poly_caddq_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_data, int32_t, MLDSA_N, NULL);
+  return ret;
 }
 #endif /* MLD_USE_NATIVE_POLY_CADDQ */
 
@@ -455,34 +547,58 @@ static int test_poly_use_hint_core(const mld_poly *poly_a,
                                    const mld_poly *poly_h,
                                    const char *test_name)
 {
-  mld_poly test_a, ref_a;
+  int ret = 1;
+  MLD_ALLOC(test_a, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_a, mld_poly, 1, NULL);
 
-  test_a = *poly_a;
-  ref_a = *poly_a;
-  mld_poly_use_hint(&test_a, poly_h);
-  mld_poly_use_hint_c(&ref_a, poly_h);
+  if (test_a == NULL || ref_a == NULL)
+  {
+    goto cleanup;
+  }
 
-  CHECK(compare_i32_arrays(test_a.coeffs, ref_a.coeffs, MLDSA_N, test_name,
+  *test_a = *poly_a;
+  *ref_a = *poly_a;
+  mld_poly_use_hint(test_a, poly_h);
+  mld_poly_use_hint_c(ref_a, poly_h);
+
+  CHECK(compare_i32_arrays(test_a->coeffs, ref_a->coeffs, MLDSA_N, test_name,
                            poly_a->coeffs));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_a, mld_poly, 1, NULL);
+  MLD_FREE(test_a, mld_poly, 1, NULL);
+  return ret;
 }
 static int test_native_use_hint(void)
 {
-  mld_poly poly_a, poly_h;
+  int ret = 1;
   int i;
-  generate_i32_array_zeros(poly_a.coeffs, MLDSA_N);
-  generate_i32_array_zeros(poly_h.coeffs, MLDSA_N);
-  CHECK(test_poly_use_hint_core(&poly_a, &poly_h, "poly_use_hint_zeros") == 0);
+  MLD_ALLOC(poly_a, mld_poly, 1, NULL);
+  MLD_ALLOC(poly_h, mld_poly, 1, NULL);
+
+  if (poly_a == NULL || poly_h == NULL)
+  {
+    goto cleanup;
+  }
+
+  generate_i32_array_zeros(poly_a->coeffs, MLDSA_N);
+  generate_i32_array_zeros(poly_h->coeffs, MLDSA_N);
+  CHECK(test_poly_use_hint_core(poly_a, poly_h, "poly_use_hint_zeros") == 0);
 
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    generate_i32_array_ranged(poly_a.coeffs, MLDSA_N, 0, MLDSA_Q);
-    generate_i32_array_ranged(poly_h.coeffs, MLDSA_N, 0, 2);
-    CHECK(test_poly_use_hint_core(&poly_a, &poly_h, "poly_use_hint_random") ==
-          0);
+    generate_i32_array_ranged(poly_a->coeffs, MLDSA_N, 0, MLDSA_Q);
+    generate_i32_array_ranged(poly_h->coeffs, MLDSA_N, 0, 2);
+    CHECK(test_poly_use_hint_core(poly_a, poly_h, "poly_use_hint_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(poly_h, mld_poly, 1, NULL);
+  MLD_FREE(poly_a, mld_poly, 1, NULL);
+  return ret;
 }
 #endif /* (MLD_USE_NATIVE_POLY_USE_HINT_88 || MLD_USE_NATIVE_POLY_USE_HINT_32) \
           && !MLD_CONFIG_NO_VERIFY_API */
@@ -508,24 +624,34 @@ static int test_poly_chknorm_core(const mld_poly *input_poly, int32_t B,
 
 static int test_native_poly_chknorm(void)
 {
-  mld_poly test_poly;
+  int ret = 1;
   int i;
+  MLD_ALLOC(test_poly, mld_poly, 1, NULL);
+
+  if (test_poly == NULL)
+  {
+    goto cleanup;
+  }
 
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    generate_i32_array_ranged(test_poly.coeffs, MLDSA_N,
+    generate_i32_array_ranged(test_poly->coeffs, MLDSA_N,
                               -MLD_REDUCE32_RANGE_MAX, MLD_REDUCE32_RANGE_MAX);
-    CHECK(test_poly_chknorm_core(&test_poly, MLDSA_Q - MLD_REDUCE32_RANGE_MAX,
+    CHECK(test_poly_chknorm_core(test_poly, MLDSA_Q - MLD_REDUCE32_RANGE_MAX,
                                  "poly_chknorm_MAX_B") == 0);
-    CHECK(test_poly_chknorm_core(&test_poly, MLDSA_GAMMA1 - MLDSA_BETA,
+    CHECK(test_poly_chknorm_core(test_poly, MLDSA_GAMMA1 - MLDSA_BETA,
                                  "poly_chknorm_gamma1_minus_beta") == 0);
-    CHECK(test_poly_chknorm_core(&test_poly, MLDSA_GAMMA2 - MLDSA_BETA,
+    CHECK(test_poly_chknorm_core(test_poly, MLDSA_GAMMA2 - MLDSA_BETA,
                                  "poly_chknorm_gamma2_minus_beta") == 0);
-    CHECK(test_poly_chknorm_core(&test_poly, MLDSA_GAMMA2,
+    CHECK(test_poly_chknorm_core(test_poly, MLDSA_GAMMA2,
                                  "poly_chknorm_gamma2") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_poly, mld_poly, 1, NULL);
+  return ret;
 }
 #endif /* MLD_USE_NATIVE_POLY_CHKNORM */
 
@@ -535,47 +661,71 @@ static int test_poly_pointwise_montgomery_core(const mld_poly *poly_a,
                                                const mld_poly *poly_b,
                                                const char *test_name)
 {
-  mld_poly test_poly_c, ref_poly_c;
+  int ret = 1;
+  MLD_ALLOC(test_poly_c, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_poly_c, mld_poly, 1, NULL);
 
-  test_poly_c = *poly_a;
-  ref_poly_c = *poly_a;
-  mld_poly_pointwise_montgomery(&test_poly_c, poly_b);
-  mld_poly_pointwise_montgomery_c(&ref_poly_c, poly_b);
+  if (test_poly_c == NULL || ref_poly_c == NULL)
+  {
+    goto cleanup;
+  }
 
-  CHECK(compare_i32_arrays(test_poly_c.coeffs, ref_poly_c.coeffs, MLDSA_N,
+  *test_poly_c = *poly_a;
+  *ref_poly_c = *poly_a;
+  mld_poly_pointwise_montgomery(test_poly_c, poly_b);
+  mld_poly_pointwise_montgomery_c(ref_poly_c, poly_b);
+
+  CHECK(compare_i32_arrays(test_poly_c->coeffs, ref_poly_c->coeffs, MLDSA_N,
                            test_name, poly_a->coeffs));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_poly_c, mld_poly, 1, NULL);
+  MLD_FREE(test_poly_c, mld_poly, 1, NULL);
+  return ret;
 }
 
 static int test_native_pointwise_montgomery(void)
 {
-  mld_poly test_poly_a, test_poly_b;
+  int ret = 1;
   int pos, i;
+  MLD_ALLOC(test_poly_a, mld_poly, 1, NULL);
+  MLD_ALLOC(test_poly_b, mld_poly, 1, NULL);
 
-  generate_i32_array_zeros(test_poly_a.coeffs, MLDSA_N);
-  generate_i32_array_zeros(test_poly_b.coeffs, MLDSA_N);
-  CHECK(test_poly_pointwise_montgomery_core(&test_poly_a, &test_poly_b,
+  if (test_poly_a == NULL || test_poly_b == NULL)
+  {
+    goto cleanup;
+  }
+
+  generate_i32_array_zeros(test_poly_a->coeffs, MLDSA_N);
+  generate_i32_array_zeros(test_poly_b->coeffs, MLDSA_N);
+  CHECK(test_poly_pointwise_montgomery_core(test_poly_a, test_poly_b,
                                             "pointwise_montgomery_zeros") == 0);
 
   for (pos = 0; pos < MLDSA_N; pos += MLDSA_N / 8)
   {
-    generate_i32_array_single(test_poly_a.coeffs, MLDSA_N, (size_t)pos, 1);
-    generate_i32_array_single(test_poly_b.coeffs, MLDSA_N, (size_t)pos, 1);
+    generate_i32_array_single(test_poly_a->coeffs, MLDSA_N, (size_t)pos, 1);
+    generate_i32_array_single(test_poly_b->coeffs, MLDSA_N, (size_t)pos, 1);
     CHECK(test_poly_pointwise_montgomery_core(
-              &test_poly_a, &test_poly_b, "pointwise_montgomery_single") == 0);
+              test_poly_a, test_poly_b, "pointwise_montgomery_single") == 0);
   }
 
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    generate_i32_array_ranged(test_poly_a.coeffs, MLDSA_N, -(MLD_NTT_BOUND - 1),
-                              MLD_NTT_BOUND);
-    generate_i32_array_ranged(test_poly_b.coeffs, MLDSA_N, -(MLD_NTT_BOUND - 1),
-                              MLD_NTT_BOUND);
+    generate_i32_array_ranged(test_poly_a->coeffs, MLDSA_N,
+                              -(MLD_NTT_BOUND - 1), MLD_NTT_BOUND);
+    generate_i32_array_ranged(test_poly_b->coeffs, MLDSA_N,
+                              -(MLD_NTT_BOUND - 1), MLD_NTT_BOUND);
     CHECK(test_poly_pointwise_montgomery_core(
-              &test_poly_a, &test_poly_b, "pointwise_montgomery_random") == 0);
+              test_poly_a, test_poly_b, "pointwise_montgomery_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_poly_b, mld_poly, 1, NULL);
+  MLD_FREE(test_poly_a, mld_poly, 1, NULL);
+  return ret;
 }
 #endif /* MLD_USE_NATIVE_POINTWISE_MONTGOMERY && (!MLD_CONFIG_NO_SIGN_API || \
           !MLD_CONFIG_NO_VERIFY_API) */
@@ -587,38 +737,62 @@ static int test_polyvecl_pointwise_acc_montgomery_core(const mld_polyvecl *u,
                                                        const mld_polyvecl *v,
                                                        const char *test_name)
 {
-  mld_poly test_w, ref_w;
+  int ret = 1;
+  MLD_ALLOC(test_w, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_w, mld_poly, 1, NULL);
 
-  mld_polyvecl_pointwise_acc_montgomery(&test_w, u, v);
-  mld_polyvecl_pointwise_acc_montgomery_c(&ref_w, u, v);
+  if (test_w == NULL || ref_w == NULL)
+  {
+    goto cleanup;
+  }
 
-  CHECK(compare_i32_arrays(test_w.coeffs, ref_w.coeffs, MLDSA_N, test_name,
+  mld_polyvecl_pointwise_acc_montgomery(test_w, u, v);
+  mld_polyvecl_pointwise_acc_montgomery_c(ref_w, u, v);
+
+  CHECK(compare_i32_arrays(test_w->coeffs, ref_w->coeffs, MLDSA_N, test_name,
                            NULL));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_w, mld_poly, 1, NULL);
+  MLD_FREE(test_w, mld_poly, 1, NULL);
+  return ret;
 }
 
 static int test_native_polyvecl_pointwise_acc_montgomery(void)
 {
-  mld_polyvecl u, v;
+  int ret = 1;
   unsigned int i;
+  MLD_ALLOC(u, mld_polyvecl, 1, NULL);
+  MLD_ALLOC(v, mld_polyvecl, 1, NULL);
+
+  if (u == NULL || v == NULL)
+  {
+    goto cleanup;
+  }
 
   /* Test with zeros */
-  generate_i32_array_zeros((int32_t *)&u, MLDSA_L * MLDSA_N);
-  generate_i32_array_zeros((int32_t *)&v, MLDSA_L * MLDSA_N);
-  CHECK(test_polyvecl_pointwise_acc_montgomery_core(&u, &v,
+  generate_i32_array_zeros((int32_t *)u, MLDSA_L * MLDSA_N);
+  generate_i32_array_zeros((int32_t *)v, MLDSA_L * MLDSA_N);
+  CHECK(test_polyvecl_pointwise_acc_montgomery_core(u, v,
                                                     "polyvecl_acc_zeros") == 0);
 
   /* Test with random values */
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    generate_i32_array_ranged((int32_t *)&u, MLDSA_L * MLDSA_N, 0, MLDSA_Q);
-    generate_i32_array_ranged((int32_t *)&v, MLDSA_L * MLDSA_N,
+    generate_i32_array_ranged((int32_t *)u, MLDSA_L * MLDSA_N, 0, MLDSA_Q);
+    generate_i32_array_ranged((int32_t *)v, MLDSA_L * MLDSA_N,
                               -MLD_NTT_BOUND + 1, MLD_NTT_BOUND);
     CHECK(test_polyvecl_pointwise_acc_montgomery_core(
-              &u, &v, "polyvecl_acc_random") == 0);
+              u, v, "polyvecl_acc_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(v, mld_polyvecl, 1, NULL);
+  MLD_FREE(u, mld_polyvecl, 1, NULL);
+  return ret;
 }
 #endif /* MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L4 || \
           MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L5 || \
@@ -631,20 +805,38 @@ static int test_native_polyvecl_pointwise_acc_montgomery(void)
 static int test_mld_polyz_unpack_core(const uint8_t *input,
                                       const char *test_name)
 {
-  mld_poly test_poly, ref_poly;
+  int ret = 1;
+  MLD_ALLOC(test_poly, mld_poly, 1, NULL);
+  MLD_ALLOC(ref_poly, mld_poly, 1, NULL);
 
-  mld_polyz_unpack(&test_poly, input);
-  mld_polyz_unpack_c(&ref_poly, input);
+  if (test_poly == NULL || ref_poly == NULL)
+  {
+    goto cleanup;
+  }
 
-  CHECK(compare_i32_arrays(test_poly.coeffs, ref_poly.coeffs, MLDSA_N,
+  mld_polyz_unpack(test_poly, input);
+  mld_polyz_unpack_c(ref_poly, input);
+
+  CHECK(compare_i32_arrays(test_poly->coeffs, ref_poly->coeffs, MLDSA_N,
                            test_name, NULL));
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(ref_poly, mld_poly, 1, NULL);
+  MLD_FREE(test_poly, mld_poly, 1, NULL);
+  return ret;
 }
 
 static int test_native_polyz_unpack(void)
 {
-  uint8_t test_bytes[MLDSA_POLYZ_PACKEDBYTES];
+  int ret = 1;
   int i;
+  MLD_ALLOC(test_bytes, uint8_t, MLDSA_POLYZ_PACKEDBYTES, NULL);
+
+  if (test_bytes == NULL)
+  {
+    goto cleanup;
+  }
 
   memset(test_bytes, 0, MLDSA_POLYZ_PACKEDBYTES);
   CHECK(test_mld_polyz_unpack_core(test_bytes, "polyz_unpack_zeros") == 0);
@@ -656,7 +848,11 @@ static int test_native_polyz_unpack(void)
     CHECK(test_mld_polyz_unpack_core(test_bytes, "polyz_unpack_random") == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(test_bytes, uint8_t, MLDSA_POLYZ_PACKEDBYTES, NULL);
+  return ret;
 }
 #endif /* (MLD_USE_NATIVE_POLYZ_UNPACK_17 || MLD_USE_NATIVE_POLYZ_UNPACK_19) \
           && (!MLD_CONFIG_NO_SIGN_API || !MLD_CONFIG_NO_VERIFY_API) */
@@ -665,14 +861,20 @@ static int test_native_polyz_unpack(void)
 #ifdef MLD_USE_FIPS202_X1_NATIVE
 static int test_keccakf1600_permute(void)
 {
-  uint64_t state[MLD_KECCAK_LANES];
-  uint64_t state_ref[MLD_KECCAK_LANES];
+  int ret = 1;
   int i;
+  MLD_ALLOC(state, uint64_t, MLD_KECCAK_LANES, NULL);
+  MLD_ALLOC(state_ref, uint64_t, MLD_KECCAK_LANES, NULL);
+
+  if (state == NULL || state_ref == NULL)
+  {
+    goto cleanup;
+  }
 
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    randombytes((uint8_t *)state, sizeof(state));
-    memcpy(state_ref, state, sizeof(state));
+    randombytes((uint8_t *)state, MLD_KECCAK_LANES * sizeof(uint64_t));
+    memcpy(state_ref, state, MLD_KECCAK_LANES * sizeof(uint64_t));
 
     mld_keccakf1600_permute(state);
     mld_keccakf1600_permute_c(state_ref);
@@ -681,21 +883,34 @@ static int test_keccakf1600_permute(void)
                              "keccakf1600_permute"));
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(state_ref, uint64_t, MLD_KECCAK_LANES, NULL);
+  MLD_FREE(state, uint64_t, MLD_KECCAK_LANES, NULL);
+  return ret;
 }
 #endif /* MLD_USE_FIPS202_X1_NATIVE */
 
 #ifdef MLD_USE_FIPS202_X4_NATIVE
 static int test_keccakf1600x4_permute(void)
 {
-  uint64_t state_x4[MLD_KECCAK_LANES * MLD_KECCAK_WAY];
-  uint64_t state_x1[MLD_KECCAK_LANES * MLD_KECCAK_WAY];
+  int ret = 1;
   int i, j;
+  MLD_ALLOC(state_x4, uint64_t, MLD_KECCAK_LANES *MLD_KECCAK_WAY, NULL);
+  MLD_ALLOC(state_x1, uint64_t, MLD_KECCAK_LANES *MLD_KECCAK_WAY, NULL);
+
+  if (state_x4 == NULL || state_x1 == NULL)
+  {
+    goto cleanup;
+  }
 
   for (i = 0; i < NUM_RANDOM_TESTS; i++)
   {
-    randombytes((uint8_t *)state_x4, sizeof(state_x4));
-    memcpy(state_x1, state_x4, sizeof(state_x4));
+    randombytes((uint8_t *)state_x4,
+                MLD_KECCAK_LANES * MLD_KECCAK_WAY * sizeof(uint64_t));
+    memcpy(state_x1, state_x4,
+           MLD_KECCAK_LANES * MLD_KECCAK_WAY * sizeof(uint64_t));
 
     mld_keccakf1600x4_permute(state_x4);
 
@@ -709,7 +924,12 @@ static int test_keccakf1600x4_permute(void)
                              "keccakf1600x4_permute"));
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(state_x1, uint64_t, MLD_KECCAK_LANES *MLD_KECCAK_WAY, NULL);
+  MLD_FREE(state_x4, uint64_t, MLD_KECCAK_LANES *MLD_KECCAK_WAY, NULL);
+  return ret;
 }
 #endif /* MLD_USE_FIPS202_X4_NATIVE */
 
@@ -789,66 +1009,87 @@ static int test_backend_units(void)
 /* Test that eager and lazy polyvec init+get produce the same results */
 static int test_polyvec_lazy_eager(void)
 {
+  int ret = 1;
   unsigned int i, t;
-  uint8_t packed_s1[MLDSA_L * MLDSA_POLYETA_PACKEDBYTES];
-  uint8_t packed_s2[MLDSA_K * MLDSA_POLYETA_PACKEDBYTES];
-  uint8_t packed_t0[MLDSA_K * MLDSA_POLYT0_PACKEDBYTES];
-  uint8_t rho[MLDSA_SEEDBYTES];
-  uint8_t rhoprime[MLDSA_CRHBYTES];
-  mld_sk_s1hat_eager s1_eager;
-  mld_sk_s1hat_lazy s1_lazy;
-  mld_sk_s2hat_eager s2_eager;
-  mld_sk_s2hat_lazy s2_lazy;
-  mld_sk_t0hat_eager t0_eager;
-  mld_sk_t0hat_lazy t0_lazy;
-  mld_yvec_eager y_eager;
-  mld_yvec_lazy y_lazy;
-  mld_poly poly_eager, poly_lazy;
-  mld_polymat_eager mat_eager;
-  mld_polymat_lazy mat_lazy;
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
   unsigned int j;
-  mld_polyvecl v;
 #endif
-  mld_polyvecl scratch_eager, scratch_lazy;
-  mld_polyveck w_eager, w_lazy;
+  MLD_ALLOC(packed_s1, uint8_t, MLDSA_L *MLDSA_POLYETA_PACKEDBYTES, NULL);
+  MLD_ALLOC(packed_s2, uint8_t, MLDSA_K *MLDSA_POLYETA_PACKEDBYTES, NULL);
+  MLD_ALLOC(packed_t0, uint8_t, MLDSA_K *MLDSA_POLYT0_PACKEDBYTES, NULL);
+  MLD_ALLOC(rho, uint8_t, MLDSA_SEEDBYTES, NULL);
+  MLD_ALLOC(rhoprime, uint8_t, MLDSA_CRHBYTES, NULL);
+  MLD_ALLOC(s1_eager, mld_sk_s1hat_eager, 1, NULL);
+  MLD_ALLOC(s1_lazy, mld_sk_s1hat_lazy, 1, NULL);
+  MLD_ALLOC(s2_eager, mld_sk_s2hat_eager, 1, NULL);
+  MLD_ALLOC(s2_lazy, mld_sk_s2hat_lazy, 1, NULL);
+  MLD_ALLOC(t0_eager, mld_sk_t0hat_eager, 1, NULL);
+  MLD_ALLOC(t0_lazy, mld_sk_t0hat_lazy, 1, NULL);
+  MLD_ALLOC(y_eager, mld_yvec_eager, 1, NULL);
+  MLD_ALLOC(y_lazy, mld_yvec_lazy, 1, NULL);
+  MLD_ALLOC(poly_eager, mld_poly, 1, NULL);
+  MLD_ALLOC(poly_lazy, mld_poly, 1, NULL);
+  MLD_ALLOC(mat_eager, mld_polymat_eager, 1, NULL);
+  MLD_ALLOC(mat_lazy, mld_polymat_lazy, 1, NULL);
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
+  MLD_ALLOC(v, mld_polyvecl, 1, NULL);
+#endif
+  MLD_ALLOC(scratch_eager, mld_polyvecl, 1, NULL);
+  MLD_ALLOC(scratch_lazy, mld_polyvecl, 1, NULL);
+  MLD_ALLOC(w_eager, mld_polyveck, 1, NULL);
+  MLD_ALLOC(w_lazy, mld_polyveck, 1, NULL);
+
+  if (packed_s1 == NULL || packed_s2 == NULL || packed_t0 == NULL ||
+      rho == NULL || rhoprime == NULL || s1_eager == NULL || s1_lazy == NULL ||
+      s2_eager == NULL || s2_lazy == NULL || t0_eager == NULL ||
+      t0_lazy == NULL || y_eager == NULL || y_lazy == NULL ||
+      poly_eager == NULL || poly_lazy == NULL || mat_eager == NULL ||
+      mat_lazy == NULL ||
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
+      v == NULL ||
+#endif
+      scratch_eager == NULL || scratch_lazy == NULL || w_eager == NULL ||
+      w_lazy == NULL)
+  {
+    goto cleanup;
+  }
 
   for (t = 0; t < NUM_RANDOM_TESTS_SLOW; t++)
   {
     /* Test s1vec: eager vs lazy */
-    randombytes(packed_s1, sizeof(packed_s1));
-    mld_unpack_sk_s1hat_eager(&s1_eager, packed_s1);
-    mld_unpack_sk_s1hat_lazy(&s1_lazy, packed_s1);
+    randombytes(packed_s1, MLDSA_L * MLDSA_POLYETA_PACKEDBYTES);
+    mld_unpack_sk_s1hat_eager(s1_eager, packed_s1);
+    mld_unpack_sk_s1hat_lazy(s1_lazy, packed_s1);
 
     for (i = 0; i < MLDSA_L; i++)
     {
-      mld_sk_s1hat_get_poly_eager(&poly_eager, &s1_eager, i);
-      mld_sk_s1hat_get_poly_lazy(&poly_lazy, &s1_lazy, i);
-      CHECK(memcmp(&poly_eager, &poly_lazy, sizeof(mld_poly)) == 0);
+      mld_sk_s1hat_get_poly_eager(poly_eager, s1_eager, i);
+      mld_sk_s1hat_get_poly_lazy(poly_lazy, s1_lazy, i);
+      CHECK(memcmp(poly_eager, poly_lazy, sizeof(mld_poly)) == 0);
     }
 
     /* Test s2vec: eager vs lazy */
-    randombytes(packed_s2, sizeof(packed_s2));
-    mld_unpack_sk_s2hat_eager(&s2_eager, packed_s2);
-    mld_unpack_sk_s2hat_lazy(&s2_lazy, packed_s2);
+    randombytes(packed_s2, MLDSA_K * MLDSA_POLYETA_PACKEDBYTES);
+    mld_unpack_sk_s2hat_eager(s2_eager, packed_s2);
+    mld_unpack_sk_s2hat_lazy(s2_lazy, packed_s2);
 
     for (i = 0; i < MLDSA_K; i++)
     {
-      mld_sk_s2hat_get_poly_eager(&poly_eager, &s2_eager, i);
-      mld_sk_s2hat_get_poly_lazy(&poly_lazy, &s2_lazy, i);
-      CHECK(memcmp(&poly_eager, &poly_lazy, sizeof(mld_poly)) == 0);
+      mld_sk_s2hat_get_poly_eager(poly_eager, s2_eager, i);
+      mld_sk_s2hat_get_poly_lazy(poly_lazy, s2_lazy, i);
+      CHECK(memcmp(poly_eager, poly_lazy, sizeof(mld_poly)) == 0);
     }
 
     /* Test t0vec: eager vs lazy */
-    randombytes(packed_t0, sizeof(packed_t0));
-    mld_unpack_sk_t0hat_eager(&t0_eager, packed_t0);
-    mld_unpack_sk_t0hat_lazy(&t0_lazy, packed_t0);
+    randombytes(packed_t0, MLDSA_K * MLDSA_POLYT0_PACKEDBYTES);
+    mld_unpack_sk_t0hat_eager(t0_eager, packed_t0);
+    mld_unpack_sk_t0hat_lazy(t0_lazy, packed_t0);
 
     for (i = 0; i < MLDSA_K; i++)
     {
-      mld_sk_t0hat_get_poly_eager(&poly_eager, &t0_eager, i);
-      mld_sk_t0hat_get_poly_lazy(&poly_lazy, &t0_lazy, i);
-      CHECK(memcmp(&poly_eager, &poly_lazy, sizeof(mld_poly)) == 0);
+      mld_sk_t0hat_get_poly_eager(poly_eager, t0_eager, i);
+      mld_sk_t0hat_get_poly_lazy(poly_lazy, t0_lazy, i);
+      CHECK(memcmp(poly_eager, poly_lazy, sizeof(mld_poly)) == 0);
     }
   }
 
@@ -858,29 +1099,29 @@ static int test_polyvec_lazy_eager(void)
    * strategies for A. */
   for (t = 0; t < NUM_RANDOM_TESTS_SLOW; t++)
   {
-    randombytes(rho, sizeof(rho));
-    mld_polyvec_matrix_expand_eager(&mat_eager, rho);
-    mld_polyvec_matrix_expand_lazy(&mat_lazy, rho);
+    randombytes(rho, MLDSA_SEEDBYTES);
+    mld_polyvec_matrix_expand_eager(mat_eager, rho);
+    mld_polyvec_matrix_expand_lazy(mat_lazy, rho);
 
-    randombytes((uint8_t *)&v, sizeof(v));
+    randombytes((uint8_t *)v, sizeof(mld_polyvecl));
     for (i = 0; i < MLDSA_L; i++)
     {
       for (j = 0; j < MLDSA_N; j++)
       {
-        v.vec[i].coeffs[j] %= MLD_NTT_BOUND;
+        v->vec[i].coeffs[j] %= MLD_NTT_BOUND;
       }
     }
 
     for (i = 0; i < MLDSA_K; i++)
     {
-      mld_polyvec_matrix_pointwise_montgomery_row_eager(&poly_eager, &mat_eager,
-                                                        &v, i);
-      mld_polyvec_matrix_pointwise_montgomery_row_lazy(&poly_lazy, &mat_lazy,
-                                                       &v, i);
+      mld_polyvec_matrix_pointwise_montgomery_row_eager(poly_eager, mat_eager,
+                                                        v, i);
+      mld_polyvec_matrix_pointwise_montgomery_row_lazy(poly_lazy, mat_lazy, v,
+                                                       i);
       /* Compare mod q */
-      mld_poly_caddq(&poly_eager);
-      mld_poly_caddq(&poly_lazy);
-      CHECK(memcmp(&poly_eager, &poly_lazy, sizeof(mld_poly)) == 0);
+      mld_poly_caddq(poly_eager);
+      mld_poly_caddq(poly_lazy);
+      CHECK(memcmp(poly_eager, poly_lazy, sizeof(mld_poly)) == 0);
     }
   }
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API || !MLD_CONFIG_NO_VERIFY_API */
@@ -890,36 +1131,63 @@ static int test_polyvec_lazy_eager(void)
    * multiplication via the yvec helper produces the same w. */
   for (t = 0; t < NUM_RANDOM_TESTS_SLOW; t++)
   {
-    randombytes(rhoprime, sizeof(rhoprime));
+    randombytes(rhoprime, MLDSA_CRHBYTES);
 
-    mld_yvec_init_eager(&y_eager, rhoprime, 0);
-    mld_yvec_init_lazy(&y_lazy, rhoprime, 0);
+    mld_yvec_init_eager(y_eager, rhoprime, 0);
+    mld_yvec_init_lazy(y_lazy, rhoprime, 0);
 
     for (i = 0; i < MLDSA_L; i++)
     {
-      mld_yvec_get_poly_eager(&poly_eager, &y_eager, i);
-      mld_yvec_get_poly_lazy(&poly_lazy, &y_lazy, i);
-      CHECK(memcmp(&poly_eager, &poly_lazy, sizeof(mld_poly)) == 0);
+      mld_yvec_get_poly_eager(poly_eager, y_eager, i);
+      mld_yvec_get_poly_lazy(poly_lazy, y_lazy, i);
+      CHECK(memcmp(poly_eager, poly_lazy, sizeof(mld_poly)) == 0);
     }
 
-    randombytes(rho, sizeof(rho));
-    mld_polyvec_matrix_expand_eager(&mat_eager, rho);
-    mld_polyvec_matrix_expand_lazy(&mat_lazy, rho);
+    randombytes(rho, MLDSA_SEEDBYTES);
+    mld_polyvec_matrix_expand_eager(mat_eager, rho);
+    mld_polyvec_matrix_expand_lazy(mat_lazy, rho);
 
-    mld_polyvec_matrix_pointwise_montgomery_yvec_eager(
-        &w_eager, &mat_eager, &y_eager, &scratch_eager);
-    mld_polyvec_matrix_pointwise_montgomery_yvec_lazy(&w_lazy, &mat_lazy,
-                                                      &y_lazy, &scratch_lazy);
+    mld_polyvec_matrix_pointwise_montgomery_yvec_eager(w_eager, mat_eager,
+                                                       y_eager, scratch_eager);
+    mld_polyvec_matrix_pointwise_montgomery_yvec_lazy(w_lazy, mat_lazy, y_lazy,
+                                                      scratch_lazy);
 
     /* Compare mod q */
-    mld_polyveck_reduce(&w_eager);
-    mld_polyveck_reduce(&w_lazy);
-    mld_polyveck_caddq(&w_eager);
-    mld_polyveck_caddq(&w_lazy);
-    CHECK(memcmp(&w_eager, &w_lazy, sizeof(mld_polyveck)) == 0);
+    mld_polyveck_reduce(w_eager);
+    mld_polyveck_reduce(w_lazy);
+    mld_polyveck_caddq(w_eager);
+    mld_polyveck_caddq(w_lazy);
+    CHECK(memcmp(w_eager, w_lazy, sizeof(mld_polyveck)) == 0);
   }
 
-  return 0;
+  ret = 0;
+
+cleanup:
+  MLD_FREE(w_lazy, mld_polyveck, 1, NULL);
+  MLD_FREE(w_eager, mld_polyveck, 1, NULL);
+  MLD_FREE(scratch_lazy, mld_polyvecl, 1, NULL);
+  MLD_FREE(scratch_eager, mld_polyvecl, 1, NULL);
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
+  MLD_FREE(v, mld_polyvecl, 1, NULL);
+#endif
+  MLD_FREE(mat_lazy, mld_polymat_lazy, 1, NULL);
+  MLD_FREE(mat_eager, mld_polymat_eager, 1, NULL);
+  MLD_FREE(poly_lazy, mld_poly, 1, NULL);
+  MLD_FREE(poly_eager, mld_poly, 1, NULL);
+  MLD_FREE(y_lazy, mld_yvec_lazy, 1, NULL);
+  MLD_FREE(y_eager, mld_yvec_eager, 1, NULL);
+  MLD_FREE(t0_lazy, mld_sk_t0hat_lazy, 1, NULL);
+  MLD_FREE(t0_eager, mld_sk_t0hat_eager, 1, NULL);
+  MLD_FREE(s2_lazy, mld_sk_s2hat_lazy, 1, NULL);
+  MLD_FREE(s2_eager, mld_sk_s2hat_eager, 1, NULL);
+  MLD_FREE(s1_lazy, mld_sk_s1hat_lazy, 1, NULL);
+  MLD_FREE(s1_eager, mld_sk_s1hat_eager, 1, NULL);
+  MLD_FREE(rhoprime, uint8_t, MLDSA_CRHBYTES, NULL);
+  MLD_FREE(rho, uint8_t, MLDSA_SEEDBYTES, NULL);
+  MLD_FREE(packed_t0, uint8_t, MLDSA_K *MLDSA_POLYT0_PACKEDBYTES, NULL);
+  MLD_FREE(packed_s2, uint8_t, MLDSA_K *MLDSA_POLYETA_PACKEDBYTES, NULL);
+  MLD_FREE(packed_s1, uint8_t, MLDSA_L *MLDSA_POLYETA_PACKEDBYTES, NULL);
+  return ret;
 }
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 

--- a/test/src/test_unit.c
+++ b/test/src/test_unit.c
@@ -55,6 +55,13 @@ void mld_polyvecl_pointwise_acc_montgomery_c(mld_poly *w, const mld_polyvecl *u,
 #if !defined(MLD_CONFIG_NO_SIGN_API) || !defined(MLD_CONFIG_NO_VERIFY_API)
 void mld_polyz_unpack_c(mld_poly *r, const uint8_t a[MLDSA_POLYZ_PACKEDBYTES]);
 #endif
+unsigned int mld_rej_uniform_c(int32_t *a, unsigned int target,
+                               unsigned int offset, const uint8_t *buf,
+                               unsigned int buflen);
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+unsigned int mld_rej_eta_c(int32_t *a, unsigned int target, unsigned int offset,
+                           const uint8_t *buf, unsigned int buflen);
+#endif
 void mld_keccakf1600_permute_c(uint64_t *state);
 
 #if defined(MLD_USE_FIPS202_X1_NATIVE) || defined(MLD_USE_FIPS202_X4_NATIVE)
@@ -121,6 +128,9 @@ static int compare_u64_arrays(const uint64_t *a, const uint64_t *b,
     defined(MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7) || \
     defined(MLD_USE_NATIVE_POLYZ_UNPACK_17) ||                      \
     defined(MLD_USE_NATIVE_POLYZ_UNPACK_19) ||                      \
+    defined(MLD_USE_NATIVE_REJ_UNIFORM) ||                          \
+    defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA2) ||                     \
+    defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA4) ||                     \
     defined(MLD_USE_FIPS202_X1_NATIVE) || defined(MLD_USE_FIPS202_X4_NATIVE)
 
 /* Backend unit test helper functions for arithmetic native backends */
@@ -857,6 +867,154 @@ cleanup:
 #endif /* (MLD_USE_NATIVE_POLYZ_UNPACK_17 || MLD_USE_NATIVE_POLYZ_UNPACK_19) \
           && (!MLD_CONFIG_NO_SIGN_API || !MLD_CONFIG_NO_VERIFY_API) */
 
+#ifdef MLD_USE_NATIVE_REJ_UNIFORM
+#define DEFINE_REJ_UNIFORM_TEST(NBLOCKS)                                 \
+  static int test_native_rej_uniform_nblocks_##NBLOCKS(void)             \
+  {                                                                      \
+    const unsigned buflen = (NBLOCKS) * 168; /* SHAKE128_RATE */         \
+    int ret = 1;                                                         \
+    int i;                                                               \
+    MLD_ALLOC(r_test, int32_t, MLDSA_N, NULL);                           \
+    MLD_ALLOC(r_ref, int32_t, MLDSA_N, NULL);                            \
+    MLD_ALLOC(buf, uint8_t, (NBLOCKS) * 168, NULL);                      \
+                                                                         \
+    if (r_test == NULL || r_ref == NULL || buf == NULL)                  \
+    {                                                                    \
+      goto cleanup;                                                      \
+    }                                                                    \
+                                                                         \
+    for (i = 0; i < NUM_RANDOM_TESTS; i++)                               \
+    {                                                                    \
+      int native_ret;                                                    \
+      unsigned c_ret;                                                    \
+      randombytes(buf, buflen);                                          \
+                                                                         \
+      native_ret = mld_rej_uniform_native(r_test, MLDSA_N, buf, buflen); \
+      if (native_ret == MLD_NATIVE_FUNC_FALLBACK)                        \
+      {                                                                  \
+        ret = 0;                                                         \
+        goto cleanup;                                                    \
+      }                                                                  \
+                                                                         \
+      c_ret = mld_rej_uniform_c(r_ref, MLDSA_N, 0, buf, buflen);         \
+                                                                         \
+      CHECK((unsigned)native_ret == c_ret);                              \
+      CHECK(compare_i32_arrays(r_test, r_ref, (unsigned)native_ret,      \
+                               "rej_uniform", NULL));                    \
+    }                                                                    \
+                                                                         \
+    ret = 0;                                                             \
+                                                                         \
+  cleanup:                                                               \
+    MLD_FREE(buf, uint8_t, (NBLOCKS) * 168, NULL);                       \
+    MLD_FREE(r_ref, int32_t, MLDSA_N, NULL);                             \
+    MLD_FREE(r_test, int32_t, MLDSA_N, NULL);                            \
+    return ret;                                                          \
+  }
+
+DEFINE_REJ_UNIFORM_TEST(1)
+DEFINE_REJ_UNIFORM_TEST(2)
+DEFINE_REJ_UNIFORM_TEST(3)
+DEFINE_REJ_UNIFORM_TEST(4)
+DEFINE_REJ_UNIFORM_TEST(5)
+#endif /* MLD_USE_NATIVE_REJ_UNIFORM */
+
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA2) && MLDSA_ETA == 2
+#define REJ_UNIFORM_ETA2_BUFLEN 136 /* 1 * SHAKE256_RATE */
+static int test_native_rej_uniform_eta2(void)
+{
+  int ret = 1;
+  int i;
+  MLD_ALLOC(r_test, int32_t, MLDSA_N, NULL);
+  MLD_ALLOC(r_ref, int32_t, MLDSA_N, NULL);
+  MLD_ALLOC(buf, uint8_t, REJ_UNIFORM_ETA2_BUFLEN, NULL);
+
+  if (r_test == NULL || r_ref == NULL || buf == NULL)
+  {
+    goto cleanup;
+  }
+
+  for (i = 0; i < NUM_RANDOM_TESTS; i++)
+  {
+    int native_ret;
+    unsigned c_ret;
+    randombytes(buf, REJ_UNIFORM_ETA2_BUFLEN);
+
+    native_ret = mld_rej_uniform_eta2_native(r_test, MLDSA_N, buf,
+                                             REJ_UNIFORM_ETA2_BUFLEN);
+    if (native_ret == MLD_NATIVE_FUNC_FALLBACK)
+    {
+      ret = 0;
+      goto cleanup;
+    }
+
+    c_ret = mld_rej_eta_c(r_ref, MLDSA_N, 0, buf, REJ_UNIFORM_ETA2_BUFLEN);
+
+    CHECK((unsigned)native_ret == c_ret);
+    CHECK(compare_i32_arrays(r_test, r_ref, (unsigned)native_ret,
+                             "rej_uniform_eta2", NULL));
+  }
+
+  ret = 0;
+
+cleanup:
+  MLD_FREE(buf, uint8_t, REJ_UNIFORM_ETA2_BUFLEN, NULL);
+  MLD_FREE(r_ref, int32_t, MLDSA_N, NULL);
+  MLD_FREE(r_test, int32_t, MLDSA_N, NULL);
+  return ret;
+}
+#undef REJ_UNIFORM_ETA2_BUFLEN
+#endif /* MLD_USE_NATIVE_REJ_UNIFORM_ETA2 && MLDSA_ETA == 2 */
+
+#if defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA4) && MLDSA_ETA == 4
+#define REJ_UNIFORM_ETA4_BUFLEN 272 /* 2 * SHAKE256_RATE */
+static int test_native_rej_uniform_eta4(void)
+{
+  int ret = 1;
+  int i;
+  MLD_ALLOC(r_test, int32_t, MLDSA_N, NULL);
+  MLD_ALLOC(r_ref, int32_t, MLDSA_N, NULL);
+  MLD_ALLOC(buf, uint8_t, REJ_UNIFORM_ETA4_BUFLEN, NULL);
+
+  if (r_test == NULL || r_ref == NULL || buf == NULL)
+  {
+    goto cleanup;
+  }
+
+  for (i = 0; i < NUM_RANDOM_TESTS; i++)
+  {
+    int native_ret;
+    unsigned c_ret;
+    randombytes(buf, REJ_UNIFORM_ETA4_BUFLEN);
+
+    native_ret = mld_rej_uniform_eta4_native(r_test, MLDSA_N, buf,
+                                             REJ_UNIFORM_ETA4_BUFLEN);
+    if (native_ret == MLD_NATIVE_FUNC_FALLBACK)
+    {
+      ret = 0;
+      goto cleanup;
+    }
+
+    c_ret = mld_rej_eta_c(r_ref, MLDSA_N, 0, buf, REJ_UNIFORM_ETA4_BUFLEN);
+
+    CHECK((unsigned)native_ret == c_ret);
+    CHECK(compare_i32_arrays(r_test, r_ref, (unsigned)native_ret,
+                             "rej_uniform_eta4", NULL));
+  }
+
+  ret = 0;
+
+cleanup:
+  MLD_FREE(buf, uint8_t, REJ_UNIFORM_ETA4_BUFLEN, NULL);
+  MLD_FREE(r_ref, int32_t, MLDSA_N, NULL);
+  MLD_FREE(r_test, int32_t, MLDSA_N, NULL);
+  return ret;
+}
+#undef REJ_UNIFORM_ETA4_BUFLEN
+#endif /* MLD_USE_NATIVE_REJ_UNIFORM_ETA4 && MLDSA_ETA == 4 */
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API */
+
 
 #ifdef MLD_USE_FIPS202_X1_NATIVE
 static int test_keccakf1600_permute(void)
@@ -984,6 +1142,23 @@ static int test_backend_units(void)
   CHECK(test_native_polyz_unpack() == 0);
 #endif
 
+#ifdef MLD_USE_NATIVE_REJ_UNIFORM
+  CHECK(test_native_rej_uniform_nblocks_1() == 0);
+  CHECK(test_native_rej_uniform_nblocks_2() == 0);
+  CHECK(test_native_rej_uniform_nblocks_3() == 0);
+  CHECK(test_native_rej_uniform_nblocks_4() == 0);
+  CHECK(test_native_rej_uniform_nblocks_5() == 0);
+#endif /* MLD_USE_NATIVE_REJ_UNIFORM */
+
+#if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA2) && MLDSA_ETA == 2
+  CHECK(test_native_rej_uniform_eta2() == 0);
+#endif
+#if defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA4) && MLDSA_ETA == 4
+  CHECK(test_native_rej_uniform_eta4() == 0);
+#endif
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API */
+
 #ifdef MLD_USE_FIPS202_X1_NATIVE
   CHECK(test_keccakf1600_permute() == 0);
 #endif
@@ -1003,7 +1178,9 @@ static int test_backend_units(void)
           MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L5 ||               \
           MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7 ||               \
           MLD_USE_NATIVE_POLYZ_UNPACK_17 || MLD_USE_NATIVE_POLYZ_UNPACK_19 ||  \
-          MLD_USE_FIPS202_X1_NATIVE || MLD_USE_FIPS202_X4_NATIVE */
+          MLD_USE_NATIVE_REJ_UNIFORM || MLD_USE_NATIVE_REJ_UNIFORM_ETA2 ||     \
+          MLD_USE_NATIVE_REJ_UNIFORM_ETA4 || MLD_USE_FIPS202_X1_NATIVE ||      \
+          MLD_USE_FIPS202_X4_NATIVE */
 
 #if !defined(MLD_CONFIG_NO_SIGN_API)
 /* Test that eager and lazy polyvec init+get produce the same results */
@@ -1215,6 +1392,9 @@ int main(void)
     defined(MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7) || \
     defined(MLD_USE_NATIVE_POLYZ_UNPACK_17) ||                      \
     defined(MLD_USE_NATIVE_POLYZ_UNPACK_19) ||                      \
+    defined(MLD_USE_NATIVE_REJ_UNIFORM) ||                          \
+    defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA2) ||                     \
+    defined(MLD_USE_NATIVE_REJ_UNIFORM_ETA4) ||                     \
     defined(MLD_USE_FIPS202_X1_NATIVE) || defined(MLD_USE_FIPS202_X4_NATIVE)
   CHECK(test_backend_units() == 0);
 #endif /* MLD_USE_NATIVE_NTT || MLD_USE_NATIVE_INTT ||                         \
@@ -1226,7 +1406,9 @@ int main(void)
           MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L5 ||               \
           MLD_USE_NATIVE_POLYVECL_POINTWISE_ACC_MONTGOMERY_L7 ||               \
           MLD_USE_NATIVE_POLYZ_UNPACK_17 || MLD_USE_NATIVE_POLYZ_UNPACK_19 ||  \
-          MLD_USE_FIPS202_X1_NATIVE || MLD_USE_FIPS202_X4_NATIVE */
+          MLD_USE_NATIVE_REJ_UNIFORM || MLD_USE_NATIVE_REJ_UNIFORM_ETA2 ||     \
+          MLD_USE_NATIVE_REJ_UNIFORM_ETA4 || MLD_USE_FIPS202_X1_NATIVE ||      \
+          MLD_USE_FIPS202_X4_NATIVE */
 
 
   return 0;


### PR DESCRIPTION
Port of [mlkem-native#1633 ](https://github.com/pq-code-package/mlkem-native/pull/1633) to mldsa-native.

* Replace aligned_alloc + MLD_ALIGN_UP with posix_memalign in custom_heap_alloc_config.h. Unlike aligned_alloc, posix_memalign does not require the size to be a multiple of the alignment, removing the need for MLD_ALIGN_UP rounding. This ensures that allocations are exact-sized, allowing memory-safety tests like valgrind and ASan to detect overflows at precise buffer boundaries. On Windows, _aligned_malloc is used instead. Also adds the missing configs.yml entry so the file is tracked by autogen.

* Replace all stack-allocated buffers in test_unit.c with heap allocations via MLD_ALLOC/MLD_FREE, using the custom_heap_alloc_config. This enables valgrind to detect buffer overflows in assembly backends, which operate on these buffers.

* Build the unit test objects with custom_heap_alloc_config.h by adding the appropriate -DMLD_CONFIG_FILE, -std=c11, and -D_GNU_SOURCE flags in components.mk, factored through a new UNIT_CFLAGS variable.

* Add unit_valgrind job to ci.yml that runs the unit tests under valgrind on x86_64 and aarch64 runners. This catches buffer overflows in hand-written assembly that ASan cannot detect, since ASan only instruments compiler-generated code.