### PR TITLE
CI: Add more legacy compiler tests and move to scheduled workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           check_namespace: 'false'
           extra_args: "--fips202-aarch64-backend ${{ matrix.backend }}"
   compiler_tests:
-    name: Compiler tests  (${{ matrix.compiler.name }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
+    name: Compiler tests  (${{ matrix.compiler.family }}-${{ matrix.compiler.version }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
     strategy:
       fail-fast: false
       matrix:
@@ -209,90 +209,55 @@ jobs:
            name: 'x86_64'
          - runner: macos-latest
            name: 'macos'
+        # Oldest available + 3 latest per family; intermediate versions run in legacy-compilers.
         compiler:
-         - name: gcc-4.8
+         - family: gcc
+           version: "4.8"
            shell: gcc48
            darwin: False
-           c17: False
-           c23: False
            opt: all
            examples: true
-         - name: gcc-4.9
-           shell: gcc49
-           darwin: False
-           c17: False
-           c23: False
-           opt: all
-           examples: true
-         - name: gcc-7
-           shell: gcc7
-           darwin: False
-           c17: False
-           c23: False
-           opt: all
-           examples: true
-         - name: gcc-11
-           shell: gcc11
-           darwin: True
-           c17: True
-           c23: False
-           opt: all
-           examples: true
-         - name: gcc-13
+         - family: gcc
+           version: "13"
            shell: gcc13
            # TODO: gcc13 broken on macOS in nixpkgs 25.11
            darwin: False
-           c17: True
-           c23: False
            opt: all
            examples: true
-         - name: gcc-14
+         - family: gcc
+           version: "14"
            shell: gcc14
            darwin: True
-           c17: True
-           c23: True
            opt: all
            examples: true
-         - name: gcc-15
+         - family: gcc
+           version: "15"
            shell: gcc15
            darwin: True
-           c17: True
-           c23: True
            opt: all
            examples: true
-         - name: clang-18
-           shell: clang18
-           darwin: True
-           c17: True
-           c23: True
+         - family: clang
+           version: "6"
+           shell: clang6
+           darwin: False
            opt: all
            examples: true
-         - name: clang-19
-           shell: clang19
-           darwin: True
-           c17: True
-           c23: True
-           opt: all
-           examples: true
-         - name: clang-20
+         - family: clang
+           version: "20"
            shell: clang20
            darwin: True
-           c17: True
-           c23: True
            opt: all
            examples: true
-         - name: clang-21
+         - family: clang
+           version: "21"
            shell: clang21
            darwin: True
-           c17: True
-           c23: True
            opt: all
            examples: true
-         - name: clang-22
+         - family: clang
+           version: "22"
            shell: clang22
            darwin: True
-           c17: True
-           c23: True
            opt: all
            examples: true
          # CPU flags are not correctly passed to the zig assembler
@@ -304,41 +269,30 @@ jobs:
          #
          # zig 0.16 still appears affected on Linux (CPU-feature
          # predefines look to be dropped in assembler-with-cpp mode).
-         - name: zig-0.12
-           shell: zig0_12
-           darwin: True
-           c17: True
-           c23: False
-           examples: False
+         - family: zig
+           version: "0.10"
+           shell: zig0_10
+           darwin: False
            opt: no_opt
-         - name: zig-0.13
-           shell: zig0_13
-           darwin: True
-           c17: True
-           c23: False
            examples: False
-           opt: no_opt
-         - name: zig-0.14
+         - family: zig
+           version: "0.14"
            shell: zig0_14
            darwin: True
-           c17: True
-           c23: True
-           examples: False
            opt: no_opt
-         - name: zig-0.15
+           examples: False
+         - family: zig
+           version: "0.15"
            shell: zig0_15
            darwin: True
-           c17: True
-           c23: True
-           examples: False
            opt: no_opt
-         - name: zig-0.16
+           examples: False
+         - family: zig
+           version: "0.16"
            shell: zig0_16
            darwin: True
-           c17: True
-           c23: True
-           examples: False
            opt: no_opt
+           examples: False
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -400,7 +354,7 @@ jobs:
           cflags: "-std=c11 ${{ matrix.cflags }}"
       - name: native build+functest (C17)
         if: ${{ (matrix.compiler.darwin || matrix.target.runner != 'macos-latest') &&
-                matrix.compiler.c17 }}
+                (matrix.compiler.family == 'zig' || (matrix.compiler.family == 'gcc' && matrix.compiler.version >= 8) || (matrix.compiler.family == 'clang' && matrix.compiler.version >= 7)) }}
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -415,7 +369,7 @@ jobs:
           cflags: "-std=c17 ${{ matrix.cflags }}"
       - name: native build+functest (C23)
         if: ${{ (matrix.compiler.darwin || matrix.target.runner != 'macos-latest') &&
-                matrix.compiler.c23 }}
+                ((matrix.compiler.family == 'zig' && matrix.compiler.version >= 0.14) || (matrix.compiler.family == 'gcc' && matrix.compiler.version >= 14) || (matrix.compiler.family == 'clang' && matrix.compiler.version >= 18)) }}
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -20,21 +20,13 @@ jobs:
       max-parallel: 10
       matrix:
         system: [ubuntu-latest, ubuntu-24.04-arm]
