### PR TITLE
CBMC: Introduce MLD_ANY_ERROR helper for error disjunctions

### DIFF
--- a/mldsa/mldsa_native.c
+++ b/mldsa/mldsa_native.c
@@ -221,6 +221,7 @@
 /* mldsa/src/common.h */
 #undef MLD_ADD_PARAM_SET
 #undef MLD_ALLOC
+#undef MLD_ANY_ERROR
 #undef MLD_APPLY
 #undef MLD_ASM_FN_SIZE
 #undef MLD_ASM_FN_SYMBOL

--- a/mldsa/mldsa_native_asm.S
+++ b/mldsa/mldsa_native_asm.S
@@ -228,6 +228,7 @@
 /* mldsa/src/common.h */
 #undef MLD_ADD_PARAM_SET
 #undef MLD_ALLOC
+#undef MLD_ANY_ERROR
 #undef MLD_APPLY
 #undef MLD_ASM_FN_SIZE
 #undef MLD_ASM_FN_SYMBOL

--- a/mldsa/src/common.h
+++ b/mldsa/src/common.h
@@ -318,6 +318,15 @@
  * has probability < 2^-256. */
 #define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED -4
 
+/* Disjunction over the full set of MLD_ERR_XXX failure codes.
+ *
+ * Intended for use in top-level `ensures` clauses that admit every
+ * possible error. Narrower contracts should enumerate only the
+ * specific errors they can actually return. */
+#define MLD_ANY_ERROR(err)                                    \
+  ((err) == MLD_ERR_FAIL || (err) == MLD_ERR_OUT_OF_MEMORY || \
+   (err) == MLD_ERR_RNG_FAIL || (err) == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
+
 
 #endif /* !__ASSEMBLER__ */
 

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -60,11 +60,7 @@ static int mld_check_pct(uint8_t const pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
 __contract__(
   requires(memory_no_alias(pk, MLDSA_CRYPTO_PUBLICKEYBYTES))
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
-  ensures(return_value == 0
-    || return_value == MLD_ERR_FAIL
-    || return_value == MLD_ERR_OUT_OF_MEMORY
-    || return_value == MLD_ERR_RNG_FAIL
-    || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
+  ensures(return_value == 0 || MLD_ANY_ERROR(return_value))
 );
 
 #if defined(MLD_CONFIG_KEYGEN_PCT)

--- a/mldsa/src/sign.h
+++ b/mldsa/src/sign.h
@@ -127,9 +127,7 @@ __contract__(
   requires(memory_no_alias(seed, MLDSA_SEEDBYTES))
   assigns(object_whole(pk))
   assigns(object_whole(sk))
-  ensures(return_value == 0 || return_value == MLD_ERR_FAIL ||
-          return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_RNG_FAIL ||
-          return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
+  ensures(return_value == 0 || MLD_ANY_ERROR(return_value))
 );
 
 #if !defined(MLD_CONFIG_CORE_API_ONLY)
@@ -170,9 +168,7 @@ __contract__(
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
   assigns(object_whole(pk))
   assigns(object_whole(sk))
-  ensures(return_value == 0 || return_value == MLD_ERR_FAIL ||
-          return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_RNG_FAIL ||
-          return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
+  ensures(return_value == 0 || MLD_ANY_ERROR(return_value))
 );
 #endif /* !MLD_CONFIG_CORE_API_ONLY */
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API */
@@ -289,7 +285,7 @@ __contract__(
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
   assigns(object_whole(siglen))
   ensures((return_value == 0 && *siglen == MLDSA_CRYPTO_BYTES) ||
-          ((return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_RNG_FAIL || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED) && *siglen == 0))
+          (MLD_ANY_ERROR(return_value) && *siglen == 0))
 );
 
 /**
@@ -334,7 +330,7 @@ __contract__(
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
   assigns(object_whole(siglen))
   ensures((return_value == 0 && *siglen == MLDSA_CRYPTO_BYTES) ||
-          ((return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_RNG_FAIL || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED) && *siglen == 0))
+          (MLD_ANY_ERROR(return_value) && *siglen == 0))
 );
 
 /**
@@ -378,10 +374,7 @@ __contract__(
   assigns(memory_slice(sm, MLDSA_CRYPTO_BYTES + mlen))
   assigns(object_whole(smlen))
   ensures((return_value == 0 && *smlen == MLDSA_CRYPTO_BYTES + mlen) ||
-          ((return_value == MLD_ERR_FAIL
-            || return_value == MLD_ERR_OUT_OF_MEMORY
-            || return_value == MLD_ERR_RNG_FAIL
-            || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED) && *smlen == 0))
+          (MLD_ANY_ERROR(return_value) && *smlen == 0))
 );
 #endif /* !MLD_CONFIG_CORE_API_ONLY */
 #endif /* !MLD_CONFIG_NO_SIGN_API */


### PR DESCRIPTION
Top-level contracts that admit every MLD_ERR_* failure code were repeating a 3-line disjunction at each call site. Introduce MLD_ANY_DEFINED_ERROR(err) in common.h (next to the error-code definitions) and apply it to the 6 full-error-set contracts in sign.h / sign.c.

Narrower contracts that only admit a subset of errors are left untouched: their restricted error set is part of their specification.

Fixes #1096.