### PR TITLE
Doc: Drop "REDUCE_RAM not covered by CBMC" warning and EXPERIMENTAL tag

### DIFF
--- a/.github/actions/cbmc/report.py
+++ b/.github/actions/cbmc/report.py
@@ -23,7 +23,6 @@ COMMENT_TAG = "cbmc-report"
 OK = "✅"
 WARN = "⚠️"
 FAIL = "❌"
-SKIP = "⏭️"
 
 ProofResult = namedtuple(
     "ProofResult", ["name", "status", "current", "previous", "change"]
@@ -135,23 +134,7 @@ def build_comment(current, baseline, cfg):
         if is_alert:
             alerts.append(result)
 
-    skipped = sorted(current.get("skipped", []))
-    skipped_rows = []
-    for name in skipped:
-        base = baseline_runtimes.get(name, {})
-        if base.get("status") == "failed":
-            prev = "failed"
-        elif base.get("value") is not None:
-            prev = f"{base['value']}s"
-        else:
-            prev = "-"
-        skipped_rows.append(ProofResult(name, SKIP, "skipped", prev, "-"))
-    alerts.extend(skipped_rows)
-    all_rows.extend(skipped_rows)
-
     def sort_key(r):
-        if r.current == "skipped":
-            return 1  # skipped proofs sink below any timed row
         if r.current == "-":
             return -1
         return -int(r.current.rstrip("s"))
@@ -185,17 +168,10 @@ def build_comment(current, baseline, cfg):
         "",
     ]
 
-    if skipped:
-        lines += [
-            f"{SKIP} **{len(skipped)} proof(s) skipped** "
-            f"(see `proofs/cbmc/reduce_ram_skip.txt`)",
-            "",
-        ]
-
     if alerts:
         lines += [f"{WARN} **Attention Required**", ""] + render_table(alerts) + [""]
 