+        # Oldest available + 3 latest per family; intermediate versions run in legacy-compilers.
         nix-shell:
-          - valgrind-varlat_clang14
-          - valgrind-varlat_clang15
-          - valgrind-varlat_clang16
-          - valgrind-varlat_clang17
-          - valgrind-varlat_clang18
-          - valgrind-varlat_clang19
+          - valgrind-varlat_clang6
           - valgrind-varlat_clang20
           - valgrind-varlat_clang21
           - valgrind-varlat_clang22
           - valgrind-varlat_gcc48
-          - valgrind-varlat_gcc49
-          - valgrind-varlat_gcc7
-          - valgrind-varlat_gcc11
-          - valgrind-varlat_gcc12
           - valgrind-varlat_gcc13
           - valgrind-varlat_gcc14
           - valgrind-varlat_gcc15
@@ -49,7 +41,7 @@ jobs:
           nix-cache: true
       - name:  Build and run test (-Oz)
         # -Oz got introduced in gcc12
-        if: ${{ matrix.nix-shell !=  'valgrind-varlat_gcc48' && matrix.nix-shell !=  'valgrind-varlat_gcc49' && matrix.nix-shell !=  'valgrind-varlat_gcc7' && matrix.nix-shell !=  'valgrind-varlat_gcc11'}}
+        if: ${{ matrix.nix-shell != 'valgrind-varlat_gcc48' }}
         uses: ./.github/actions/ct-test
         with:
           cflags: -Oz -DMLD_CONFIG_KEYGEN_PCT

