### PR TITLE
Avoid mismatched comparison (suggested code improvement, not a bug!)

### DIFF
--- a/mldsa/src/ct.h
+++ b/mldsa/src/ct.h
@@ -299,7 +299,7 @@ __contract__(
   ensures((return_value == 0) == forall(i, 0, len, (a[i] == b[i]))))
 {
   uint8_t r = 0, s = 0;
-  unsigned i;
+  size_t i;
 
   for (i = 0; i < len; i++)
   __loop__(

--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -77,7 +77,8 @@ __contract__(
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   ensures(return_value < r))
 {
-  size_t rsize = r; // Safety: widen r to avoid type mismatch warning
+  /* Safety: widen r to avoid type mismatch warning */
+  size_t rsize = r;
   while (inlen >= rsize - pos)
   __loop__(
     assigns(pos, in, inlen,
@@ -151,7 +152,8 @@ __contract__(
   ensures(return_value <= r))
 {
   unsigned int i;
-  size_t rsize = r; // Safety: widen r to avoid type mismatch warning
+  /* Safety: widen r to avoid type mismatch warning */
+  size_t rsize = r;
   size_t out_offset = 0;
 
   /* Reference: This code is re-factored from the reference implementation

--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -77,7 +77,7 @@ __contract__(
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   ensures(return_value < r))
 {
-  size_t rsize = r;
+  size_t rsize = r; // Safety: widen r to avoid type mismatch warning
   while (inlen >= rsize - pos)
   __loop__(
     assigns(pos, in, inlen,
@@ -151,7 +151,7 @@ __contract__(
   ensures(return_value <= r))
 {
   unsigned int i;
-  size_t rsize = r;
+  size_t rsize = r; // Safety: widen r to avoid type mismatch warning
   size_t out_offset = 0;
 
   /* Reference: This code is re-factored from the reference implementation

--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -76,8 +76,9 @@ __contract__(
   requires(memory_no_alias(in, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   ensures(return_value < r))
-{
-  while (inlen >= r - pos)
+  {
+    size_t rsize = r;
+    while (inlen >= rsize - pos)
   __loop__(
     assigns(pos, in, inlen,
       memory_slice(s, sizeof(uint64_t) *  MLD_KECCAK_LANES))
@@ -150,6 +151,7 @@ __contract__(
   ensures(return_value <= r))
 {
   unsigned int i;
+  size_t rsize = r;
   size_t out_offset = 0;
 
   /* Reference: This code is re-factored from the reference implementation
@@ -175,7 +177,7 @@ __contract__(
       pos = 0;
     }
     /* Safety: If bytes_to_go < r - pos, truncation to unsigned is safe. */
-    i = bytes_to_go < r - pos ? (unsigned)bytes_to_go : r - pos;
+    i = bytes_to_go < rsize - pos ? (unsigned)bytes_to_go : r - pos;
     mld_keccakf1600_extract_bytes(s, out + out_offset, pos, i);
     bytes_to_go -= i;
     pos += i;

--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -178,7 +178,7 @@ __contract__(
       mld_keccakf1600_permute(s);
       pos = 0;
     }
-    /* Safety: If bytes_to_go < r - pos, truncation to unsigned is safe. */
+    /* Safety: If bytes_to_go < rsize - pos, truncation to unsigned is safe. */
     i = bytes_to_go < rsize - pos ? (unsigned)bytes_to_go : r - pos;
     mld_keccakf1600_extract_bytes(s, out + out_offset, pos, i);
     bytes_to_go -= i;

--- a/mldsa/src/fips202/fips202.c
+++ b/mldsa/src/fips202/fips202.c
@@ -76,9 +76,9 @@ __contract__(
   requires(memory_no_alias(in, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES))
   ensures(return_value < r))
-  {
-    size_t rsize = r;
-    while (inlen >= rsize - pos)
+{
+  size_t rsize = r;
+  while (inlen >= rsize - pos)
   __loop__(
     assigns(pos, in, inlen,
       memory_slice(s, sizeof(uint64_t) *  MLD_KECCAK_LANES))

--- a/mldsa/src/fips202/fips202x4.c
+++ b/mldsa/src/fips202/fips202x4.c
@@ -39,7 +39,8 @@ __contract__(
   requires(memory_no_alias(in3, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY)))
 {
-  while (inlen >= r)
+  size_t rsize = r;
+  while (inlen >= rsize)
   __loop__(
     assigns(inlen, in0, in1, in2, in3, memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY))
     invariant(inlen <= loop_entry(inlen))
@@ -66,7 +67,7 @@ __contract__(
     mld_keccakf1600x4_xor_bytes(s, in0, in1, in2, in3, 0, (unsigned)inlen);
   }
 
-  if (inlen == r - 1)
+  if (inlen == rsize - 1)
   {
     p |= 128;
     mld_keccakf1600x4_xor_bytes(s, &p, &p, &p, &p, (unsigned)inlen, 1);

--- a/mldsa/src/fips202/fips202x4.c
+++ b/mldsa/src/fips202/fips202x4.c
@@ -39,7 +39,8 @@ __contract__(
   requires(memory_no_alias(in3, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY)))
 {
-  size_t rsize = r; // Safety: widen r to avoid type mismatch warning
+  /* Safety: widen r to avoid type mismatch warning */
+  size_t rsize = r;
   while (inlen >= rsize)
   __loop__(
     assigns(inlen, in0, in1, in2, in3, memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY))

--- a/mldsa/src/fips202/fips202x4.c
+++ b/mldsa/src/fips202/fips202x4.c
@@ -39,7 +39,7 @@ __contract__(
   requires(memory_no_alias(in3, inlen))
   assigns(memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY)))
 {
-  size_t rsize = r;
+  size_t rsize = r; // Safety: widen r to avoid type mismatch warning
   while (inlen >= rsize)
   __loop__(
     assigns(inlen, in0, in1, in2, in3, memory_slice(s, sizeof(uint64_t) * MLD_KECCAK_LANES * MLD_KECCAK_WAY))


### PR DESCRIPTION
I searched for all comparisons where the left and right hand sides have different types.

If we exclude cases where either side is a constant (e.g., `inlen > 0` corresponds to `size_t > int`), then there are only five results.

Four results occur in `fips202.c` and `fips202x4.c`, and all of them involve upcasting `r` from `unsigned int` to `size_t`. So this can never result in an issue, even when verification is turned off.

The fifth result occurs in `ct.h`, where the comparison `i < len` corresponds to `unsigned int < size_t`. I am suggesting to avoid this mismatched comparison by declaring `i` as `size_t` instead of `unsigned`.

This is not a bug, but a potential issue if `mld_ct_memcmp` is used to replace `memcmp` in an unrelated project where verification is turned off (otherwise the precondition on `len` will detect any issues).

I am suggesting my proposed change not as a bug fix but as a code improvement, as it may benefit projects that reuse `mld_ct_memcmp` without verification.