-    total = current.get("summary", {}).get("total", len(all_rows)) + len(skipped)
+    total = current.get("summary", {}).get("total", len(all_rows))
     lines += (
         [
             "<details>",

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ mldsa-native is used in
 
 We use the [C Bounded Model Checker (CBMC)](https://github.com/diffblue/cbmc) to prove absence of various classes of undefined behaviour in C, including out of bounds memory accesses and integer overflows. The proofs cover all C code in [mldsa/src/*](mldsa) and [mldsa/src/fips202/*](mldsa/src/fips202) involved in running mldsa-native with its C backend. See [proofs/cbmc](proofs/cbmc) for details.
 
-**Note:** The `MLD_CONFIG_REDUCE_RAM` configuration option is not currently covered by CBMC proofs.
-
 HOL-Light functional correctness proofs can be found in [proofs/hol_light](proofs/hol_light). See the [HOL-Light README](proofs/hol_light/README.md) for the list of functions that have been proven correct. These proofs utilize the verification infrastructure in [s2n-bignum](https://github.com/awslabs/s2n-bignum).
 
 Finally, [proofs/isabelle](proofs/isabelle/compress) contains proofs in [Isabelle/HOL](https://isabelle.in.tum.de/) of the correctness of

--- a/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
@@ -75,6 +75,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 #define MLD_CONFIG_NO_RANDOMIZED_API
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -522,6 +546,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -543,6 +568,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -553,6 +579,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -563,6 +590,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -584,6 +612,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -596,6 +625,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -616,6 +646,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -634,6 +665,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -656,6 +688,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -677,6 +710,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -687,6 +721,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -696,6 +731,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
@@ -697,7 +697,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -707,9 +707,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/basic_lowram/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_lowram/mldsa_native/mldsa_native_config.h
@@ -696,7 +696,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -706,9 +706,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 #if !defined(MLD_CONFIG_REDUCE_RAM)
 #define MLD_CONFIG_REDUCE_RAM

--- a/examples/basic_lowram/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_lowram/mldsa_native/mldsa_native_config.h
@@ -74,6 +74,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -521,6 +545,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -542,6 +567,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -552,6 +578,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -562,6 +589,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -583,6 +611,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -595,6 +624,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -615,6 +645,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -633,6 +664,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -655,6 +687,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -676,6 +709,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -686,6 +720,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -695,6 +730,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
@@ -75,6 +75,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "../custom_fips202/fips202.h"
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "../custom_fips202/fips202x4.h"
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -522,6 +546,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -543,6 +568,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -553,6 +579,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -563,6 +590,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -584,6 +612,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -596,6 +625,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -616,6 +646,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -634,6 +665,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -656,6 +688,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -677,6 +710,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -687,6 +721,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -696,6 +731,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
@@ -697,7 +697,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -707,9 +707,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
@@ -76,6 +76,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -87,6 +88,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -106,6 +108,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -119,6 +122,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -129,6 +133,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -141,6 +146,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -154,6 +160,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -162,6 +169,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -179,6 +187,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -190,6 +199,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -209,6 +219,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -231,6 +242,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -250,6 +262,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -264,6 +277,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -285,6 +299,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -303,6 +318,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -324,6 +340,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -339,6 +356,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -353,6 +371,7 @@
  * the same API (see FIPS202.md).
  */
 #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "../custom_fips202/fips202.h"
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -367,6 +386,7 @@
  * the same API (see FIPS202.md).
  */
 #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "../custom_fips202/fips202x4.h"
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -404,6 +424,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -429,6 +450,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -459,6 +481,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -502,6 +525,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -523,6 +547,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -544,6 +569,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -554,6 +580,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -564,6 +591,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -585,6 +613,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -597,6 +626,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -617,6 +647,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -635,6 +666,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -657,6 +689,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -678,6 +711,7 @@
  * Only enable this when you have to.
  */
 #define MLD_CONFIG_SERIAL_FIPS202_ONLY
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -688,6 +722,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -697,6 +732,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
@@ -698,7 +698,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -708,9 +708,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/custom_backend/mldsa_native/mldsa_native_config.h
+++ b/examples/custom_backend/mldsa_native/mldsa_native_config.h
@@ -693,7 +693,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -703,9 +703,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/custom_backend/mldsa_native/mldsa_native_config.h
+++ b/examples/custom_backend/mldsa_native/mldsa_native_config.h
@@ -77,6 +77,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -88,6 +89,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX CUSTOM_TINY_SHA3
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -107,6 +109,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -120,6 +123,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -130,6 +134,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -142,6 +147,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -155,6 +161,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -163,6 +170,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -180,6 +188,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -191,6 +200,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -210,6 +220,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -232,6 +243,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -251,6 +263,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -265,6 +278,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -285,6 +299,7 @@
  */
 /* No native arithmetic backend */
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -303,6 +318,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -334,6 +351,7 @@
  * This can be set using CFLAGS.
  */
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/custom/custom.h"
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -348,6 +366,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -362,6 +381,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -399,6 +419,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -424,6 +445,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -454,6 +476,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -497,6 +520,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -518,6 +542,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -539,6 +564,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -549,6 +575,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -559,6 +586,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -580,6 +608,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -592,6 +621,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -612,6 +642,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -630,6 +661,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -652,6 +684,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -673,6 +706,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -683,6 +717,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -692,6 +727,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/monolithic_build/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build/mldsa_native/mldsa_native_config.h
@@ -696,7 +696,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -706,9 +706,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/monolithic_build/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build/mldsa_native/mldsa_native_config.h
@@ -74,6 +74,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -521,6 +545,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -542,6 +567,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -552,6 +578,7 @@
  * in which case this option can be set to `static`.
  */
 #define MLD_CONFIG_INTERNAL_API_QUALIFIER static
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -562,6 +589,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -583,6 +611,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -595,6 +624,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -615,6 +645,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -633,6 +664,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -655,6 +687,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -676,6 +709,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -686,6 +720,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -695,6 +730,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
@@ -76,6 +76,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -87,6 +88,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -106,6 +108,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_MULTILEVEL_BUILD
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -119,6 +122,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -129,6 +133,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -141,6 +146,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -154,6 +160,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -162,6 +169,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -179,6 +187,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -190,6 +199,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 #define MLD_CONFIG_NO_SUPERCOP
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -209,6 +219,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -231,6 +242,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -250,6 +262,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -264,6 +277,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -285,6 +299,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -303,6 +318,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -324,6 +340,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -339,6 +356,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -353,6 +371,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -367,6 +386,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -404,6 +424,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -429,6 +450,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -459,6 +481,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -502,6 +525,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -523,6 +547,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -544,6 +569,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -554,6 +580,7 @@
  * in which case this option can be set to `static`.
  */
 #define MLD_CONFIG_INTERNAL_API_QUALIFIER static
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -564,6 +591,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -585,6 +613,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -597,6 +626,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -617,6 +647,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -635,6 +666,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -657,6 +689,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -678,6 +711,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -688,6 +722,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -697,6 +732,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
@@ -698,7 +698,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -708,9 +708,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
@@ -704,7 +704,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -714,9 +714,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
@@ -80,6 +80,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -91,6 +92,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -110,6 +112,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_MULTILEVEL_BUILD
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -123,6 +126,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 #define MLD_CONFIG_EXTERNAL_API_QUALIFIER static
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -133,6 +137,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -145,6 +150,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -158,6 +164,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -166,6 +173,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -183,6 +191,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -194,6 +203,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 #define MLD_CONFIG_NO_SUPERCOP
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -213,6 +223,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -235,6 +246,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -254,6 +266,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -268,6 +281,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -287,6 +301,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -305,6 +320,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -324,6 +340,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -339,6 +356,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -353,6 +371,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -367,6 +386,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -404,6 +424,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -435,6 +456,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -465,6 +487,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -508,6 +531,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -529,6 +553,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -550,6 +575,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -560,6 +586,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * in which case this option can be set to `static`.
  */
 #define MLD_CONFIG_INTERNAL_API_QUALIFIER static
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -570,6 +597,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -591,6 +619,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -603,6 +632,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -623,6 +653,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -641,6 +672,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -663,6 +695,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -684,6 +717,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -694,6 +728,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -703,6 +738,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
@@ -696,7 +696,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -706,9 +706,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
@@ -74,6 +74,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -521,6 +545,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -542,6 +567,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -552,6 +578,7 @@
  * in which case this option can be set to `static`.
  */
 #define MLD_CONFIG_INTERNAL_API_QUALIFIER static
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -562,6 +589,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -583,6 +611,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -595,6 +624,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -615,6 +645,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -633,6 +664,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -655,6 +687,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -676,6 +709,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -686,6 +720,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -695,6 +730,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/multilevel_build/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build/mldsa_native/mldsa_native_config.h
@@ -697,7 +697,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -707,9 +707,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/multilevel_build/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build/mldsa_native/mldsa_native_config.h
@@ -75,6 +75,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_MULTILEVEL_BUILD
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 #define MLD_CONFIG_NO_SUPERCOP
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -522,6 +546,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -543,6 +568,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -553,6 +579,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -563,6 +590,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -584,6 +612,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -596,6 +625,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -616,6 +646,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -634,6 +665,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -656,6 +688,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -677,6 +710,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -687,6 +721,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -696,6 +731,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
@@ -695,7 +695,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -705,9 +705,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
@@ -77,6 +77,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -88,6 +89,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -107,6 +109,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_MULTILEVEL_BUILD
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -120,6 +123,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -130,6 +134,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -142,6 +147,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -155,6 +161,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -163,6 +170,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -180,6 +188,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -191,6 +200,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 #define MLD_CONFIG_NO_SUPERCOP
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -210,6 +220,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -232,6 +243,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -251,6 +263,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -265,6 +278,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -321,6 +337,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -336,6 +353,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -350,6 +368,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -364,6 +383,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -401,6 +421,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -426,6 +447,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -456,6 +478,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -499,6 +522,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -520,6 +544,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -541,6 +566,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -551,6 +577,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -561,6 +588,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -582,6 +610,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -594,6 +623,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -614,6 +644,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -632,6 +663,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -654,6 +686,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -675,6 +708,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -685,6 +719,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -694,6 +729,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/mldsa/mldsa_native_config.h
+++ b/mldsa/mldsa_native_config.h
@@ -57,6 +57,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -70,6 +71,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -89,6 +91,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -102,6 +105,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -112,6 +116,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -124,6 +129,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -137,6 +143,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -145,6 +152,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -162,6 +170,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -173,6 +182,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -192,6 +202,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -214,6 +225,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -233,6 +245,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -247,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -268,6 +282,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -286,6 +301,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -307,6 +323,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -322,6 +339,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -336,6 +354,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -350,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -387,6 +407,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -412,6 +433,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -442,6 +464,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -485,6 +508,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -506,6 +530,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -527,6 +552,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -537,6 +563,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -547,6 +574,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -568,6 +596,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -580,6 +609,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -600,6 +630,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -618,6 +649,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -640,6 +672,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -661,6 +694,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -671,6 +705,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -680,6 +715,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/mldsa/mldsa_native_config.h
+++ b/mldsa/mldsa_native_config.h
@@ -681,7 +681,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -691,9 +691,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/proofs/cbmc/mldsa_native_config_cbmc.h
+++ b/proofs/cbmc/mldsa_native_config_cbmc.h
@@ -695,7 +695,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -705,9 +705,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/proofs/cbmc/mldsa_native_config_cbmc.h
+++ b/proofs/cbmc/mldsa_native_config_cbmc.h
@@ -73,6 +73,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -84,6 +85,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mld
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -103,6 +105,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -116,6 +119,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -126,6 +130,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -138,6 +143,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -151,6 +157,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -159,6 +166,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -176,6 +184,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -187,6 +196,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -206,6 +216,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -228,6 +239,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -247,6 +259,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -261,6 +274,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -282,6 +296,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -300,6 +315,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -321,6 +337,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -336,6 +353,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -350,6 +368,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -364,6 +383,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -401,6 +421,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -426,6 +447,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -456,6 +478,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -499,6 +522,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -520,6 +544,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -541,6 +566,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -551,6 +577,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -561,6 +588,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -582,6 +610,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -594,6 +623,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -614,6 +644,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -632,6 +663,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -654,6 +686,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -675,6 +708,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -685,6 +719,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -694,6 +729,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/proofs/cbmc/reduce_ram_skip.txt
+++ b/proofs/cbmc/reduce_ram_skip.txt
@@ -1,5 +1,0 @@
-# Copyright (c) The mldsa-native project authors
-# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
-#
-# Proofs to skip when CBMC is run with --reduce-ram. One name per line.
-# TODO(REDUCE_RAM): remove once all proofs cover the REDUCE_RAM configuration.

--- a/scripts/tests
+++ b/scripts/tests
@@ -913,17 +913,6 @@ class Tests:
             proofs = filter(lambda s: s.strip() != "", p.stdout.decode().split("\n"))
             return list(proofs)
 
-        def load_reduce_ram_skiplist():
-            path = "proofs/cbmc/reduce_ram_skip.txt"
-            if not os.path.exists(path):
-                return set()
-            with open(path) as f:
-                return {
-                    line.strip()
-                    for line in f
-                    if line.strip() and not line.lstrip().startswith("#")
-                }
-
         if self.args.list_functions:
             for p in list_proofs():
                 print(p)
@@ -998,21 +987,6 @@ class Tests:
                     proofs += list(filter(lambda x: re.match(pat, x), all_proofs))
                 proofs = sorted(set(proofs))
 
-            # TODO(REDUCE_RAM): remove once all proofs cover the REDUCE_RAM configuration.
-            dropped = []
-            if self.args.reduce_ram:
-                skip = load_reduce_ram_skiplist()
-                dropped = sorted(p for p in proofs if p in skip)
-                proofs = [p for p in proofs if p not in skip]
-                if dropped:
-                    log.info(
-                        f"Skipping {len(dropped)} proof(s) under --reduce-ram: "
-                        f"{', '.join(dropped)}"
-                    )
-                if not proofs:
-                    log.info("No proofs left to run after --reduce-ram skiplist")
-                    return
-
             if self.args.single_step:
                 run_cbmc_single_step(mldsa_parameter_set, proofs)
                 return
@@ -1039,17 +1013,6 @@ class Tests:
                 cwd="proofs/cbmc",
                 env=os.environ.copy() | envvars,
             )
-
-            if dropped and self.args.output_result_json:
-                try:
-                    with open(self.args.output_result_json) as f:
-                        data = json.load(f)
-                    data["skipped"] = dropped
-                    data["summary"]["skipped"] = len(dropped)
-                    with open(self.args.output_result_json, "w") as f:
-                        json.dump(data, f, indent=2)
-                except (OSError, json.JSONDecodeError) as e:
-                    log.error(f"Could not annotate result JSON with skiplist: {e}")
 
             if p.returncode != 0:
                 self.fail(f"CBMC proofs for parameter set={mldsa_parameter_set}")

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -701,7 +701,7 @@ static MLD_INLINE int mld_break_pct(void)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -711,9 +711,6 @@ static MLD_INLINE int mld_break_pct(void)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -522,6 +546,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -543,6 +568,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -553,6 +579,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -563,6 +590,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -584,6 +612,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -596,6 +625,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -616,6 +646,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 #define MLD_CONFIG_KEYGEN_PCT
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -637,6 +668,7 @@ static MLD_INLINE int mld_break_pct(void)
   return val != NULL && strcmp(val, "1") == 0;
 }
 #endif /* !__ASSEMBLER__ */
+
 
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
@@ -660,6 +692,7 @@ static MLD_INLINE int mld_break_pct(void)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -681,6 +714,7 @@ static MLD_INLINE int mld_break_pct(void)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -691,6 +725,7 @@ static MLD_INLINE int mld_break_pct(void)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -700,6 +735,7 @@ static MLD_INLINE int mld_break_pct(void)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -72,6 +72,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -518,6 +541,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
 #endif /* !_WIN32 */
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -539,6 +563,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -560,6 +585,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -570,6 +596,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -580,6 +607,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -601,6 +629,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -613,6 +642,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -633,6 +663,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -651,6 +682,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -673,6 +705,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -694,6 +727,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -704,6 +738,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -713,6 +748,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -714,7 +714,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -724,9 +724,6 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -72,6 +72,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -529,6 +553,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -550,6 +575,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -560,6 +586,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -570,6 +597,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -591,6 +619,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -603,6 +632,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -623,6 +653,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -641,6 +672,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -663,6 +695,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -684,6 +717,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -694,6 +728,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -703,6 +738,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -704,7 +704,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -714,9 +714,6 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -72,6 +72,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -521,6 +545,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -549,6 +574,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -559,6 +585,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -569,6 +596,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -590,6 +618,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -602,6 +631,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -622,6 +652,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -640,6 +671,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -662,6 +694,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -683,6 +716,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -693,6 +727,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -702,6 +737,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -703,7 +703,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -713,9 +713,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -463,6 +485,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
   return 0;
 }
 #endif /* !__ASSEMBLER__ */
+
 
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
@@ -507,6 +530,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -528,6 +552,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -549,6 +574,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -559,6 +585,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -569,6 +596,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -590,6 +618,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -602,6 +631,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -622,6 +652,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -640,6 +671,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -662,6 +694,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -683,6 +716,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -693,6 +727,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -702,6 +737,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -703,7 +703,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -713,9 +713,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -462,6 +484,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
   return 1;
 }
 #endif /* !__ASSEMBLER__ */
+
 
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
@@ -506,6 +529,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -527,6 +551,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -548,6 +573,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -558,6 +584,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -568,6 +595,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -589,6 +617,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -601,6 +630,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -621,6 +651,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -639,6 +670,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -661,6 +693,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -682,6 +715,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -692,6 +726,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -701,6 +736,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -702,7 +702,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -712,9 +712,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -495,6 +517,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -538,6 +561,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -559,6 +583,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -580,6 +605,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -590,6 +616,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -600,6 +627,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -621,6 +649,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -633,6 +662,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -653,6 +683,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -671,6 +702,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -693,6 +725,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -714,6 +747,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -724,6 +758,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -733,6 +768,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -734,7 +734,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -744,9 +744,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -721,7 +721,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -731,9 +731,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -482,6 +504,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -525,6 +548,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -546,6 +570,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -567,6 +592,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -577,6 +603,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -587,6 +614,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -608,6 +636,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -620,6 +649,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -640,6 +670,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -658,6 +689,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -680,6 +712,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -701,6 +734,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -711,6 +745,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -720,6 +755,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -696,7 +696,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -706,9 +706,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -72,6 +72,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -426,6 +447,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
   return randombytes(ptr, len);
 }
 #endif /* !__ASSEMBLER__ */