--- a/.github/workflows/legacy-compilers.yml
+++ b/.github/workflows/legacy-compilers.yml
@@ -1,0 +1,562 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: Legacy compilers
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+jobs:
+  compiler_tests_linux:
+    name: Compiler tests (${{ matrix.compiler.family }}-${{ matrix.compiler.version }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'legacy-compiler-tests'))
+    strategy:
+      fail-fast: false
+      matrix:
+        cflags: [ "-O0", "-Os", "-O3" ]
+        target:
+         - runner: ubuntu-24.04-arm
+           name: 'aarch64'
+         - runner: ubuntu-latest
+           name: 'x86_64'
+        # All available compiler versions are tested here, including those also
+        # covered by ci.yml on every PR.
+        # C17 support starts at gcc 8, clang 7, all zig; C23 at gcc 14, clang 18,
+        # zig 0.14 (encoded in the C17/C23 step conditions below).
+        compiler:
+         - family: gcc
+           version: "4.8"
+           shell: gcc48
+           opt: all
+           examples: true
+         - family: gcc
+           version: "4.9"
+           shell: gcc49
+           opt: all
+           examples: true
+         - family: gcc
+           version: "6"
+           shell: gcc6
+           opt: all
+           examples: true
+         - family: gcc
+           version: "7"
+           shell: gcc7
+           opt: all
+           examples: true
+         - family: gcc
+           version: "8"
+           shell: gcc8
+           opt: all
+           examples: true
+         - family: gcc
+           version: "9"
+           shell: gcc9
+           opt: all
+           examples: true
+         - family: gcc
+           version: "10"
+           shell: gcc10
+           opt: all
+           examples: true
+         - family: gcc
+           version: "11"
+           shell: gcc11
+           opt: all
+           examples: true
+         - family: gcc
+           version: "12"
+           shell: gcc12
+           opt: all
+           examples: true
+         - family: gcc
+           version: "13"
+           shell: gcc13
+           opt: all
+           examples: true
+         - family: gcc
+           version: "14"
+           shell: gcc14
+           opt: all
+           examples: true
+         - family: gcc
+           version: "15"
+           shell: gcc15
+           opt: all
+           examples: true
+         - family: clang
+           version: "6"
+           shell: clang6
+           opt: all
+           examples: true
+         - family: clang
+           version: "7"
+           shell: clang7
+           opt: all
+           examples: true
+         - family: clang
+           version: "8"
+           shell: clang8
+           opt: all
+           examples: true
+         - family: clang
+           version: "9"
+           shell: clang9
+           opt: all
+           examples: true
+         - family: clang
+           version: "10"
+           shell: clang10
+           opt: all
+           examples: true
+         - family: clang
+           version: "11"
+           shell: clang11
+           opt: all
+           examples: true
+         - family: clang
+           version: "12"
+           shell: clang12
+           opt: all
+           examples: true
+         - family: clang
+           version: "13"
+           shell: clang13
+           opt: all
+           examples: true
+         - family: clang
+           version: "14"
+           shell: clang14
+           opt: all
+           examples: true
+         - family: clang
+           version: "15"
+           shell: clang15
+           opt: all
+           examples: true
+         - family: clang
+           version: "16"
+           shell: clang16
+           opt: all
+           examples: true
+         - family: clang
+           version: "17"
+           shell: clang17
+           opt: all
+           examples: true
+         - family: clang
+           version: "18"
+           shell: clang18
+           opt: all
+           examples: true
+         - family: clang
+           version: "19"
+           shell: clang19
+           opt: all
+           examples: true
+         - family: clang
+           version: "20"
+           shell: clang20
+           opt: all
+           examples: true
+         - family: clang
+           version: "21"
+           shell: clang21
+           opt: all
+           examples: true
+         - family: clang
+           version: "22"
+           shell: clang22
+           opt: all
+           examples: true
+         # CPU flags are not correctly passed to the zig assembler
+         # https://github.com/ziglang/zig/issues/23576
+         # We therefore only test the C backend, which is why opt is set to
+         # no_opt and examples are omitted (there is currently no way to run
+         # only those examples not involving native code).
+         - family: zig
+           version: "0.10"
+           shell: zig0_10
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.11"
+           shell: zig0_11
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.12"
+           shell: zig0_12
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.13"
+           shell: zig0_13
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.14"
+           shell: zig0_14
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.15"
+           shell: zig0_15
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.16"
+           shell: zig0_16
+           opt: no_opt
+           examples: False
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: native build+functest (default)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "${{ matrix.cflags }}"
+      - name: native build+functest (C90)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c90 ${{ matrix.cflags }}"
+      - name: native build+functest (C99)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c99 ${{ matrix.cflags }}"
+      - name: native build+functest (C11)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c11 ${{ matrix.cflags }}"
+      - name: native build+functest (C17)
+        if: ${{ matrix.compiler.family == 'zig' || (matrix.compiler.family == 'gcc' && matrix.compiler.version >= 8) || (matrix.compiler.family == 'clang' && matrix.compiler.version >= 7) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c17 ${{ matrix.cflags }}"
+      - name: native build+functest (C23)
+        if: ${{ (matrix.compiler.family == 'zig' && matrix.compiler.version >= 0.14) || (matrix.compiler.family == 'gcc' && matrix.compiler.version >= 14) || (matrix.compiler.family == 'clang' && matrix.compiler.version >= 18) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c23 ${{ matrix.cflags }}"
+
+  compiler_tests_macos:
+    name: Compiler tests (${{ matrix.compiler.family }}-${{ matrix.compiler.version }}, macos, ${{ matrix.cflags }})
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'legacy-compiler-tests'))
+    strategy:
+      fail-fast: false
+      matrix:
+        cflags: [ "-O0", "-Os", "-O3" ]
+        # Subset of compiler_tests_linux known to build on aarch64-darwin.
+        compiler:
+         - family: gcc
+           version: "11"
+           shell: gcc11
+           opt: all
+           examples: true
+         - family: gcc
+           version: "14"
+           shell: gcc14
+           opt: all
+           examples: true
+         - family: gcc
+           version: "15"
+           shell: gcc15
+           opt: all
+           examples: true
+         - family: clang
+           version: "18"
+           shell: clang18
+           opt: all
+           examples: true
+         - family: clang
+           version: "19"
+           shell: clang19
+           opt: all
+           examples: true
+         - family: clang
+           version: "20"
+           shell: clang20
+           opt: all
+           examples: true
+         - family: clang
+           version: "21"
+           shell: clang21
+           opt: all
+           examples: true
+         - family: clang
+           version: "22"
+           shell: clang22
+           opt: all
+           examples: true
+         - family: zig
+           version: "0.12"
+           shell: zig0_12
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.13"
+           shell: zig0_13
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.14"
+           shell: zig0_14
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.15"
+           shell: zig0_15
+           opt: no_opt
+           examples: False
+         - family: zig
+           version: "0.16"
+           shell: zig0_16
+           opt: no_opt
+           examples: False
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: native build+functest (default)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "${{ matrix.cflags }}"
+      - name: native build+functest (C90)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c90 ${{ matrix.cflags }}"
+      - name: native build+functest (C99)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c99 ${{ matrix.cflags }}"
+      - name: native build+functest (C11)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c11 ${{ matrix.cflags }}"
+      - name: native build+functest (C17)
+        if: ${{ matrix.compiler.family == 'zig' || (matrix.compiler.family == 'gcc' && matrix.compiler.version >= 8) || (matrix.compiler.family == 'clang' && matrix.compiler.version >= 7) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c17 ${{ matrix.cflags }}"
+      - name: native build+functest (C23)
+        if: ${{ (matrix.compiler.family == 'zig' && matrix.compiler.version >= 0.14) || (matrix.compiler.family == 'gcc' && matrix.compiler.version >= 14) || (matrix.compiler.family == 'clang' && matrix.compiler.version >= 18) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          kat: false
+          acvp: false
+          wycheproof: false
+          examples: ${{ matrix.compiler.examples }}
+          opt: ${{ matrix.compiler.opt }}
+          nix-shell: ${{ matrix.compiler.shell }}
+          cflags: "-std=c23 ${{ matrix.cflags }}"
+
+  check-ct-varlat-legacy:
+    name: Constant-time test ${{ matrix.compiler.family }}-${{ matrix.compiler.version }} ${{ matrix.system }}
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'legacy-compiler-tests'))
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        system: [ubuntu-latest, ubuntu-24.04-arm]
+        compiler:
+          - { family: gcc,   version: "4.8", shell: gcc48 }
+          - { family: gcc,   version: "4.9", shell: gcc49 }
+          - { family: gcc,   version: "6",   shell: gcc6 }
+          - { family: gcc,   version: "7",   shell: gcc7 }
+          - { family: gcc,   version: "8",   shell: gcc8 }
+          - { family: gcc,   version: "9",   shell: gcc9 }
+          - { family: gcc,   version: "10",  shell: gcc10 }
+          - { family: gcc,   version: "11",  shell: gcc11 }
+          - { family: gcc,   version: "12",  shell: gcc12 }
+          - { family: gcc,   version: "13",  shell: gcc13 }
+          - { family: gcc,   version: "14",  shell: gcc14 }
+          - { family: gcc,   version: "15",  shell: gcc15 }
+          - { family: clang, version: "6",   shell: clang6 }
+          - { family: clang, version: "7",   shell: clang7 }
+          - { family: clang, version: "8",   shell: clang8 }
+          - { family: clang, version: "9",   shell: clang9 }
+          - { family: clang, version: "10",  shell: clang10 }
+          - { family: clang, version: "11",  shell: clang11 }
+          - { family: clang, version: "12",  shell: clang12 }
+          - { family: clang, version: "13",  shell: clang13 }
+          - { family: clang, version: "14",  shell: clang14 }
+          - { family: clang, version: "15",  shell: clang15 }
+          - { family: clang, version: "16",  shell: clang16 }
+          - { family: clang, version: "17",  shell: clang17 }
+          - { family: clang, version: "18",  shell: clang18 }
+          - { family: clang, version: "19",  shell: clang19 }
+          - { family: clang, version: "20",  shell: clang20 }
+          - { family: clang, version: "21",  shell: clang21 }
+          - { family: clang, version: "22",  shell: clang22 }
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup nix
+        uses: ./.github/actions/setup-shell
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: "valgrind-varlat_${{ matrix.compiler.shell }}"
+          nix-cache: true
+      - name: Build and run test (-Oz)
+        # -Oz got introduced in gcc12
+        if: ${{ matrix.compiler.family != 'gcc' || matrix.compiler.version >= 12 }}
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -Oz -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-Os)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -Os -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-O3)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O3 -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-Ofast)
+        # -Ofast got deprecated in clang19; -O3 -ffast-math should be used instead
+        if: ${{ !(matrix.compiler.family == 'clang' && matrix.compiler.version >= 19) }}
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -Ofast -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-O3 -ffast-math)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O3 -ffast-math -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-O2)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O2 -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-O1)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O1 -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes
+      - name: Build and run test (-O0)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O0 -DMLD_CONFIG_KEYGEN_PCT
+          valgrind_flags: --variable-latency-errors=yes

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make test
 mldsa-native is used in
  - AWS' Cryptography library [AWS-LC](https://github.com/aws/aws-lc/)
  - [libOQS](https://github.com/open-quantum-safe/liboqs/) of the Open Quantum Safe project
- - [Pavona](https://github.com/pavona/pavona) - an open source silicon Root of Trust (RoT)
+ - [Pavona](https://github.com/pavona/pavona) - a library of modular, tapeout-proven, and secure-by-default open silicon blocks
  - [CHERIoT-PQC](https://github.com/CHERIoT-Platform/cheriot-pqc) — post-quantum cryptography support for the CHERIoT platform
 
 ## Formal Verification

--- a/flake.lock
+++ b/flake.lock
@@ -36,22 +36,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2405": {
-      "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1776877367,
@@ -72,7 +56,6 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
   description = "mldsa-native";
 
   inputs = {
-    nixpkgs-2405.url = "github:NixOS/nixpkgs/nixos-24.05";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
@@ -18,12 +17,11 @@
 
   outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      imports = [ ];
+      imports = [ ./nix/legacy/module.nix ];
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { config, pkgs, system, ... }:
         let
           pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
-          pkgs-2405 = inputs.nixpkgs-2405.legacyPackages.${system};
           util = pkgs.callPackage ./nix/util.nix {
             inherit (pkgs) bitwuzla z3;
             inherit (pkgs-unstable) cbmc;
@@ -66,21 +64,11 @@
               (_:_: {
                 clang_22 = pkgs-unstable.clang_22;
                 zig_0_16 = pkgs-unstable.zig;
-
-                # From 24.05 (dropped in 25.11)
-                gcc48 = pkgs-2405.gcc48;
-                gcc49 = pkgs-2405.gcc49;
-                gcc7 = pkgs-2405.gcc7;
-                gcc11 = pkgs-2405.gcc11;
-                gcc12 = pkgs-2405.gcc12;
-                clang_14 = pkgs-2405.clang_14;
-                clang_15 = pkgs-2405.clang_15;
-                clang_16 = pkgs-2405.clang_16;
-                clang_17 = pkgs-2405.clang_17;
-                zig_0_12 = pkgs-2405.zig_0_12;
               })
             ];
           };
+          _module.args.util = util;
+          _module.args.zigWrapCC = zigWrapCC;
 
           packages.linters = util.linters;
           packages.cbmc = util.cbmc_pkgs;
@@ -189,46 +177,27 @@
           devShells.linter = util.mkShellNoCC {
             packages = builtins.attrValues { inherit (config.packages) linters; };
           };
-          devShells.clang14 = util.mkShellWithCC' pkgs.clang_14;
-          devShells.clang15 = util.mkShellWithCC' pkgs.clang_15;
-          devShells.clang16 = util.mkShellWithCC' pkgs.clang_16;
-          devShells.clang17 = util.mkShellWithCC' pkgs.clang_17;
           devShells.clang18 = util.mkShellWithCC' pkgs.clang_18;
           devShells.clang19 = util.mkShellWithCC' pkgs.clang_19;
           devShells.clang20 = util.mkShellWithCC' pkgs.clang_20;
           devShells.clang21 = util.mkShellWithCC' pkgs.clang_21;
           devShells.clang22 = util.mkShellWithCC' pkgs.clang_22;
 
-          devShells.zig0_12 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_12);
           devShells.zig0_13 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_13);
           devShells.zig0_14 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_14);
           devShells.zig0_15 = util.mkShellWithCC' (zigWrapCC pkgs.zig);
           devShells.zig0_16 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_16);
 
