### PR TITLE
nix: Bump z3 to 4.16.0 from nixpkgs-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,8 @@
           pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
           pkgs-2405 = inputs.nixpkgs-2405.legacyPackages.${system};
           util = pkgs.callPackage ./nix/util.nix {
-            inherit (pkgs) bitwuzla z3;
-            inherit (pkgs-unstable) cbmc;
+            inherit (pkgs) bitwuzla;
+            inherit (pkgs-unstable) cbmc z3;
             # TODO: switch back to stable python3 for slothy once ortools is fixed in 25.11
             python3-for-slothy = pkgs-unstable.python3;
           };
@@ -240,8 +240,8 @@
             pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.x86_64-linux;
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
-              inherit (pkgs) bitwuzla z3;
-              inherit (pkgs-unstable) cbmc;
+              inherit (pkgs) bitwuzla;
+              inherit (pkgs-unstable) cbmc z3;
               # TODO: switch back to stable python3 for slothy once ortools is fixed in 25.11
               python3-for-slothy = pkgs-unstable.python3;
             };

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -26,12 +26,12 @@ buildEnv {
       litani = callPackage ./litani.nix { }; # 1.29.0
       cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.12
       z3 = z3.overrideAttrs (_: {
-        version = "4.15.3";
+        version = "4.16.0";
         src = fetchFromGitHub {
           owner = "Z3Prover";
           repo = "z3";
-          rev = "z3-4.15.3";
-          hash = "sha256-Lw037Z0t0ySxkgMXkbjNW5CB4QQLRrrSEBsLJqiomZ4=";
+          rev = "z3-4.16.0";
+          hash = "sha256-DnhX3kxggnFmyYwXEPBsBA1rh4oor1oIJR5TMJk/jvc=";
         };
       });
 


### PR DESCRIPTION
It is somewhat inconvienent for developers having to compile z3 from source. While this a one-off step, I would still like to avoid it if possible.

This commit sources z3 from nixpkgs-unstable rather than the local override so we pick up the binary cache, and aligns the pinned version with what nixpkgs 26.05 will ship.

Port of https://github.com/pq-code-package/mlkem-native/pull/1702.