+
 
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
@@ -457,6 +479,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -521,6 +545,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -542,6 +567,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -552,6 +578,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -562,6 +589,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -583,6 +611,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -595,6 +624,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -615,6 +645,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -633,6 +664,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -655,6 +687,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -676,6 +709,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -686,6 +720,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -695,6 +730,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -530,6 +554,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -558,6 +583,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -568,6 +594,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -578,6 +605,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -599,6 +627,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -611,6 +640,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -631,6 +661,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -649,6 +680,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -671,6 +703,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -692,6 +725,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -702,6 +736,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -711,6 +746,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -712,7 +712,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -722,9 +722,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -697,7 +697,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -707,9 +707,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -72,6 +72,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -522,6 +546,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -543,6 +568,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -553,6 +579,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -563,6 +590,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -584,6 +612,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -596,6 +625,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -616,6 +646,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -634,6 +665,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -656,6 +688,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -677,6 +710,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -687,6 +721,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -696,6 +731,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/low_signing_bound_config.h
+++ b/test/configs/low_signing_bound_config.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -403,6 +423,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -428,6 +449,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -458,6 +480,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -501,6 +524,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -522,6 +546,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -543,6 +568,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -553,6 +579,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -563,6 +590,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -584,6 +612,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -596,6 +625,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -616,6 +646,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -634,6 +665,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -658,6 +690,7 @@
 #define MLD_ALLOW_NONCOMPLIANT_SIGNING_BOUND
 #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 1
 
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -679,6 +712,7 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -689,6 +723,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -698,6 +733,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/low_signing_bound_config.h
+++ b/test/configs/low_signing_bound_config.h
@@ -699,7 +699,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -709,9 +709,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -73,6 +73,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -86,6 +87,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -105,6 +107,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -118,6 +121,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -128,6 +132,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -140,6 +145,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -153,6 +159,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -161,6 +168,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -178,6 +186,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -189,6 +198,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -208,6 +218,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -230,6 +241,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -249,6 +261,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -263,6 +276,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -284,6 +298,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -302,6 +317,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -323,6 +339,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -338,6 +355,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -352,6 +370,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -366,6 +385,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -404,6 +424,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
 }
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -429,6 +450,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -459,6 +481,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -502,6 +525,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -523,6 +547,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -544,6 +569,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -554,6 +580,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -564,6 +591,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -585,6 +613,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * native backends will be used.
  */
 #define MLD_CONFIG_NO_ASM
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -597,6 +626,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -617,6 +647,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -635,6 +666,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -657,6 +689,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -678,6 +711,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -688,6 +722,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -697,6 +732,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -698,7 +698,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -708,9 +708,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -72,6 +72,7 @@
  * on the command line.
  */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -85,6 +86,7 @@
 #if !defined(MLD_CONFIG_NAMESPACE_PREFIX)
 #define MLD_CONFIG_NAMESPACE_PREFIX MLD_DEFAULT_NAMESPACE_PREFIX
 #endif
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -104,6 +106,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -117,6 +120,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -127,6 +131,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -139,6 +144,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -152,6 +158,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -160,6 +167,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -177,6 +185,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -188,6 +197,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -207,6 +217,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -229,6 +240,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -248,6 +260,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -262,6 +275,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -283,6 +297,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -301,6 +316,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -322,6 +338,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -337,6 +354,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -351,6 +369,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -365,6 +384,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -402,6 +422,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -427,6 +448,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -457,6 +479,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -500,6 +523,7 @@
    #define MLD_CUSTOM_FREE(v, T, N) free(v)
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -521,6 +545,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -542,6 +567,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -552,6 +578,7 @@
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -562,6 +589,7 @@
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -583,6 +611,7 @@
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -595,6 +624,7 @@
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -615,6 +645,7 @@
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -633,6 +664,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -655,6 +687,7 @@
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -676,6 +709,7 @@
  * Only enable this when you have to.
  */
 #define MLD_CONFIG_SERIAL_FIPS202_ONLY
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -686,6 +720,7 @@
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -695,6 +730,7 @@
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -696,7 +696,7 @@
  */
 /* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -706,9 +706,6 @@
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -77,6 +77,7 @@
  */
 /* No need to set this -- we _are_ already in a custom config */
 /* #define MLD_CONFIG_FILE "mldsa_native_config.h" */