-          devShells.gcc48 = util.mkShellWithCC' pkgs.gcc48;
-          devShells.gcc49 = util.mkShellWithCC' pkgs.gcc49;
-          devShells.gcc7 = util.mkShellWithCC' pkgs.gcc7;
-          devShells.gcc11 = util.mkShellWithCC' pkgs.gcc11;
-          devShells.gcc12 = util.mkShellWithCC' pkgs.gcc12;
           devShells.gcc13 = util.mkShellWithCC' pkgs.gcc13;
           devShells.gcc14 = util.mkShellWithCC' pkgs.gcc14;
           devShells.gcc15 = util.mkShellWithCC' pkgs.gcc15;
 
           # valgrind with a patch for detecting variable-latency instructions
-          devShells.valgrind-varlat_clang14 = util.mkShellWithCC_valgrind' pkgs.clang_14;
-          devShells.valgrind-varlat_clang15 = util.mkShellWithCC_valgrind' pkgs.clang_15;
-          devShells.valgrind-varlat_clang16 = util.mkShellWithCC_valgrind' pkgs.clang_16;
-          devShells.valgrind-varlat_clang17 = util.mkShellWithCC_valgrind' pkgs.clang_17;
           devShells.valgrind-varlat_clang18 = util.mkShellWithCC_valgrind' pkgs.clang_18;
           devShells.valgrind-varlat_clang19 = util.mkShellWithCC_valgrind' pkgs.clang_19;
           devShells.valgrind-varlat_clang20 = util.mkShellWithCC_valgrind' pkgs.clang_20;
           devShells.valgrind-varlat_clang21 = util.mkShellWithCC_valgrind' pkgs.clang_21;
           devShells.valgrind-varlat_clang22 = util.mkShellWithCC_valgrind' pkgs.clang_22;