+
 /**
  * MLD_CONFIG_NAMESPACE_PREFIX
  *
@@ -88,6 +89,7 @@
  * This can also be set using CFLAGS.
  */
 #define MLD_CONFIG_NAMESPACE_PREFIX mld
+
 /**
  * MLD_CONFIG_MULTILEVEL_BUILD
  *
@@ -107,6 +109,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_BUILD */
+
 /**
  * MLD_CONFIG_EXTERNAL_API_QUALIFIER
  *
@@ -120,6 +123,7 @@
  * even mldsa-native's public API can be marked `static`.
  */
 /* #define MLD_CONFIG_EXTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_NO_KEYPAIR_API
  *
@@ -130,6 +134,7 @@
  * those functions.
  */
 /* #define MLD_CONFIG_NO_KEYPAIR_API */
+
 /**
  * MLD_CONFIG_NO_SIGN_API
  *
@@ -142,6 +147,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_SIGN_API */
+
 /**
  * MLD_CONFIG_NO_VERIFY_API
  *
@@ -155,6 +161,7 @@
  * only needed by those functions.
  */
 /* #define MLD_CONFIG_NO_VERIFY_API */
+
 /**
  * MLD_CONFIG_CORE_API_ONLY
  *
@@ -163,6 +170,7 @@
  * and crypto_sign_verify_internal.
  */
 /* #define MLD_CONFIG_CORE_API_ONLY */