-          devShells.valgrind-varlat_gcc48 = util.mkShellWithCC_valgrind' pkgs.gcc48;
-          devShells.valgrind-varlat_gcc49 = util.mkShellWithCC_valgrind' pkgs.gcc49;
-          devShells.valgrind-varlat_gcc7 = util.mkShellWithCC_valgrind' pkgs.gcc7;
-          devShells.valgrind-varlat_gcc11 = util.mkShellWithCC_valgrind' pkgs.gcc11;
-          devShells.valgrind-varlat_gcc12 = util.mkShellWithCC_valgrind' pkgs.gcc12;
           devShells.valgrind-varlat_gcc13 = util.mkShellWithCC_valgrind' pkgs.gcc13;
           devShells.valgrind-varlat_gcc14 = util.mkShellWithCC_valgrind' pkgs.gcc14;
           devShells.valgrind-varlat_gcc15 = util.mkShellWithCC_valgrind' pkgs.gcc15;

--- a/nix/legacy/default.nix
+++ b/nix/legacy/default.nix
@@ -1,0 +1,51 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+{ system }:
+let
+  pkgs-2405 = import
+    (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/b134951a4c9f3c995fd7be05f3243f8ecd65d798.tar.gz";
+      sha256 = "0zydsqiaz8qi4zd63zsb2gij2p614cgkcaisnk11wjy3nmiq0x1s";
+    })
+    { inherit system; };
+
+  pkgs-2305 = import
+    (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
+      sha256 = "05cbl1k193c9la9xhlz4y6y8ijpb2mkaqrab30zij6z4kqgclsrd";
+    })
+    { inherit system; };
+in
+{
+  ccs = {
+    gcc48 = pkgs-2405.gcc48;
+    gcc49 = pkgs-2405.gcc49;
+    gcc6 = pkgs-2405.gcc6;
+    gcc7 = pkgs-2405.gcc7;
+    gcc8 = pkgs-2405.gcc8;
+    gcc9 = pkgs-2405.gcc9;
+    gcc10 = pkgs-2405.gcc10;
+    gcc11 = pkgs-2405.gcc11;
+    gcc12 = pkgs-2405.gcc12;
+
+    clang6 = pkgs-2305.clang_6;
+    clang7 = pkgs-2305.clang_7;
+    clang8 = pkgs-2305.clang_8;
+    clang9 = pkgs-2305.clang_9;
+    clang10 = pkgs-2305.clang_10;
+    clang11 = pkgs-2305.clang_11;
+    clang12 = pkgs-2405.clang_12;
+    clang13 = pkgs-2405.clang_13;
+    clang14 = pkgs-2405.clang_14;
+    clang15 = pkgs-2405.clang_15;
+    clang16 = pkgs-2405.clang_16;
+    clang17 = pkgs-2405.clang_17;
+  };
+
+  zigs = {
+    zig0_10 = pkgs-2405.zig_0_10;
+    zig0_11 = pkgs-2405.zig_0_11;
+    zig0_12 = pkgs-2405.zig_0_12;
+  };
+}