+
 /**
  * MLD_CONFIG_NO_RANDOMIZED_API
  *
@@ -180,6 +188,7 @@
  * crypto_sign_signature().
  */
 /* #define MLD_CONFIG_NO_RANDOMIZED_API */
+
 /**
  * MLD_CONFIG_NO_SUPERCOP
  *
@@ -191,6 +200,7 @@
  * naming does not disambiguate between the parameter sets.
  */
 /* #define MLD_CONFIG_NO_SUPERCOP */
+
 /**
  * MLD_CONFIG_CONSTANTS_ONLY
  *
@@ -210,6 +220,7 @@
  *
  *****************************************************************************/
 #if defined(MLD_BUILD_INTERNAL)
+
 /**
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED
  *
@@ -232,6 +243,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_WITH_SHARED */
+
 /**
  * MLD_CONFIG_MULTILEVEL_NO_SHARED
  *
@@ -251,6 +263,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MULTILEVEL_NO_SHARED */
+
 /**
  * MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *
@@ -265,6 +278,7 @@
  * This can also be set using CFLAGS.
  */
 /* #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
@@ -286,6 +300,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif
+
 /**
  * MLD_CONFIG_ARITH_BACKEND_FILE
  *
@@ -304,6 +319,7 @@
     !defined(MLD_CONFIG_ARITH_BACKEND_FILE)
 #define MLD_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
 #endif
+
 /**
  * MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *
@@ -325,6 +341,7 @@
 #if !defined(MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /* #define MLD_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_BACKEND_FILE
  *
@@ -340,6 +357,7 @@
     !defined(MLD_CONFIG_FIPS202_BACKEND_FILE)
 #define MLD_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
+
 /**
  * MLD_CONFIG_FIPS202_CUSTOM_HEADER
  *
@@ -354,6 +372,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_FIPS202X4_CUSTOM_HEADER
  *
@@ -368,6 +387,7 @@
  * the same API (see FIPS202.md).
  */
 /* #define MLD_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
 /**
  * MLD_CONFIG_CUSTOM_ZEROIZE
  *
@@ -405,6 +425,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_RANDOMBYTES
  *
@@ -430,6 +451,7 @@
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_CAPABILITY_FUNC
  *
@@ -460,6 +482,7 @@
        ... your implementation ...
    }
 */
+
 /**
  * MLD_CONFIG_CUSTOM_ALLOC_FREE
  *
@@ -508,6 +531,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
   custom_free(ctx, v, sizeof(T) * (N), __FILE__, __LINE__, #v, #T)
 #endif /* !__ASSEMBLER__ */
 
+
 /**
  * MLD_CONFIG_CUSTOM_MEMCPY
  *
@@ -529,6 +553,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_CUSTOM_MEMSET
  *
@@ -550,6 +575,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
@@ -560,6 +586,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * in which case this option can be set to `static`.
  */
 /* #define MLD_CONFIG_INTERNAL_API_QUALIFIER */
+
 /**
  * MLD_CONFIG_CT_TESTING_ENABLED
  *
@@ -570,6 +597,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * on the exact version of valgrind installed).
  */
 /* #define MLD_CONFIG_CT_TESTING_ENABLED */
+
 /**
  * MLD_CONFIG_NO_ASM
  *
@@ -591,6 +619,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * native backends will be used.
  */
 /* #define MLD_CONFIG_NO_ASM */
+
 /**
  * MLD_CONFIG_NO_ASM_VALUE_BARRIER
  *
@@ -603,6 +632,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * 'opt blocker' instead; see ct.h.
  */
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT
  *
@@ -623,6 +653,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * requires crypto_sign_signature() and crypto_sign_verify().
  */
 /* #define MLD_CONFIG_KEYGEN_PCT */
+
 /**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
@@ -641,6 +672,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
    }
    #endif
 */
+
 /**
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS
  *
@@ -663,6 +695,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * failure rate is < 2^{-256}.
  */
 /* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY
  *
@@ -684,6 +717,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER
  *
@@ -694,6 +728,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
  */
 #define MLD_CONFIG_CONTEXT_PARAMETER
+
 /**
  * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
  *
@@ -703,6 +738,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
  */
 #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE struct test_ctx_t *
+
 /**
  * MLD_CONFIG_REDUCE_RAM
  *

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -704,7 +704,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  */
 #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE struct test_ctx_t *
 /**
- * MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * MLD_CONFIG_REDUCE_RAM
  *
  * Set this to reduce RAM usage. This trades memory for performance.
  *
@@ -714,9 +714,6 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * This option is useful for embedded systems with tight RAM constraints but
  * relaxed performance requirements.
  *
- * @warning This option is experimental! CBMC proofs do not currently cover
- * this configuration option. Its scope and configuration may change at any
- * time.
  */
 /* #define MLD_CONFIG_REDUCE_RAM */
 


### PR DESCRIPTION
- Depends on #1030 