--- a/nix/legacy/module.nix
+++ b/nix/legacy/module.nix
@@ -1,0 +1,15 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+{
+  perSystem = { lib, system, util, zigWrapCC, ... }:
+    let
+      legacy = import ./default.nix { inherit system; };
+    in
+    {
+      devShells =
+        lib.mapAttrs (_: cc: util.mkShellWithCC' cc) legacy.ccs
+        // lib.mapAttrs' (n: cc: lib.nameValuePair "valgrind-varlat_${n}" (util.mkShellWithCC_valgrind' cc)) legacy.ccs
+        // lib.mapAttrs (_: zig: util.mkShellWithCC' (zigWrapCC zig)) legacy.zigs;
+    };
+}


### PR DESCRIPTION
Our compiler tests and constant-time tests have been steadily
growing over time which is not sustainable in the medium term.

This commit solves that by splitting the set of compiler versions
into two
1) Per-PR compilers - tested on every PR. For each family (gcc, clang,
zig) we keep the oldest available version plus the three latest ones.

2) Legacy compilers - all versions, tested
in a scheduled job or when the `legacy-compiler-tests` label is added
to the PR. Currently the job is scheduled to run daily, but in the long
term we may want to switch it to weekly.

This allows us to extend compiler coverage by gcc 6, 8, 9, 10, zig
0.10+0.11, and clang 6..13 for both CT and compiler tests.

My expectation is that the legacy compilers only get changed
whenever nixpkgs drops a compiler version.

- Port of https://github.com/pq-code-package/mlkem-native/pull/1700