### PR TITLE
Proofs/Isabelle: Add Neon NTT formalization and conformance harness

### DIFF
--- a/.github/workflows/isabelle.yml
+++ b/.github/workflows/isabelle.yml
@@ -16,3 +16,38 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Compress session
         run: /home/isabelle/Isabelle/bin/isabelle build -D proofs/isabelle/compress
+  neon_ntt:
+    # AArch64 is required: hw_exec.c rejects non-AArch64 hosts at compile time.
+    runs-on: ubuntu-24.04-arm
+    container:
+      # arm64 image variant; "_X11_Latex" is required because the NeonNTT
+      # ROOT builds a PDF document.
+      image: makarius/isabelle:Isabelle2025-1_ARM_X11_Latex
+      options: --user root
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install conformance build tools and missing TeX packages
+        run: |
+          apt-get update
+          # texlive-luatex supplies luacode.sty, required by hyperxmp (loaded
+          # via iacrtrans -> hyperref) when the NeonNTT document is built.
+          apt-get install -y --no-install-recommends \
+            gcc libc6-dev make python3 texlive-luatex
+      - name: Build NeonNTT session
+        run: /home/isabelle/Isabelle/bin/isabelle build -D proofs/isabelle/neon_ntt
+      - name: Upload formalization PDF
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: neon_ntt_autoformalized
+          path: proofs/isabelle/neon_ntt/output/document.pdf
+      - name: Build hw_exec (AArch64 NEON reference)
+        working-directory: proofs/isabelle/neon_ntt/model/hw
+        run: make
+      - name: Build model_exec (Isabelle SML export)
+        working-directory: proofs/isabelle/neon_ntt/model/sml
+        run: make ISABELLE_DIR=/home/isabelle/Isabelle
+      - name: Run conformance (edge + random)
+        working-directory: proofs/isabelle/neon_ntt
+        run: |
+          python3 model/conformance/run.py edge
+          python3 model/conformance/run.py random -n 50000

--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -16,6 +16,24 @@ source code and documentation.
 * Referenced from:
   - [README.md](README.md)
 
+### `AutoCorrode`
+
+* AutoCorrode software verification framework for Isabelle/HOL
+* Author(s):
+  - Hanno Becker
+  - Nathan Chong
+  - Robert Dockins
+  - Jim Grundy
+  - Jason Z. S. Hu
+  - Ike Mulder
+  - Dominic P. Mulligan
+  - Paul Mure
+  - Lawrence C. Paulson
+  - Konrad Slind
+* URL: https://github.com/awslabs/autocorrode
+* Referenced from:
+  - [proofs/isabelle/neon_ntt/README.md](proofs/isabelle/neon_ntt/README.md)
+
 ### `FIPS140_3_IG`
 
 * Implementation Guidance for FIPS 140-3 and the Cryptographic Module Validation Program
@@ -178,6 +196,7 @@ source code and documentation.
   - Shang-Yi Yang
 * URL: https://eprint.iacr.org/2021/986
 * Referenced from:
+  - [README.md](README.md)
   - [dev/aarch64_clean/src/intt_aarch64_asm.S](dev/aarch64_clean/src/intt_aarch64_asm.S)
   - [dev/aarch64_clean/src/ntt_aarch64_asm.S](dev/aarch64_clean/src/ntt_aarch64_asm.S)
   - [dev/aarch64_opt/README.md](dev/aarch64_opt/README.md)
@@ -187,6 +206,7 @@ source code and documentation.
   - [mldsa/src/native/aarch64/src/ntt_aarch64_asm.S](mldsa/src/native/aarch64/src/ntt_aarch64_asm.S)
   - [proofs/hol_light/aarch64/mldsa/intt_aarch64_asm.S](proofs/hol_light/aarch64/mldsa/intt_aarch64_asm.S)
   - [proofs/hol_light/aarch64/mldsa/ntt_aarch64_asm.S](proofs/hol_light/aarch64/mldsa/ntt_aarch64_asm.S)
+  - [proofs/isabelle/neon_ntt/README.md](proofs/isabelle/neon_ntt/README.md)
 
 ### `REF`
 

--- a/BIBLIOGRAPHY.yml
+++ b/BIBLIOGRAPHY.yml
@@ -29,19 +29,19 @@
   url: https://csrc.nist.gov/pubs/fips/202/final
 
 - id: NIST_FAQ
-  name: "Post-Quantum Cryptography FAQs" 
+  name: "Post-Quantum Cryptography FAQs"
   author: National Institute of Standards and Technology
   url: https://csrc.nist.gov/Projects/post-quantum-cryptography/faqs#Rdc7
 
 - id: NIST_FIPS204_SEC6
-  name: "FIPS 204 Section 6 Guidance" 
+  name: "FIPS 204 Section 6 Guidance"
   author: National Institute of Standards and Technology
   url: https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf
 
 - id: REF
   name: "CRYSTALS-Dilithium reference implementation"
   author:
-  - Bai, Shi  
+  - Bai, Shi
   - Ducas, Léo
   - Kiltz, Eike
   - Lepoint, Tancrède
@@ -89,13 +89,13 @@
 - id: Round3_Spec
   name: "CRYSTALS-Dilithium Algorithm Specifications and Supporting Documentation (Version 3.1)"
   author:
-  - Bai, Shi  
-  - Ducas, Léo 
-  - Kiltz, Eike 
-  - Lepoint, Tancrède 
-  - Lyubashevsky, Vadim 
+  - Bai, Shi
+  - Ducas, Léo
+  - Kiltz, Eike
+  - Lepoint, Tancrède
+  - Lyubashevsky, Vadim
   - Schwabe, Peter
-  - Seiler, Gregor 
+  - Seiler, Gregor
   - Stehlé, Damien
   url: https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 
@@ -119,13 +119,30 @@
   - Kannwischer, Matthias J.
   - Yang, Bo-Yin
   - Yang, Shang-Yi
+
+- id: AutoCorrode
+  name: "AutoCorrode software verification framework for Isabelle/HOL"
+  year: 2025
+  url: https://github.com/awslabs/autocorrode
+  author:
+  - Becker, Hanno
+  - Chong, Nathan
+  - Dockins, Robert
+  - Grundy, Jim
+  - Hu, Jason Z. S.
+  - Mulder, Ike
+  - Mulligan, Dominic P.
+  - Mure, Paul
+  - Paulson, Lawrence C.
+  - Slind, Konrad
+
 - id: mupq
   name: Common files for pqm4, pqm3, pqriscv
-  author: 
-  - Kannwischer, Matthias J. 
+  author:
+  - Kannwischer, Matthias J.
   - Petri, Richard
   - Rijneveld, Joost
-  - Schwabe, Peter 
+  - Schwabe, Peter
   - Stoffelen, Ko
   url: https://github.com/mupq/mupq
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ HOL-Light functional correctness proofs can be found in [proofs/hol_light](proof
 
 Finally, [proofs/isabelle](proofs/isabelle/compress) contains proofs in [Isabelle/HOL](https://isabelle.in.tum.de/) of the correctness of
 different approaches for computing the scalar decomposition routines used in ML-DSA. Those are still experimental and do not yet operate
-on the source level.
+on the source level. [proofs/isabelle/neon_ntt](proofs/isabelle/neon_ntt) additionally provides a machine-checked formalisation of the
+modular-arithmetic core of the Neon NTT paper[^NeonNTT], covering the Barrett and Montgomery primitives underlying the AArch64 NTT and
+pointwise-multiplication assembly; see its [README](proofs/isabelle/neon_ntt/README.md).
 
 **NOTE:** Formal Verification is never absolute. See [SOUNDNESS.md](SOUNDNESS.md) for an analysis of the scope, assumptions and risks of the formal verification efforts around mldsa-native.
 
@@ -229,6 +231,7 @@ through the [PQCA Discord](https://discord.com/invite/xyVnwzfg5R). See also [CON
 [^FIPS204]: National Institute of Standards and Technology: FIPS 204 Module-Lattice-Based Digital Signature Standard, [https://csrc.nist.gov/pubs/fips/204/final](https://csrc.nist.gov/pubs/fips/204/final)
 [^NIST_FAQ]: National Institute of Standards and Technology: Post-Quantum Cryptography FAQs, [https://csrc.nist.gov/Projects/post-quantum-cryptography/faqs#Rdc7](https://csrc.nist.gov/Projects/post-quantum-cryptography/faqs#Rdc7)
 [^NIST_FIPS204_SEC6]: National Institute of Standards and Technology: FIPS 204 Section 6 Guidance, [https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf](https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf)
+[^NeonNTT]: Becker, Hwang, Kannwischer, Yang, Yang: Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1, [https://eprint.iacr.org/2021/986](https://eprint.iacr.org/2021/986)
 [^REF]: Bai, Ducas, Kiltz, Lepoint, Lyubashevsky, Schwabe, Seiler, Stehlé: CRYSTALS-Dilithium reference implementation, [https://github.com/pq-crystals/dilithium/tree/master/ref](https://github.com/pq-crystals/dilithium/tree/master/ref)
 [^tiny_sha3]: Markku-Juhani O. Saarinen: tiny_sha3, [https://github.com/mjosaarinen/tiny_sha3](https://github.com/mjosaarinen/tiny_sha3)
 [^wycheproof]: Community Cryptography Specification Project: Project Wycheproof, [https://github.com/C2SP/wycheproof](https://github.com/C2SP/wycheproof)

--- a/dev/aarch64_clean/src/intt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/intt_aarch64_asm.S
@@ -32,6 +32,10 @@
         // round-to-nearest-even-integer approximation. Following loc.cit.,
         // this is functionally the same as a signed Montgomery multiplication
         // with a suitable constant of absolute value < q.
+        //
+        // Functional correctness and the bound below are formalised in
+        // Isabelle/HOL as `barrett_mul_neon_word_correct`; see
+        // proofs/isabelle/neon_ntt, theory `Asm_Barrett`.
         sqrdmulh t2.4s,      \src\().4s, \const\().s[\idx1\()]
         mul      \dst\().4s, \src\().4s, \const\().s[\idx0\()]
         mls      \dst\().4s, t2.4s,      consts.s[0]
@@ -42,6 +46,7 @@
 
 .macro mulmod dst, src, const, const_twisted
         // Same as mulmodq, but with different multiplier across each lanes.
+        // Same formal guarantee as mulmodq, see proofs/isabelle/neon_ntt.
         sqrdmulh t2.4s,      \src\().4s, \const_twisted\().4s
         mul      \dst\().4s, \src\().4s, \const\().4s
         mls      \dst\().4s, t2.4s,      consts.s[0]

--- a/dev/aarch64_clean/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/ntt_aarch64_asm.S
@@ -32,6 +32,10 @@
         // round-to-nearest-even-integer approximation. Following loc.cit.,
         // this is functionally the same as a signed Montgomery multiplication
         // with a suitable constant of absolute value < q.
+        //
+        // Functional correctness and the bound below are formalised in
+        // Isabelle/HOL as `barrett_mul_neon_word_correct`; see
+        // proofs/isabelle/neon_ntt, theory `Asm_Barrett`.
         sqrdmulh t2.4s,      \src\().4s, \const\().s[\idx1\()]
         mul      \dst\().4s, \src\().4s, \const\().s[\idx0\()]
         mls      \dst\().4s, t2.4s,      consts.s[0]
@@ -43,6 +47,7 @@
 
 .macro mulmod dst, src, const, const_twisted
         // Same as mulmodq, but with different multiplier across each lanes.
+        // Same formal guarantee as mulmodq, see proofs/isabelle/neon_ntt.
         sqrdmulh t2.4s,   \src\().4s, \const_twisted\().4s
         mul      \dst\().4s, \src\().4s, \const\().4s
         mls      \dst\().4s, t2.4s,   consts.s[0]

--- a/proofs/isabelle/neon_ntt/Asm_Barrett.thy
+++ b/proofs/isabelle/neon_ntt/Asm_Barrett.thy
@@ -1,0 +1,1175 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Asm_Barrett
+  imports Word_Ops Barrett_Montgomery
+begin
+
+unbundle %invisible ASM_syntax
+
+chapter \<open>Neon kernels for Barrett-style modular arithmetic \label{ch:asm_barrett}\<close>
+
+text \<open>In this chapter we analyse three Neon ASM kernels for Barrett-style
+modular arithmetic and connect them to the corresponding abstract operators.
+In consequence, we obtain correctness and bounds statements for the kernel
+output.\<close>
+
+section \<open>Signed Barrett multiplication\<close>
+
+text \<open>We verify \cite[Algorithm~10, \S 3.2]{NeonNTT}: the three-instruction
+\<^verbatim>\<open>MUL\<close>/\<^verbatim>\<open>SQRDMULH\<close>/\<^verbatim>\<open>MLS\<close> sequence computes
+\<^term>\<open>barM\<^sup>\<plusminus>\<lbrakk>N,n,\<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a,b\<rangle>\<close> on signed lanes. The precomputed
+constant \<^term>\<open>bt\<close> carries half the round-to-even magic constant (halving
+is exact since round-to-even produces an even integer). The bound
+\<^term>\<open>\<bar>sint b\<bar> < sint N\<close> ensures \<^term>\<open>bt\<close> avoids the extreme negative
+value, excluding \<^verbatim>\<open>SQRDMULH\<close> saturation for any \<^term>\<open>a\<close>.\<close>
+
+definition %internal \<open>barrett_mul_neon_int n N b halfBT a \<equiv>
+     let R  = 2^n;
+         z1 = (a * b) mod\<^sup>\<plusminus> R;
+         t  = \<lfloor>2 * a * halfBT /\<^sub>\<rat> R\<rceil>;
+         z2 = (z1 - t * N) mod\<^sup>\<plusminus> R
+     in z2\<close>
+
+text %internal \<open>Halving the magic constant is harmless: doubling the second operand of a
+rounded high-half multiply exactly cancels the prior division by two, provided
+the magic constant is even.\<close>
+
+lemma %internal sqrdmulh_halved_eq:
+  fixes a m :: int and n :: nat
+  assumes \<open>even m\<close>
+  shows \<open>\<lfloor>2 * a * (m div 2) /\<^sub>\<rat> 2^n\<rceil> = \<lfloor>a * m /\<^sub>\<rat> 2^n\<rceil>\<close>
+  using assms by (simp add: algebra_simps)
+
+text %internal \<open>Fed \<^term>\<open>\<lfloor>b * R /\<^sub>\<rat> N\<rceil>\<^sub>2 div 2\<close>, the kernel equals \<^term>\<open>barM\<^sup>\<plusminus>\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a, b\<rangle>\<close> modulo
+the lane width. The ambient \<^term>\<open>x mod\<^sup>\<plusminus> R\<close> is identity once inputs are bounded. The
+round-to-even approximation produces an even integer, so \<^term>\<open>sqrdmulh_halved_eq\<close>
+applies to the magic constant \<^term>\<open>\<lfloor>b * R /\<^sub>\<rat> N\<rceil>\<^sub>2\<close>.\<close>
+
+lemma %internal barrett_mul_neon_int_eq:
+  fixes a b N :: int and n :: nat
+  defines \<open>m \<equiv> \<lfloor>b * 2^n /\<^sub>\<rat> N\<rceil>\<^sub>2\<close>
+  shows \<open>barrett_mul_neon_int n N b (m div 2) a
+           = barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a, b\<rangle> mod\<^sup>\<plusminus> 2^n\<close>
+proof -
+  have m_even: \<open>even m\<close>
+    unfolding m_def round_even_def by simp
+  let ?R = \<open>(2::int)^n\<close>
+  let ?t = \<open>\<lfloor>\<cdot>\<rceil> (a * m /\<^sub>\<rat> ?R)\<close>
+  define cc :: int where \<open>cc = \<lfloor>\<cdot>\<rceil> ((a * b) /\<^sub>\<rat> ?R)\<close>
+  have \<open>barrett_mul_neon_int n N b (m div 2) a
+          = ((a * b) mod\<^sup>\<plusminus> ?R - ?t * N) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_mul_neon_int_def Let_def
+    using sqrdmulh_halved_eq[OF m_even, of a n] by (simp add: algebra_simps)
+  also have \<open>\<dots> = (a * b - N * ?t) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding mod_approx_def cc_def[symmetric]
+    using mod_approx_shift[OF shift_compat_round, of ?R \<open>a * b - N * ?t\<close> \<open>-cc\<close>]
+    by (simp add: algebra_simps mod_approx_def)
+  also have \<open>\<dots> = barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a, b\<rangle> mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_mul_signed_def Let_def m_def by simp
+  finally show ?thesis .
+qed
+
+definition %internal barrett_mul_neon_word
+  :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>barrett_mul_neon_word N b halfBT a \<equiv>
+     let ASM \<guillemotleft>
+       MUL      z1 a b;
+       SQRDMULH t  a halfBT;
+       MLS      r  z1 t N
+     \<guillemotright> in r\<close>
+
+text %internal \<open>Under the absolute-value bounds and the standard cryptographic precondition
+on the modulus \<^term>\<open>N\<close>, the signed interpretation of the word-level kernel agrees
+with the integer model.\<close>
+
+lemma %internal sint_barrett_mul_neon_word:
+  fixes N b halfBT a :: \<open>'a::len word\<close>
+    and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes nondeg_halfBT: \<open>\<bar>sint halfBT\<bar> < 2^(n-1)\<close>
+  shows \<open>sint (barrett_mul_neon_word N b halfBT a)
+           = barrett_mul_neon_int n (sint N) (sint b) (sint halfBT) (sint a)\<close>
+proof -
+  let ?z1 = \<open>mul_word a b\<close>
+  let ?t  = \<open>sqrdmulh_word a halfBT\<close>
+  let ?R  = \<open>(2::int) ^ n\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have not_extreme: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint halfBT = -(2^(n-1)))\<close>
+    using nondeg_halfBT by linarith
+  have z1_int: \<open>sint ?z1 = (sint a * sint b) mod\<^sup>\<plusminus> ?R\<close>
+    by (rule sint_mul_word[OF n_def])
+  have t_int: \<open>sint ?t = sqrdmulh_int n (sint a) (sint halfBT)\<close>
+    by (rule sint_sqrdmulh_word[OF n_def not_extreme])
+  have \<open>sint (barrett_mul_neon_word N b halfBT a)
+          = (sint ?z1 - sint ?t * sint N) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_mul_neon_word_def Let_def
+    by (rule sint_mls_word[OF n_def])
+  also have \<open>\<dots> = ((sint a * sint b) mod\<^sup>\<plusminus> ?R
+                   - sqrdmulh_int n (sint a) (sint halfBT) * sint N) mod\<^sup>\<plusminus> ?R\<close>
+    using z1_int t_int by simp
+  also have \<open>\<dots> = barrett_mul_neon_int n (sint N) (sint b) (sint halfBT) (sint a)\<close>
+    unfolding barrett_mul_neon_int_def Let_def sqrdmulh_int_def
+    by simp
+  finally show ?thesis .
+qed
+
+text %internal \<open>A small-input identity for the canonical signed residue: when \<^term>\<open>2 * \<bar>x\<bar> < R\<close>,
+\<^term>\<open>x mod\<^sup>\<plusminus> R\<close> is just \<^term>\<open>x\<close>. Used to discharge the ambient \<^term>\<open>y mod\<^sup>\<plusminus> (2::int)^n\<close> in the
+small-input correctness theorems below.\<close>
+
+lemma %internal mod_approx_round_id_small:
+  fixes x R :: int
+  assumes \<open>0 < R\<close> and \<open>2 * \<bar>x\<bar> < R\<close>
+  shows \<open>x mod\<^sup>\<plusminus> R = x\<close>
+proof -
+  have iR_pos: \<open>0 < R\<^sub>\<rat>\<close> using assms(1) by simp
+  have \<open>\<bar>x /\<^sub>\<rat> R\<bar> < 1/2\<close>
+    using assms iR_pos by (simp add: abs_divide field_simps)
+  hence \<open>\<lfloor>x /\<^sub>\<rat> R\<rceil> = 0\<close>
+    unfolding round_def by linarith
+  thus ?thesis unfolding mod_approx_def by simp
+qed
+
+theorem barrett_mul_neon_word_correct:
+  fixes N a b bt :: \<open>'a::len word\<close> and n :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes bt_eq: \<open>sint bt = \<lfloor>sint b * 2^n /\<^sub>\<rat> sint N\<rceil>\<^sub>2 div 2\<close>
+      and N_std: \<open>StandardModulus (sint N) (n-1)\<close>
+      and b_bound: \<open>\<bar>sint b\<bar>\<^sub>\<rat> < (sint N)\<^sub>\<rat>\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    MUL      z1 a b;
+                    SQRDMULH t  a bt;
+                    MLS      r  z1 t N
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = barM\<^sup>\<plusminus> \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>sint a, sint b\<rangle>\<close>
+        \<comment> \<open>abstract description\<close>
+    and \<open>sint out mod sint N = (sint a * sint b) mod sint N\<close>
+        \<comment> \<open>correctness\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar> * sint N /\<^sub>\<rat> 2^n + sint N /\<^sub>\<rat> 2\<close>
+        \<comment> \<open>fine output bound\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (sint N)\<^sub>\<rat>\<close>
+        \<comment> \<open>coarse output bound\<close>
+proof -
+  define m where \<open>m \<equiv> \<lfloor>sint b * 2^n /\<^sub>\<rat> sint N\<rceil>\<^sub>2\<close>
+  have halfBT_eq: \<open>sint bt = m div 2\<close> using bt_eq unfolding m_def .
+
+  interpret SM: StandardModulus \<open>sint N\<close> \<open>n-1\<close> by (rule N_std)
+  have npos: \<open>0 < n\<close> using SM.npos by simp
+  have N_lt: \<open>sint N < 2^(n-1)\<close> using SM.N_lt_R .
+  have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close> using npos by (cases n) auto
+  have N2_bound: \<open>2 * sint N < 2^n\<close> using N_lt R_eq by linarith
+  have N_lt_R: \<open>sint N < 2^n\<close>
+  proof -
+    have \<open>(2::int)^(n-1) \<le> 2^n\<close> by (rule power_increasing) auto
+    thus ?thesis using N_lt by linarith
+  qed
+  \<comment> \<open>Derive non-degeneracy of halfBT from b being signed-canonical\<close>
+  have N_pos_int: \<open>(0::int) < sint N\<close> using SM.Npos .
+  have N_pos_rat: \<open>(0::rat) < (sint N)\<^sub>\<rat>\<close>
+    using N_pos_int by (metis of_int_0_less_iff)
+  have b_int: \<open>\<bar>sint b\<bar> < sint N\<close>
+    using b_bound by (metis of_int_abs of_int_less_iff)
+  \<comment> \<open>From $|sint b| < N$ and $N < 2^{n-1}$: $value = sint b * 2^n / N$ has
+      $|value| < 2^n$. Round-to-even adds at most 1 to magnitude, so $|m| \le 2^n$.
+      The bad case for halfBT is $m \in \{-2^n, -2^n+1\}$ (giving $m \div 2 = -2^{n-1}$).
+      We exclude this using $value > -2^n + 2$ (from $sint b \ge -N + 1$ and $2^n/N > 2$).\<close>
+  have approx_err: \<open>\<bar>sint b * 2^n /\<^sub>\<rat> sint N - (\<lfloor>sint b * 2^n /\<^sub>\<rat> sint N\<rceil>\<^sub>2)\<^sub>\<rat>\<bar> \<le> 1\<close>
+    using is_int_approx_round_even[unfolded is_int_approx_def, rule_format] .
+  have N_lt_R: \<open>2 * sint N < 2^n\<close>
+    using N_lt R_eq by linarith
+  have val_gt: \<open>sint b * 2^n /\<^sub>\<rat> sint N > -((2^n)\<^sub>\<rat>) + 2\<close>
+  proof -
+    have b_lo: \<open>sint b \<ge> -sint N + 1\<close> using b_int by linarith
+    have prod_lo: \<open>sint b * 2^n \<ge> -sint N * 2^n + 2^n\<close>
+    proof -
+      have \<open>sint b * 2^n \<ge> (-sint N + 1) * 2^n\<close>
+        using b_lo by (intro mult_right_mono) auto
+      thus ?thesis by (simp add: algebra_simps)
+    qed
+    have prod_lo': \<open>sint b * 2^n > -sint N * 2^n + 2 * sint N\<close>
+      using prod_lo N_lt_R by linarith
+    have rat_lo: \<open>(sint b * 2^n)\<^sub>\<rat> > (-sint N * 2^n + 2 * sint N)\<^sub>\<rat>\<close>
+      using prod_lo' by (metis of_int_less_iff)
+    have val_eq: \<open>sint b * 2^n /\<^sub>\<rat> sint N = (sint b * 2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>\<close>
+      by (simp add: of_int_mult)
+    have rhs_eq: \<open>(-sint N * 2^n + 2 * sint N)\<^sub>\<rat> / (sint N)\<^sub>\<rat> = -((2^n)\<^sub>\<rat>) + 2\<close>
+      using N_pos_rat by (simp add: of_int_mult of_int_add of_int_minus
+                                     field_simps)
+    have \<open>(sint b * 2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>
+            > (-sint N * 2^n + 2 * sint N)\<^sub>\<rat> / (sint N)\<^sub>\<rat>\<close>
+      using rat_lo N_pos_rat by (intro divide_strict_right_mono) auto
+    thus ?thesis using val_eq rhs_eq by simp
+  qed
+  have val_lt: \<open>sint b * 2^n /\<^sub>\<rat> sint N < (2^n)\<^sub>\<rat>\<close>
+  proof -
+    have b_hi: \<open>sint b < sint N\<close> using b_int by linarith
+    have prod_hi: \<open>sint b * 2^n < sint N * 2^n\<close>
+      using b_hi by (intro mult_strict_right_mono) auto
+    hence \<open>(sint b * 2^n)\<^sub>\<rat> < (sint N * 2^n)\<^sub>\<rat>\<close> by (metis of_int_less_iff)
+    hence \<open>(sint b * 2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat> < (sint N * 2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>\<close>
+      using N_pos_rat by (intro divide_strict_right_mono) auto
+    also have \<open>(sint N * 2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat> = (2^n)\<^sub>\<rat>\<close>
+      using N_pos_rat by (simp add: of_int_mult)
+    finally show ?thesis by (simp add: of_int_mult)
+  qed
+  have nondeg_halfBT: \<open>\<bar>sint bt\<bar> < 2^(n-1)\<close>
+  proof -
+    \<comment> \<open>From $|value - m_\rat| \le 1$, $value > -2^n + 2$, and $value < 2^n$:
+        $m_\rat > -2^n + 1$ and $m_\rat < 2^n + 1$, hence $m \ge -2^n + 2$ and $m \le 2^n$.\<close>
+    have m_lo: \<open>m \<ge> -(2^n) + 2\<close>
+    proof -
+      have \<open>(m)\<^sub>\<rat> > -((2^n)\<^sub>\<rat>) + 1\<close>
+        using val_gt approx_err unfolding m_def by linarith
+      hence \<open>(m)\<^sub>\<rat> > (-(2^n) + 1)\<^sub>\<rat>\<close>
+        by (simp add: of_int_add of_int_minus)
+      hence \<open>m > -(2^n) + 1\<close> by (metis of_int_less_iff)
+      thus ?thesis by linarith
+    qed
+    have m_hi: \<open>m \<le> 2^n\<close>
+    proof -
+      have \<open>(m)\<^sub>\<rat> < (2^n)\<^sub>\<rat> + 1\<close>
+        using val_lt approx_err unfolding m_def by linarith
+      hence \<open>(m)\<^sub>\<rat> < (2^n + 1)\<^sub>\<rat>\<close> by (simp add: of_int_add)
+      hence \<open>m < 2^n + 1\<close> by (metis of_int_less_iff)
+      thus ?thesis by linarith
+    qed
+    \<comment> \<open>From $-2^n + 2 \le m \le 2^n$ and $halfBT = m \div 2$: $-2^{n-1} + 1 \le halfBT \le 2^{n-1}$.
+        But $sint halfBT < 2^{n-1}$ always (word width), so $halfBT \le 2^{n-1} - 1$.\<close>
+    have nge: \<open>n \<ge> 2\<close> using SM.npos by linarith
+    have pow_split: \<open>(2::int)^n = 2 * 2^(n-1)\<close> using R_eq .
+    have hi_div: \<open>m div 2 \<le> 2^(n-1)\<close>
+    proof -
+      have \<open>m div 2 \<le> 2^n div 2\<close> using m_hi by (intro zdiv_mono1) auto
+      also have \<open>(2::int)^n div 2 = 2^(n-1)\<close>
+        using pow_split by (metis nonzero_mult_div_cancel_left zero_neq_numeral)
+      finally show ?thesis .
+    qed
+    have lo_div: \<open>m div 2 \<ge> -(2^(n-1)) + 1\<close>
+    proof -
+      have \<open>m div 2 \<ge> (-(2^n) + 2) div 2\<close> using m_lo by (intro zdiv_mono1) auto
+      also have \<open>(-((2::int)^n) + 2) div 2 = -(2^(n-1)) + 1\<close>
+        using pow_split by simp
+      finally show ?thesis .
+    qed
+    have halfBT_range: \<open>-(2^(n-1)) + 1 \<le> sint bt \<and> sint bt \<le> 2^(n-1)\<close>
+      using halfBT_eq lo_div hi_div by simp
+    \<comment> \<open>The upper end is automatically tighter via word width: $sint halfBT < 2^{n-1}$.\<close>
+    have halfBT_word: \<open>sint bt < 2^(n-1)\<close>
+      using sint_range_size[of bt] by (simp add: word_size n_def)
+    show ?thesis using halfBT_range halfBT_word by linarith
+  qed
+
+  \<comment> \<open>sint a is bounded by the word width (always true)\<close>
+  have a_range: \<open>-(2^(n-1)) \<le> sint a \<and> sint a < 2^(n-1)\<close>
+    using sint_range_size[of a] by (simp add: word_size n_def)
+  have a_le_R2: \<open>\<bar>sint a\<bar> \<le> 2^(n-1)\<close> using a_range by linarith
+  \<comment> \<open>For SQRDMULH: halfBT not INT_MIN suffices\<close>
+  have nondeg_a_or: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint bt = -(2^(n-1)))\<close>
+    using nondeg_halfBT by linarith
+  let ?abs = \<open>barM\<^sup>\<plusminus> \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>sint a, sint b\<rangle>\<close>
+  interpret BMS: BarrettContext \<open>sint N\<close> n \<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close>
+    using SM.Ngt1 SM.Nodd npos N_lt_R is_int_approx_round_even
+    by unfold_locales (auto simp: IntegerApproximation_def)
+  \<comment> \<open>Barrett output bound: uses |sint a| \<le> 2^(n-1) (word-width constraint)\<close>
+  have abs_bound: \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+  proof -
+    have B: \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * ((sint N)\<^sub>\<rat> * \<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2)) / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+      using BMS.barrett_mul_signed_bound_eps[OF is_int_approx_quality_round_even,
+                                              of \<open>sint a\<close> \<open>sint b\<close>]
+      by simp
+    have \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2) = 1\<close> by (rule quality_round_even)
+    thus ?thesis using B by simp
+  qed
+  \<comment> \<open>The abstract result fits in the lane: \<open>|barM\<^sup>\<plusminus>| \<le> N/2 + N/2 = N \<le> 2^(n-1)\<close>\<close>
+  have abs_lt_R2: \<open>\<bar>?abs\<bar> < 2^(n-1)\<close>
+  proof -
+    have \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+      by (rule abs_bound)
+    also have \<open>\<dots> \<le> (2^(n-1))\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+    proof -
+      have h1: \<open>\<bar>sint a\<bar>\<^sub>\<rat> \<le> (2^(n-1))\<^sub>\<rat>\<close>
+        using a_le_R2 by (metis of_int_abs of_int_le_iff of_int_numeral of_int_power)
+      have h2: \<open>0 \<le> (sint N)\<^sub>\<rat>\<close>
+        using SM.Npos by (metis of_int_0_le_iff order_less_imp_le)
+      have h3: \<open>(0::rat) < (2^n)\<^sub>\<rat>\<close> by simp
+      from h1 h2 have step1: \<open>\<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> \<le> (2^(n-1))\<^sub>\<rat> * (sint N)\<^sub>\<rat>\<close>
+        by (intro mult_right_mono)
+      hence \<open>\<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat>
+                \<le> (2^(n-1))\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat>\<close>
+        using h3 by (intro divide_right_mono) auto
+      thus ?thesis by linarith
+    qed
+    also have \<open>\<dots> = (sint N)\<^sub>\<rat> / 2 + (sint N)\<^sub>\<rat> / 2\<close>
+      using R_eq by simp
+    also have \<open>\<dots> = (sint N)\<^sub>\<rat>\<close> by simp
+    also have \<open>\<dots> < (2^(n-1))\<^sub>\<rat>\<close> using N_lt by (metis of_int_less_iff of_int_of_nat_eq)
+    finally show ?thesis by (metis of_int_abs of_int_less_iff)
+  qed
+  have small: \<open>2 * \<bar>?abs\<bar> < 2^n\<close>
+    using abs_lt_R2 R_eq by linarith
+  have R_pos: \<open>(0::int) < 2^n\<close> by simp
+  have id_eq: \<open>?abs mod\<^sup>\<plusminus> 2^n = ?abs\<close>
+    by (rule mod_approx_round_id_small[OF R_pos small])
+  have step1: \<open>sint (barrett_mul_neon_word N b bt a)
+                 = barrett_mul_neon_int n (sint N) (sint b) (sint bt) (sint a)\<close>
+    by (rule sint_barrett_mul_neon_word[OF n_def nondeg_halfBT])
+  have step2: \<open>barrett_mul_neon_int n (sint N) (sint b) (sint bt) (sint a)
+                 = barrett_mul_neon_int n (sint N) (sint b) (m div 2) (sint a)\<close>
+    using halfBT_eq by simp
+  have step3: \<open>barrett_mul_neon_int n (sint N) (sint b) (m div 2) (sint a)
+                 = ?abs mod\<^sup>\<plusminus> 2^n\<close>
+    using barrett_mul_neon_int_eq[where N=\<open>sint N\<close> and b=\<open>sint b\<close> and a=\<open>sint a\<close>
+                                    and n=\<open>n\<close>]
+          m_def
+    by simp
+  have abs_eq: \<open>sint out = ?abs\<close>
+    unfolding out_def barrett_mul_neon_word_def[symmetric]
+    using step1 step2 step3 id_eq by simp
+  show \<open>sint out = barM\<^sup>\<plusminus> \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>sint a, sint b\<rangle>\<close>
+    by (rule abs_eq)
+  define K :: int where \<open>K \<equiv> \<lfloor>(sint a)\<^sub>\<rat> * \<lfloor>(sint b)\<^sub>\<rat> * (2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>\<rceil>\<^sub>2\<^sub>\<rat> / (2^n)\<^sub>\<rat>\<rceil>\<close>
+  have abs_decomp: \<open>?abs = sint a * sint b - sint N * K\<close>
+    unfolding barrett_mul_signed_def Let_def K_def by simp
+  have mod_eq: \<open>?abs mod sint N = (sint a * sint b) mod sint N\<close>
+    unfolding abs_decomp by algebra
+  show \<open>sint out mod sint N = (sint a * sint b) mod sint N\<close>
+    using abs_eq mod_eq by simp
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar> * sint N /\<^sub>\<rat> 2^n + sint N /\<^sub>\<rat> 2\<close>
+    using abs_eq abs_bound by simp
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (sint N)\<^sub>\<rat>\<close>
+  proof (cases \<open>sint b = 0\<close>)
+    case True    have \<open>?abs = 0\<close>
+    proof -
+      have fl: \<open>\<lfloor>(1/2 :: rat)\<rfloor> = 0\<close> by linarith
+      show ?thesis using True
+        unfolding barrett_mul_signed_def Let_def m_def round_even_def round_def
+        by (simp add: fl)
+    qed
+    thus ?thesis using abs_eq N_pos_int by linarith
+  next
+    case False
+    hence b_ne: \<open>sint b \<noteq> 0\<close> .
+    have \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> < (sint N)\<^sub>\<rat>\<close>
+      using BMS.barrett_mul_narrow(1)[OF a_le_R2 b_int b_ne] .
+    thus ?thesis using abs_eq by simp
+  qed
+qed
+
+section \<open>Unsigned-style Barrett multiplication\<close>
+
+text \<open>Replacing \<^verbatim>\<open>SQRDMULH\<close> with truncating \<^verbatim>\<open>MULH\<close>, the three-instruction
+\<^verbatim>\<open>MUL\<close>/\<^verbatim>\<open>MULH\<close>/\<^verbatim>\<open>MLS\<close> sequence computes
+\<^term>\<open>barM\<^sup>+\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>\<close> on signed lanes. The coarse output
+bound is \<^term>\<open>5*N /\<^sub>\<rat> 4\<close> rather than \<^term>\<open>(N::int)\<close>, requiring a
+correspondingly tighter modulus constraint
+\<^term>\<open>StandardModulus N (n-2)\<close>.\<close>
+
+
+
+definition %internal \<open>barrett_mul_unsigned_neon_int n N b m a \<equiv>
+     (let R = (2::int)^n;
+          z1 = (a * b) mod\<^sup>\<plusminus> R;
+          t  = (a * m) div R;
+          z2 = (z1 - t * N) mod\<^sup>\<plusminus> R
+      in z2)\<close>
+
+lemma %internal barrett_mul_unsigned_neon_int_eq:
+  fixes a b N :: int and n :: nat
+    and f :: \<open>rat \<Rightarrow> int\<close>  \<comment> \<open>integer approximation used for the precomputed magic constant\<close>
+  defines \<open>m \<equiv> f (b * 2^n /\<^sub>\<rat> N)\<close>
+  shows \<open>barrett_mul_unsigned_neon_int n N b m a
+           = barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> mod\<^sup>\<plusminus> 2^n\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?t = \<open>(a * m) div ?R\<close>
+  have div_eq: \<open>\<lfloor>a * m /\<^sub>\<rat> ?R\<rfloor> = (a * m) div ?R\<close>
+    using floor_divide_of_int_eq[of \<open>a*m\<close> \<open>?R\<close>] by (simp add: of_int_mult)
+  have br_unfold: \<open>barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = a * b - N * ?t\<close>
+    unfolding barrett_mul_unsigned_def Let_def m_def[symmetric]
+    using div_eq by simp
+  have \<open>barrett_mul_unsigned_neon_int n N b m a = ((a * b) mod\<^sup>\<plusminus> ?R - ?t * N) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_mul_unsigned_neon_int_def Let_def by simp
+  also have \<open>\<dots> = (a * b - ?t * N) mod\<^sup>\<plusminus> ?R\<close>
+    using mod_approx_shift[OF shift_compat_round, of ?R \<open>a*b - ?t*N\<close> \<open>- \<lfloor>\<cdot>\<rceil> ((a*b) /\<^sub>\<rat> ?R)\<close>]
+    by (simp add: mod_approx_def algebra_simps)
+  finally show ?thesis using br_unfold by (simp add: mult.commute)
+qed
+
+text %internal \<open>The integer-level kernel transcribes verbatim onto fixed-width signed
+lanes: \<^const>\<open>mul_word\<close>, \<^const>\<open>mulh_word\<close> and \<^const>\<open>mls_word\<close> all match
+their integer specifications without saturation, so the word kernel computes
+exactly the integer kernel on \<^const>\<open>sint\<close>-projected operands.\<close>
+
+definition %internal barrett_mul_unsigned_neon_word
+  :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>barrett_mul_unsigned_neon_word N b m a \<equiv>
+     let ASM \<guillemotleft>
+       MUL  z1 a b;
+       MULH t  a m;
+       MLS  r  z1 t N
+     \<guillemotright> in r\<close>
+
+lemma %internal sint_barrett_mul_unsigned_neon_word:
+  fixes N b m a :: \<open>'a::len word\<close>
+    and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (barrett_mul_unsigned_neon_word N b m a)
+           = barrett_mul_unsigned_neon_int n (sint N) (sint b) (sint m) (sint a)\<close>
+proof -
+  let ?z1 = \<open>mul_word a b\<close>
+  let ?t  = \<open>mulh_word a m\<close>
+  let ?R  = \<open>(2::int) ^ n\<close>
+  have z1_int: \<open>sint ?z1 = (sint a * sint b) mod\<^sup>\<plusminus> ?R\<close>
+    by (rule sint_mul_word[OF n_def])
+  have t_int: \<open>sint ?t = mulh_int n (sint a) (sint m)\<close>
+    by (rule sint_mulh_word[OF n_def])
+  have \<open>sint (barrett_mul_unsigned_neon_word N b m a)
+          = (sint ?z1 - sint ?t * sint N) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_mul_unsigned_neon_word_def Let_def
+    by (rule sint_mls_word[OF n_def])
+  also have \<open>\<dots> = ((sint a * sint b) mod\<^sup>\<plusminus> ?R
+                   - mulh_int n (sint a) (sint m) * sint N) mod\<^sup>\<plusminus> ?R\<close>
+    using z1_int t_int by simp
+  also have \<open>\<dots> = barrett_mul_unsigned_neon_int n (sint N) (sint b) (sint m) (sint a)\<close>
+    unfolding barrett_mul_unsigned_neon_int_def Let_def mulh_int_def
+    by simp
+  finally show ?thesis .
+qed
+
+theorem barrett_mul_unsigned_neon_word_correct:
+  fixes N a b m :: \<open>'a::len word\<close> and n :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes m_eq: \<open>sint m = \<lfloor>sint b * 2^n /\<^sub>\<rat> sint N\<rceil>\<close>
+      and N_std: \<open>StandardModulus (sint N) (n-2)\<close>
+      and b_bound: \<open>\<bar>sint b\<bar>\<^sub>\<rat> < (sint N)\<^sub>\<rat>\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    MUL  z1 a b;
+                    MULH t  a m;
+                    MLS  r  z1 t N
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = barM\<^sup>+ \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>sint a, sint b\<rangle>\<close>
+        \<comment> \<open>functional description\<close>
+    and \<open>sint out mod sint N = (sint a * sint b) mod sint N\<close>
+        \<comment> \<open>correctness\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat>\<close>
+        \<comment> \<open>fine output bound\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < 5 * (sint N)\<^sub>\<rat> / 4\<close>
+        \<comment> \<open>coarse output bound\<close>
+
+proof -
+  interpret SM: StandardModulus \<open>sint N\<close> \<open>n-2\<close> by (rule N_std)
+  have npos: \<open>0 < n\<close> using SM.npos by simp
+  have N_lt: \<open>sint N < 2^(n-2)\<close> using SM.N_lt_R .
+  have N_lt_R: \<open>sint N < 2^n\<close>
+  proof -
+    have \<open>(2::int)^(n-2) \<le> 2^n\<close> by (rule power_increasing) auto
+    thus ?thesis using N_lt by linarith
+  qed
+  have N3_bound: \<open>3 * sint N < 2^n\<close>
+  proof -
+    have n2: \<open>2 \<le> n\<close> using SM.npos by simp
+    have \<open>3 * sint N < 3 * 2^(n-2)\<close> using N_lt SM.Npos by linarith
+    also have \<open>\<dots> < (4::int) * 2^(n-2)\<close> by simp
+    also have \<open>\<dots> = 2^n\<close>
+    proof -
+      have \<open>(4::int) = 2^2\<close> by simp
+      hence \<open>(4::int) * 2^(n-2) = 2^2 * 2^(n-2)\<close> by simp
+      also have \<open>\<dots> = 2^(2 + (n-2))\<close> by (simp add: power_add)
+      also have \<open>2 + (n-2) = n\<close> using n2 by simp
+      finally show ?thesis .
+    qed
+    finally show ?thesis .
+  qed
+
+  have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close> using npos by (cases n) auto
+  have N_pos_int: \<open>(0::int) < sint N\<close> using SM.Npos .
+  have N_pos_rat: \<open>(0::rat) < (sint N)\<^sub>\<rat>\<close>
+    using N_pos_int by (metis of_int_0_less_iff)
+  \<comment> \<open>sint a is bounded by the word width\<close>
+  have a_range: \<open>-(2^(n-1)) \<le> sint a \<and> sint a < 2^(n-1)\<close>
+    using sint_range_size[of a] by (simp add: word_size n_def)
+  have a_le_R2: \<open>\<bar>sint a\<bar> \<le> 2^(n-1)\<close> using a_range by linarith
+  let ?abs = \<open>barM\<^sup>+ \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>sint a, sint b\<rangle>\<close>
+  have Ngt1: \<open>1 < sint N\<close> using SM.Ngt1 .
+  have Nodd: \<open>odd (sint N)\<close> using SM.Nodd .
+  interpret BMS: BarrettContext \<open>sint N\<close> n \<open>\<lfloor>\<cdot>\<rceil>\<close>
+    using Ngt1 Nodd npos N_lt_R is_int_approx_round
+    by unfold_locales (auto simp: IntegerApproximation_def)
+
+
+  have abs_bound: \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat>\<close>
+  proof -
+    have B: \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * ((sint N)\<^sub>\<rat> * \<epsilon>(\<lfloor>\<cdot>\<rceil>)) / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> - sint N /\<^sub>\<rat> 2^n\<close>
+      using BMS.barrett_mul_unsigned_bound_eps[OF is_int_approx_quality_round,
+                                                of \<open>sint a\<close> \<open>sint b\<close>]
+      by simp
+    have eps_le: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>) = 1/2\<close> by (rule quality_round)
+    have nn: \<open>0 \<le> (sint N)\<^sub>\<rat> / (2^n :: int)\<^sub>\<rat>\<close>
+      using N_pos_rat by simp
+    have h2: \<open>0 \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat>\<close>
+      using N_pos_rat by simp
+    from B eps_le nn h2 show ?thesis by simp
+  qed
+  have abs_lt_R2: \<open>2 * \<bar>?abs\<bar> < 2^n\<close>
+  proof -
+    have \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat>\<close>
+      by (rule abs_bound)
+    also have \<open>\<dots> \<le> (2^(n-1))\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat>\<close>
+    proof -
+      have h1: \<open>\<bar>sint a\<bar>\<^sub>\<rat> \<le> (2^(n-1))\<^sub>\<rat>\<close>
+        using a_le_R2 by (metis of_int_abs of_int_le_iff of_int_numeral of_int_power)
+      have h2: \<open>0 \<le> (sint N)\<^sub>\<rat>\<close> using N_pos_rat by linarith
+      have h3: \<open>(0::rat) < (2^n)\<^sub>\<rat>\<close> by simp
+      from h1 h2 have \<open>\<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> \<le> (2^(n-1))\<^sub>\<rat> * (sint N)\<^sub>\<rat>\<close>
+        by (intro mult_right_mono)
+      hence \<open>\<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat>
+                \<le> (2^(n-1))\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat>\<close>
+        using h3 by (intro divide_right_mono) auto
+      thus ?thesis by linarith
+    qed
+    also have \<open>\<dots> = (sint N)\<^sub>\<rat> / 2 + (sint N)\<^sub>\<rat>\<close> using R_eq by simp
+    also have \<open>\<dots> = 3/2 * (sint N)\<^sub>\<rat>\<close> by simp
+    finally have rat_bd: \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> \<le> 3/2 * (sint N)\<^sub>\<rat>\<close> .
+    hence rat_bd2: \<open>(2 * \<bar>?abs\<bar>)\<^sub>\<rat> \<le> (3 * sint N)\<^sub>\<rat>\<close>
+      by (simp add: of_int_mult of_int_abs)
+    hence int_bd: \<open>2 * \<bar>?abs\<bar> \<le> 3 * sint N\<close> by (metis of_int_le_iff)
+    thus ?thesis using N3_bound by linarith
+  qed
+  have small: \<open>2 * \<bar>?abs\<bar> < 2^n\<close> by (rule abs_lt_R2)
+  have R_pos: \<open>(0::int) < 2^n\<close> by simp
+  have id_eq: \<open>?abs mod\<^sup>\<plusminus> 2^n = ?abs\<close>
+    by (rule mod_approx_round_id_small[OF R_pos small])
+  have m_eq': \<open>sint m = \<lfloor>\<cdot>\<rceil> ((sint b)\<^sub>\<rat> * (2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>)\<close>
+    using m_eq by simp
+  have step1: \<open>sint (barrett_mul_unsigned_neon_word N b m a)
+                 = barrett_mul_unsigned_neon_int n (sint N) (sint b) (sint m) (sint a)\<close>
+    by (rule sint_barrett_mul_unsigned_neon_word[OF n_def])
+  have step2: \<open>barrett_mul_unsigned_neon_int n (sint N) (sint b) (sint m) (sint a)
+                 = barrett_mul_unsigned_neon_int n (sint N) (sint b)
+                     (\<lfloor>\<cdot>\<rceil> ((sint b)\<^sub>\<rat> * (2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>)) (sint a)\<close>
+    using m_eq' by simp
+  have step3: \<open>barrett_mul_unsigned_neon_int n (sint N) (sint b)
+                  (\<lfloor>\<cdot>\<rceil> ((sint b)\<^sub>\<rat> * (2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>)) (sint a)
+                 = ?abs mod\<^sup>\<plusminus> 2^n\<close>
+    using barrett_mul_unsigned_neon_int_eq[where N=\<open>sint N\<close> and b=\<open>sint b\<close> and a=\<open>sint a\<close>
+                                              and n=\<open>n\<close> and f=round]
+    by simp
+  have abs_eq: \<open>sint out = ?abs\<close>
+    unfolding out_def barrett_mul_unsigned_neon_word_def[symmetric]
+    using step1 step2 step3 id_eq by simp
+  show \<open>sint out = barM\<^sup>+ \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>sint a, sint b\<rangle>\<close>
+    by (rule abs_eq)
+  define K :: int where \<open>K \<equiv> \<lfloor>(sint a)\<^sub>\<rat> * \<lfloor>(sint b)\<^sub>\<rat> * (2^n)\<^sub>\<rat> / (sint N)\<^sub>\<rat>\<rceil>\<^sub>\<rat> / (2^n)\<^sub>\<rat>\<rfloor>\<close>
+  have abs_decomp: \<open>?abs = sint a * sint b - sint N * K\<close>
+    unfolding barrett_mul_unsigned_def Let_def K_def by simp
+  have mod_eq: \<open>?abs mod sint N = (sint a * sint b) mod sint N\<close>
+    unfolding abs_decomp by algebra
+  show \<open>sint out mod sint N = (sint a * sint b) mod sint N\<close>
+    using abs_eq mod_eq by simp
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat>\<close>
+    using abs_eq abs_bound by simp
+  have b_int: \<open>\<bar>sint b\<bar> < sint N\<close>
+    using b_bound by (metis of_int_abs of_int_less_iff)
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < 5 * (sint N)\<^sub>\<rat> / 4\<close>
+  proof (cases \<open>sint b = 0\<close>)
+    case True
+    have \<open>?abs = 0\<close>
+    proof -
+      have fl: \<open>\<lfloor>(1/2 :: rat)\<rfloor> = 0\<close> by linarith
+      show ?thesis using True
+        unfolding barrett_mul_unsigned_def Let_def round_def
+        by (simp add: fl)
+    qed
+    thus ?thesis using abs_eq N_pos_int by linarith
+  next
+    case False
+    hence b_ne: \<open>sint b \<noteq> 0\<close> .
+    have \<open>\<bar>(?abs)\<^sub>\<rat>\<bar> < 5 * (sint N)\<^sub>\<rat> / 4\<close>
+      using BMS.barrett_mul_narrow(3)[OF a_le_R2 b_int b_ne] by simp
+
+    thus ?thesis using abs_eq by simp
+  qed
+qed
+
+section \<open>Single-input Barrett reduction\<close>
+
+text \<open>We verify \cite[Algorithm~9, \S 3.2]{NeonNTT}: the two-instruction
+\<^verbatim>\<open>SQRDMULH\<close>/\<^verbatim>\<open>MLS\<close> sequence computes
+\<^term>\<open>bar\<^sup>\<plusminus>\<lbrakk>N,n,\<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> z\<close> on signed lanes.\<close>
+
+
+definition %internal \<open>barrett_red_neon_int n N halfM z \<equiv>
+     (let R = 2^n;
+          t = \<lfloor>\<cdot>\<rceil> ((2 * z * halfM) /\<^sub>\<rat> R)
+      in (z - t * N) mod\<^sup>\<plusminus> R)\<close>
+
+text %internal \<open>Fed half of the round-to-even magic constant, the kernel equals the
+abstract single-input Barrett reduction operator modulo the lane width.\<close>
+
+lemma %internal barrett_red_neon_int_eq:
+  fixes z N :: int and n :: nat
+  defines \<open>m \<equiv> \<lfloor>2^n /\<^sub>\<rat> N\<rceil>\<^sub>2\<close>
+  shows \<open>barrett_red_neon_int n N (m div 2) z = bar\<^sup>\<plusminus>\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> z mod\<^sup>\<plusminus> 2^n\<close>
+proof -
+  have m_even: \<open>even m\<close>
+    unfolding m_def round_even_def by simp
+  have step1: \<open>\<lfloor>\<cdot>\<rceil> ((2 * z * (m div 2)) /\<^sub>\<rat> (2^n))
+                 = \<lfloor>\<cdot>\<rceil> ((z * m) /\<^sub>\<rat> (2^n))\<close>
+    using sqrdmulh_halved_eq[OF m_even, of z n] by simp
+  have step2: \<open>(z * m) /\<^sub>\<rat> (2^n) = z\<^sub>\<rat> * m\<^sub>\<rat> / (2^n)\<^sub>\<rat>\<close>
+    by (simp add: of_int_mult)
+  have br_unfold: \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> z
+                   = z - N * \<lfloor>\<cdot>\<rceil> (z\<^sub>\<rat> * m\<^sub>\<rat> / (2^n)\<^sub>\<rat>)\<close>
+    unfolding barrett_red_signed_def m_def by simp
+  let ?R = \<open>(2::int)^n\<close>
+  let ?t = \<open>\<lfloor>\<cdot>\<rceil> (z\<^sub>\<rat> * m\<^sub>\<rat> / ?R\<^sub>\<rat>)\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have neon_unfold: \<open>barrett_red_neon_int n N (m div 2) z = (z - ?t * N) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_red_neon_int_def Let_def
+    using step1 step2 by (simp add: algebra_simps)
+  have comm: \<open>z - ?t * N = z - N * ?t\<close> by simp
+  have \<open>barrett_red_neon_int n N (m div 2) z = (z - ?t * N) mod\<^sup>\<plusminus> ?R\<close>
+    using neon_unfold by simp
+  also have \<open>\<dots> = (z - N * ?t) mod\<^sup>\<plusminus> ?R\<close>
+    by (subst comm) (rule refl)
+  also have \<open>\<dots> = (bar\<^sup>\<plusminus>\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> z) mod\<^sup>\<plusminus> ?R\<close>
+    using br_unfold by simp
+  finally show ?thesis .
+qed
+
+text %internal \<open>The integer-level reduction kernel transcribes onto fixed-width signed
+lanes provided the saturation case for \<^const>\<open>sqrdmulh_word\<close> is excluded;
+\<^const>\<open>mls_word\<close> matches its integer specification unconditionally.\<close>
+
+definition %internal barrett_red_neon_word
+  :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>barrett_red_neon_word N halfM z \<equiv>
+     let ASM \<guillemotleft>
+       SQRDMULH t z halfM;
+       MLS      r z t N
+     \<guillemotright> in r\<close>
+
+lemma %internal sint_barrett_red_neon_word:
+  fixes N halfM z :: \<open>'a::len word\<close>
+    and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes nondeg_halfM: \<open>\<bar>sint halfM\<bar> < 2^(n-1)\<close>
+    shows \<open>sint (barrett_red_neon_word N halfM z)
+              = barrett_red_neon_int n (sint N) (sint halfM) (sint z)\<close>
+proof -
+  let ?t = \<open>sqrdmulh_word z halfM\<close>
+  let ?R = \<open>(2::int) ^ n\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have not_extreme: \<open>\<not> (sint z = -(2^(n-1)) \<and> sint halfM = -(2^(n-1)))\<close>
+    using nondeg_halfM by linarith
+  have t_int: \<open>sint ?t = sqrdmulh_int n (sint z) (sint halfM)\<close>
+    by (rule sint_sqrdmulh_word[OF n_def not_extreme])
+  have \<open>sint (barrett_red_neon_word N halfM z) = (sint z - sint ?t * sint N) mod\<^sup>\<plusminus> ?R\<close>
+    unfolding barrett_red_neon_word_def Let_def
+    by (rule sint_mls_word[OF n_def])
+  also have \<open>\<dots> = (sint z - sqrdmulh_int n (sint z) (sint halfM) * sint N) mod\<^sup>\<plusminus> ?R\<close>
+    using t_int by simp
+  also have \<open>\<dots> = barrett_red_neon_int n (sint N) (sint halfM) (sint z)\<close>
+    unfolding barrett_red_neon_int_def Let_def sqrdmulh_int_def
+    by simp
+  finally show ?thesis .
+qed
+
+theorem barrett_red_neon_word_correct:
+  fixes N Nt z :: \<open>'a::len word\<close>
+    and n :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes Nt_eq: \<open>sint Nt = \<lfloor>2^n /\<^sub>\<rat> sint N\<rceil>\<^sub>2 div 2\<close>
+      and N_std: \<open>StandardModulus (sint N) (n-2)\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQRDMULH t z Nt;
+                    MLS      r z t N
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z)\<close>
+        \<comment> \<open>abstract description\<close>
+    and \<open>sint out mod sint N = sint z mod sint N\<close>
+        \<comment> \<open>correctness\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint z\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+        \<comment> \<open>fine output bound\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> 3/2 * (sint N)\<^sub>\<rat>\<close>
+        \<comment> \<open>coarse output bound\<close>
+
+proof -
+  define m where \<open>m \<equiv> \<lfloor>2^n /\<^sub>\<rat> sint N\<rceil>\<^sub>2\<close>
+  have halfM_eq: \<open>sint Nt = m div 2\<close> using Nt_eq unfolding m_def .
+  interpret SM: StandardModulus \<open>sint N\<close> \<open>n-2\<close> by (rule N_std)
+
+  have n_ge_2: \<open>n \<ge> 2\<close> using SM.npos by simp
+  have npos: \<open>0 < n\<close> using n_ge_2 by simp
+  have N_lt: \<open>sint N < 2^(n-1)\<close>
+    using SM.N_lt_R power_increasing[of \<open>n-2\<close> \<open>n-1\<close> \<open>2::int\<close>] by linarith
+
+  have N_ge_2: \<open>2 \<le> sint N\<close> using SM.Ngt1 by linarith
+  have N2_pos: \<open>(0::int) < 2 * sint N\<close> using N_ge_2 by linarith
+  \<comment> \<open>Reduce \<open>m div 2\<close> to a single rounded ratio.\<close>
+  have m_div2: \<open>m div 2 = \<lfloor>2^n /\<^sub>\<rat> (2 * sint N)\<rceil>\<close>
+    unfolding m_def round_even_def by (simp add: field_simps mult.commute)
+  \<comment> \<open>Lower and upper bounds on \<open>halfM\<close> via \<open>0 \<le> \<dots> \<le> 2^(n-2) < 2^(n-1)\<close>.\<close>
+  have ratio_nonneg: \<open>0 \<le> 2^n /\<^sub>\<rat> (2 * sint N)\<close>
+  proof -
+    have \<open>0 < (2 * sint N)\<^sub>\<rat>\<close> using N2_pos by linarith
+    thus ?thesis by (simp add: zero_le_divide_iff)
+  qed
+  have halfM_lb: \<open>0 \<le> m div 2\<close>
+    unfolding m_div2 using ratio_nonneg by (simp add: round_def)
+  have pow_n: \<open>(2::int)^n = 4 * 2^(n-2)\<close>
+    using n_ge_2 by (simp add: power_eq_if numeral_eq_Suc)
+  have step: \<open>(2::int)^n \<le> 2 * sint N * 2^(n-2)\<close>
+    using N_ge_2 pow_n by (simp add: mult_right_mono)
+  have ratio_ub: \<open>2^n /\<^sub>\<rat> (2 * sint N) \<le> (2^(n-2))\<^sub>\<rat>\<close>
+  proof -
+    have N2pos: \<open>0 < (2 * sint N)\<^sub>\<rat>\<close> using N2_pos by linarith
+    from step have \<open>(2^n)\<^sub>\<rat> \<le> ((2 * sint N) * 2^(n-2))\<^sub>\<rat>\<close>
+      by (simp only: of_int_le_iff)
+    hence \<open>(2^n)\<^sub>\<rat> \<le> (2 * sint N)\<^sub>\<rat> * (2^(n-2))\<^sub>\<rat>\<close> by (simp add: of_int_mult)
+    thus ?thesis using N2pos by (simp add: pos_divide_le_eq mult.commute)
+  qed
+  have halfM_ub: \<open>m div 2 \<le> 2^(n-2)\<close>
+  proof -
+    have \<open>\<lfloor>2^n /\<^sub>\<rat> (2 * sint N)\<rceil> \<le> \<lfloor>(2^(n-2))\<^sub>\<rat>\<rceil>\<close>
+      using ratio_ub by (rule round_mono)
+    also have \<open>\<lfloor>(2^(n-2))\<^sub>\<rat>\<rceil> = 2^(n-2)\<close> by (rule round_of_int)
+    finally show ?thesis unfolding m_div2 .
+  qed
+  have pow_lt: \<open>(2::int)^(n-2) < 2^(n-1)\<close>
+    using n_ge_2 by (intro power_strict_increasing) auto
+  have nondeg_Nt: \<open>\<bar>sint Nt\<bar> < 2^(n-1)\<close>
+    using halfM_lb halfM_ub halfM_eq pow_lt by linarith
+  \<comment> \<open>Chain to the lane-width residue \<open>bar\<^sup>\<plusminus> mod\<^sup>\<plusminus> 2^n\<close>.\<close>
+  have step_chain: \<open>sint (barrett_red_neon_word N Nt z)
+                      = bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z) mod\<^sup>\<plusminus> 2^n\<close>
+    using sint_barrett_red_neon_word[OF n_def nondeg_Nt]
+          halfM_eq
+          barrett_red_neon_int_eq[where N=\<open>sint N\<close> and z=\<open>sint z\<close> and n=\<open>n\<close>]
+          m_def
+    by simp
+
+
+  \<comment> \<open>Bound \<open>2\<bar>bar\<^sup>\<plusminus>\<bar> < 3N\<close> via \<open>barrett_red_narrow\<close>, using \<open>3N \<le> 2^n\<close> to drop \<open>mod\<^sup>\<plusminus> 2^n\<close>.\<close>
+  have N_lt_R: \<open>sint N < 2^n\<close>
+    using N_lt power_increasing[of "n-1" n "2::int"] by linarith
+  interpret BMS: BarrettContext \<open>sint N\<close> n \<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close>
+    using SM.Ngt1 SM.Nodd npos N_lt_R is_int_approx_round_even
+    by unfold_locales (auto simp: IntegerApproximation_def)
+  have abs_bound: \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z)\<bar> < sint N\<close>
+  proof -
+    have z_le: \<open>\<bar>sint z\<bar> \<le> 2^(n-1)\<close>
+      using sint_range_size[of z] by (simp add: word_size n_def, linarith)
+    have \<open>\<bar>(bar\<^sup>\<plusminus> \<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z))\<^sub>\<rat>\<bar> < (sint N)\<^sub>\<rat>\<close>
+      using BMS.barrett_red_narrow(1)[OF z_le] .
+    thus ?thesis using SM.Npos by (simp, linarith)
+  qed
+  have abs_eq: \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z)\<close>
+  proof -
+    have R_pos: \<open>(0::int) < 2^n\<close> by simp
+    have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close> using npos by (cases n) auto
+    have small: \<open>2 * \<bar>bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z)\<bar> < 2^n\<close>
+      using abs_bound N_lt R_eq by linarith
+
+    have id_eq: \<open>bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z) mod\<^sup>\<plusminus> 2^n
+                   = bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z)\<close>
+      by (rule mod_approx_round_id_small[OF R_pos small])
+    show ?thesis
+      unfolding out_def barrett_red_neon_word_def[symmetric]
+      using step_chain id_eq by simp
+  qed
+  show \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z)\<close> by (rule abs_eq)
+  show \<open>sint out mod sint N = sint z mod sint N\<close>
+  proof -
+    define K :: int where \<open>K \<equiv> \<lfloor>(sint z) * \<lfloor>2^n /\<^sub>\<rat> (sint N)\<rceil>\<^sub>2 /\<^sub>\<rat> 2^n\<rceil>\<close>
+    have decomp: \<open>bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z) = sint z - sint N * K\<close>
+      unfolding barrett_red_signed_def K_def by simp
+    have \<open>bar\<^sup>\<plusminus>\<lbrakk>sint N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> (sint z) mod sint N = sint z mod sint N\<close>
+      unfolding decomp by algebra
+    thus ?thesis using abs_eq by simp
+  qed
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint z\<bar>\<^sub>\<rat> * (sint N)\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+    using abs_eq
+          BMS.barrett_red_signed_bound_eps[OF is_int_approx_quality_round_even, of \<open>sint z\<close>]
+    by (simp add: quality_round_even)
+  have out_lt: \<open>\<bar>sint out\<bar> < sint N\<close>
+    using abs_eq abs_bound by simp
+  hence \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (sint N)\<^sub>\<rat>\<close>
+    by (metis of_int_abs of_int_less_iff)
+  thus \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> 3/2 * (sint N)\<^sub>\<rat>\<close>
+    using SM.Npos by linarith
+
+
+
+qed
+
+section \<open>Refined Barrett reduction\<close>
+
+text \<open>\cite[Algorithm~11, \S 3.2]{NeonNTT} discusses a three-instruction
+\<^verbatim>\<open>SQDMULH\<close>/\<^verbatim>\<open>SRSHR\<close>/\<^verbatim>\<open>MLS\<close> sequence implementing refined Barrett reduction
+at effective radix \<^term>\<open>2^(n+\<alpha>-1) :: int\<close>. The output is canonical
+if we assume \<^term>\<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) < 1/4\<close> instead of the
+guaranteed \<^term>\<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) < 1/2\<close>. Otherwise, the
+output is only guaranteed to be canonical for inputs with
+\<^term>\<open>\<bar>sint z\<bar> \<le> 2^(n-2)\<close>. The statement of \cite[Algorithm~11]{NeonNTT} as 
+published misses this and is wrong as stated. However, we note --- and show below ---
+that the assumption \<^term>\<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) < 1/4\<close> does hold in the context
+of ML-KEM and ML-DSA, so for those applications the error is of no consequence.\<close>
+
+definition %internal \<open>barrett_red_refined_neon_int n \<alpha> N V z \<equiv>
+     (let t = sqdmulh_int n z V;
+          q = srshr_int \<alpha> t
+      in (z - q * N) mod\<^sup>\<plusminus> 2^n)\<close>
+
+text %internal \<open>The integer kernel equals the refined Barrett reduction.\<close>
+
+lemma %internal barrett_red_refined_neon_int_eq:
+  shows \<open>barrett_red_refined_neon_int n \<alpha> N V z
+           = (barrett_red_refined N n \<alpha> V z) mod\<^sup>\<plusminus> 2^n\<close>
+  unfolding barrett_red_refined_neon_int_def barrett_red_refined_def
+            sqdmulh_int_def srshr_int_def Let_def
+  by simp
+
+definition %internal barrett_red_refined_neon_word
+  :: \<open>'a::len word \<Rightarrow> nat \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>barrett_red_refined_neon_word N \<alpha> V z \<equiv>
+     let t = sqdmulh_word z V;
+         q = srshr_word \<alpha> t
+     in mls_word z q N\<close>
+
+lemma %internal sint_barrett_red_refined_neon_word:
+  fixes N V z :: \<open>'a::len word\<close> and n \<alpha> :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes nondeg_V: \<open>\<bar>sint V\<bar> < 2^(n-1)\<close>
+  shows \<open>sint (barrett_red_refined_neon_word N \<alpha> V z)
+            = barrett_red_refined_neon_int n \<alpha> (sint N) (sint V) (sint z)\<close>
+proof -
+  define t :: \<open>'a word\<close> where \<open>t = sqdmulh_word z V\<close>
+  define q :: \<open>'a word\<close> where \<open>q = srshr_word \<alpha> t\<close>
+  have expand: \<open>barrett_red_refined_neon_word N \<alpha> V z = mls_word z q N\<close>
+    unfolding barrett_red_refined_neon_word_def Let_def t_def q_def by simp
+  have not_extreme: \<open>\<not>(sint z = -(2^(n-1)) \<and> sint V = -(2^(n-1)))\<close>
+    using nondeg_V by linarith
+  have t_int: \<open>sint t = sqdmulh_int n (sint z) (sint V)\<close>
+    unfolding t_def by (rule sint_sqdmulh_word[OF n_def not_extreme])
+  have q_int: \<open>sint q = srshr_int \<alpha> (sint t)\<close>
+    unfolding q_def by (rule sint_srshr_word[OF n_def])
+  have mls_eq: \<open>sint (mls_word z q N) = (sint z - sint q * sint N) mod\<^sup>\<plusminus> 2^n\<close>
+    by (rule sint_mls_word[OF n_def])
+  have \<open>sint (barrett_red_refined_neon_word N \<alpha> V z)
+          = (sint z - srshr_int \<alpha> (sqdmulh_int n (sint z) (sint V)) * sint N) mod\<^sup>\<plusminus> 2^n\<close>
+    using expand mls_eq q_int t_int by simp
+  also have \<open>\<dots> = barrett_red_refined_neon_int n \<alpha> (sint N) (sint V) (sint z)\<close>
+    unfolding barrett_red_refined_neon_int_def Let_def by simp
+  finally show ?thesis .
+qed
+
+theorem barrett_red_refined_neon_word_correct:
+  fixes N V z :: \<open>'a::len word\<close> and n \<alpha> \<delta> :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes V_eq: \<open>sint V = \<lfloor>2^(n+\<alpha>-1) /\<^sub>\<rat> sint N\<rceil>\<close>
+        \<comment> \<open>magic constant; the RHS fits in a signed \<^term>\<open>n\<close>-bit word
+            because \<^term>\<open>2^\<alpha> < sint N\<close>\<close>
+      and N_std: \<open>StandardModulus (sint N) n\<close>
+      and N_alpha: \<open>2^\<alpha> < sint N\<close> \<open>sint N < 2^(\<alpha>+1)\<close>
+        \<comment> \<open>\<open>\<alpha> = \<lfloor>log\<^sub>2 (sint N)\<rfloor>\<close>\<close>
+      and \<delta>_quality: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) \<le> 1/2^\<delta>\<close>
+      and z_bound: \<open>\<bar>sint z\<bar> \<le> 2^(n-1-(2-\<delta>))\<close>
+        \<comment> \<open>\<^term>\<open>\<delta>=1\<close> requires 1 bit of slack, \<^term>\<open>\<delta> \<ge> 2\<close> covers full signed \<^term>\<open>n\<close>-bit range\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQDMULH t z V;
+                    SRSHR   q t #\<alpha>;
+                    MLS     r z q N
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+        \<comment> \<open>abstract description: refined Barrett at radix \<open>2^(n+\<alpha>-1)\<close>\<close>
+    and \<open>sint out = sint z mod\<^sup>\<plusminus> sint N\<close>
+        \<comment> \<open>output is the signed canonical residue\<close>
+proof -
+  have mod_signed_unique:
+    \<open>\<And>x y N. odd N \<Longrightarrow> 0 < N \<Longrightarrow> y mod N = x mod N
+              \<Longrightarrow> 2 * \<bar>y\<bar> < N \<Longrightarrow> y = x mod\<^sup>\<plusminus> N\<close>
+  proof -
+    fix x y N :: int
+    assume Nodd: \<open>odd N\<close> and Npos: \<open>0 < N\<close>
+       and mod_eq: \<open>y mod N = x mod N\<close>
+       and small: \<open>2 * \<bar>y\<bar> < N\<close>
+    define r where \<open>r = x mod\<^sup>\<plusminus> N\<close>
+    have r_lo: \<open>- (N div 2) \<le> r\<close>
+      using mod_signed_lower[OF Npos] r_def by simp
+    have r_hi: \<open>r \<le> (N - 1) div 2\<close>
+      using mod_signed_upper[OF Npos] r_def by simp
+    have r_eq: \<open>r = x - N * \<lfloor>x /\<^sub>\<rat> N\<rceil>\<close>
+      unfolding r_def mod_approx_def by simp
+    have shift_eq: \<open>(x - N * \<lfloor>x /\<^sub>\<rat> N\<rceil>) mod N = x mod N\<close>
+    proof -
+      have \<open>x - N * \<lfloor>x /\<^sub>\<rat> N\<rceil> = x + N * (- \<lfloor>x /\<^sub>\<rat> N\<rceil>)\<close> by simp
+      also have \<open>(x + N * (- \<lfloor>x /\<^sub>\<rat> N\<rceil>)) mod N = x mod N\<close> by (rule mod_mult_self2)
+      finally show ?thesis .
+    qed
+    have r_mod: \<open>r mod N = x mod N\<close> using r_eq shift_eq by simp
+    have yr_mod: \<open>y mod N = r mod N\<close> using mod_eq r_mod by simp
+    have N_div2: \<open>2 * (N div 2) = N - 1\<close> using Nodd by (auto elim: oddE)
+    have small_y: \<open>2 * y < N \<and> -N < 2 * y\<close> using small by linarith
+    have small_r: \<open>2 * r < N \<and> -N < 2 * r\<close>
+      using r_lo r_hi N_div2 by linarith
+    have diff_bd: \<open>\<bar>y - r\<bar> < N\<close> using small_y small_r by linarith
+    have Ndvd: \<open>N dvd (y - r)\<close> using yr_mod by (simp add: mod_eq_dvd_iff)
+    have \<open>y - r = 0\<close>
+    proof (rule ccontr)
+      assume \<open>y - r \<noteq> 0\<close>
+      hence \<open>\<bar>N\<bar> \<le> \<bar>y - r\<bar>\<close> using Ndvd by (rule dvd_imp_le_int)
+      thus False using diff_bd Npos by simp
+    qed
+    hence \<open>y = r\<close> by simp
+    thus \<open>y = x mod\<^sup>\<plusminus> N\<close> using r_def by simp
+  qed
+
+  interpret SM: StandardModulus \<open>sint N\<close> n by (rule N_std)
+  have \<alpha>_pos: \<open>1 \<le> \<alpha>\<close>
+    using N_alpha SM.Ngt1 power_less_imp_less_exp[of \<open>2::int\<close> 1 \<open>\<alpha>+1\<close>] by simp
+
+  \<comment> \<open>Bound on \<^term>\<open>sint V\<close>: nonneg and bounded by \<^term>\<open>2^(n-1)\<close> (since \<^term>\<open>(2::int)^\<alpha> \<le> sint N\<close>).\<close>
+  have V_nn: \<open>sint V \<ge> 0\<close>
+  proof -
+    have \<open>(of_int (sint N) :: rat) > 0\<close> using SM.Ngt1 by linarith
+    hence \<open>(0::rat) \<le> of_int ((2::int)^(n+\<alpha>-1)) / of_int (sint N)\<close>
+      by (simp add: zero_le_divide_iff)
+    thus ?thesis using V_eq by (simp add: round_def)
+  qed
+  have nondeg_V: \<open>\<bar>sint V\<bar> < 2^(n-1)\<close>
+    using V_nn n_def sint_lt[of V] by simp
+
+  \<comment> \<open>Set up Barrett context at radix \<^term>\<open>n+\<alpha>-1\<close>.\<close>
+  have N_lt_Rn\<alpha>: \<open>sint N < 2^(n+\<alpha>-1)\<close>
+    using SM.N_lt_R power_increasing[of n \<open>n+\<alpha>-1\<close> \<open>2::int\<close>] \<alpha>_pos by linarith
+  interpret BMS: BarrettContext \<open>sint N\<close> \<open>n+\<alpha>-1\<close> round
+    using SM.Ngt1 SM.Nodd SM.npos \<alpha>_pos N_lt_Rn\<alpha> is_int_approx_round
+    by unfold_locales auto
+
+  \<comment> \<open>Coarse bound on the abstract Barrett result via \<^term>\<open>barrett_red_narrow\<close>.\<close>
+  have z_le_Rn\<alpha>: \<open>\<bar>sint z\<bar> \<le> 2^(n+\<alpha>-1 - 1)\<close>
+    using sint_in_signed_range[OF n_def, of z]
+          power_increasing[of \<open>n-1\<close> \<open>n+\<alpha>-1-1\<close> \<open>2::int\<close>] \<alpha>_pos SM.npos by linarith
+  have abs_int_bound: \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<bar> < sint N\<close>
+  proof -
+    have \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z))\<^sub>\<rat>\<bar> < (sint N)\<^sub>\<rat>\<close>
+      using BMS.barrett_red_narrow(2)[OF z_le_Rn\<alpha>] by simp
+    thus ?thesis by (metis of_int_abs of_int_less_iff)
+  qed
+
+  \<comment> \<open>The Barrett result fits in a signed \<open>n\<close>-bit lane, so \<open>mod\<^sup>\<plusminus> 2^n\<close> is the identity.\<close>
+  have small: \<open>2 * \<bar>bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<bar> < 2^n\<close>
+  proof -
+    have N_lt_half: \<open>sint N < 2^(n-1)\<close> using sint_in_signed_range[OF n_def, of N] by auto
+    have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close> using SM.npos by (cases n) auto
+    show ?thesis using abs_int_bound N_lt_half R_eq by linarith
+  qed
+  have id_eq: \<open>bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z) mod\<^sup>\<plusminus> 2^n
+                 = bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+    by (rule mod_approx_round_id_small[OF zero_less_power[of \<open>2::int\<close> n] small]) simp
+
+  \<comment> \<open>Bridge chain: word \<rightarrow> int \<rightarrow> refined \<rightarrow> abstract Barrett.\<close>
+  have abs_eq: \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+    using sint_barrett_red_refined_neon_word[OF n_def nondeg_V, of N \<alpha> z]
+          barrett_red_refined_neon_int_eq[of n \<alpha> \<open>sint N\<close> \<open>sint V\<close> \<open>sint z\<close>]
+          barrett_red_refined_eq[OF \<alpha>_pos V_eq] id_eq
+    unfolding out_def Let_def barrett_red_refined_neon_word_def by simp
+
+  show \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close> by (rule abs_eq)
+
+  \<comment> \<open>Correctness: \<open>sint out \<equiv> sint z\<close> modulo \<^term>\<open>sint N\<close>.\<close>
+  have mod_eq: \<open>sint out mod sint N = sint z mod sint N\<close>
+  proof -
+    define K :: int
+      where \<open>K = \<lfloor>(sint z)\<^sub>\<rat> * \<lfloor>2^(n+\<alpha>-1) /\<^sub>\<rat> sint N\<rceil>\<^sub>\<rat> / (2^(n+\<alpha>-1))\<^sub>\<rat>\<rceil>\<close>
+    have decomp: \<open>bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z) = sint z - sint N * K\<close>
+      unfolding barrett_red_signed_def K_def by simp
+    have \<open>bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z) mod sint N = sint z mod sint N\<close>
+      unfolding decomp by algebra
+    thus ?thesis using abs_eq by simp
+  qed
+
+  \<comment> \<open>Signed canonical bound via the (\<gamma>, \<delta>) corollary, with \<^term>\<open>\<gamma>_canon = \<alpha>+1-\<delta>\<close>.\<close>
+  have canonical_bound: \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < sint N /\<^sub>\<rat> 2\<close>
+  proof -
+    have eps_le: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, BMS.R /\<^sub>\<rat> sint N) \<le> 1/2^\<delta>\<close> using \<delta>_quality by simp
+    have N_ge3: \<open>sint N \<ge> 3\<close>
+      using N_alpha(1) \<alpha>_pos power_increasing[of 1 \<alpha> \<open>2::int\<close>] by simp
+    have n_ge3: \<open>n \<ge> 3\<close>
+    proof -
+      have \<open>(2::int)^2 \<le> 2^(n-1)\<close> using N_ge3 sint_in_signed_range[OF n_def, of N] by simp
+      thus ?thesis using power_le_imp_le_exp[of \<open>2::int\<close> 2 \<open>n-1\<close>] by simp
+    qed
+    have z_le: \<open>\<bar>sint z\<bar> \<le> 2^((n+\<alpha>-1) - 1 - (\<alpha>+1-\<delta>))\<close>
+    proof -
+      have \<open>n - 1 - (2 - \<delta>) \<le> (n+\<alpha>-1) - 1 - (\<alpha>+1-\<delta>)\<close> using \<alpha>_pos SM.npos by linarith
+      hence \<open>(2::int)^(n - 1 - (2 - \<delta>)) \<le> 2^((n+\<alpha>-1) - 1 - (\<alpha>+1-\<delta>))\<close>
+        by (rule power_increasing) simp
+      thus ?thesis using z_bound by linarith
+    qed
+    have \<gamma>_le: \<open>\<alpha> + 1 - \<delta> \<le> (n+\<alpha>-1) - 1\<close> using \<alpha>_pos n_ge3 by linarith
+    have N_lt: \<open>sint N < 2^((\<alpha>+1-\<delta>) + \<delta>)\<close>
+      using N_alpha(2) power_increasing[of \<open>\<alpha>+1\<close> \<open>(\<alpha>+1-\<delta>)+\<delta>\<close> \<open>2::int\<close>] by linarith
+    have \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>sint N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z))\<^sub>\<rat>\<bar> < sint N /\<^sub>\<rat> 2\<close>
+      using BMS.barrett_red_signed_canonical[OF eps_le z_le \<gamma>_le N_lt] .
+    thus ?thesis using abs_eq by simp
+  qed
+
+  \<comment> \<open>Combine: \<^term>\<open>sint out\<close> matches \<^term>\<open>sint z mod\<^sup>\<plusminus> sint N\<close> by the canonical-residue
+      uniqueness lemma, since \<^term>\<open>sint N\<close> is odd, positive, and the bounds match.\<close>
+  show \<open>sint out = sint z mod\<^sup>\<plusminus> sint N\<close>
+  proof -
+    have small: \<open>2 * \<bar>sint out\<bar> < sint N\<close>
+    proof -
+      have \<open>(2 * \<bar>sint out\<bar>)\<^sub>\<rat> < (sint N)\<^sub>\<rat>\<close>
+        using canonical_bound by (simp add: of_int_mult of_int_abs)
+      thus ?thesis by (metis of_int_less_iff)
+    qed
+    show ?thesis
+      using mod_signed_unique[OF SM.Nodd SM.Npos mod_eq small] .
+  qed
+qed
+
+
+text \<open>Specialisation to ML-KEM: \<^term>\<open>N = 3329\<close>, \<^term>\<open>n = 16\<close>, \<^term>\<open>\<alpha> = 11\<close>, \<^term>\<open>\<delta> = 2\<close>.
+For this modulus, the rounding-quality factor satisfies
+\<^term>\<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^26 /\<^sub>\<rat> 3329) \<le> 1/4\<close>, so the canonical-output theorem applies for the full
+signed 16-bit input range.\<close>
+
+theorem barrett_red_refined_neon_word_correct_ml_kem:
+  fixes z :: \<open>16 word\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQDMULH t z 20159; \<comment> \<open>(@{lemma \<open>20159=\<lfloor>2^(16 + 11 - 1) /\<^sub>\<rat> 3329\<rceil>\<close> by eval})\<close>
+                    SRSHR   q t #11;
+                    MLS     r z q 3329
+                  \<guillemotright> in r\<close>
+  
+  shows \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>3329, 26, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+        \<comment> \<open>abstract description: refined Barrett at radix \<open>2^26\<close>\<close>
+    and \<open>sint out = sint z mod\<^sup>\<plusminus> 3329\<close>
+        \<comment> \<open>output is the signed canonical residue\<close>
+proof -
+  have V_eq: \<open>sint (20159 :: 16 word) = \<lfloor>2^(16+11-1) /\<^sub>\<rat> sint (3329 :: 16 word)\<rceil>\<close>
+    by eval
+  have N_std: \<open>StandardModulus (sint (3329 :: 16 word)) 16\<close>
+    by unfold_locales eval+
+  have N_alpha1: \<open>(2::int)^11 < sint (3329 :: 16 word)\<close>
+    by eval
+  have N_alpha2: \<open>sint (3329 :: 16 word) < (2::int)^(11+1)\<close>
+    by eval
+  have \<delta>_quality: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(16+11-1) /\<^sub>\<rat> sint (3329 :: 16 word)) \<le> 1/2^(2::nat)\<close>
+    by eval
+  have z_bound: \<open>\<bar>sint z\<bar> \<le> 2^(16-1-(2-(2::nat)))\<close>
+    using sint_in_signed_range[of 16 z] by (simp, linarith)
+  have len16: \<open>(16 :: nat) = LENGTH(16)\<close> by simp
+  have N_sint: \<open>sint (3329 :: 16 word) = 3329\<close> by eval
+  have thm1: \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint (3329 :: 16 word), 16+11-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+   and thm2: \<open>sint out = sint z mod\<^sup>\<plusminus> sint (3329 :: 16 word)\<close>
+    unfolding out_def
+    using barrett_red_refined_neon_word_correct
+            [where 'a=16 and n=16 and \<alpha>=11 and \<delta>=2 and N=\<open>3329 :: 16 word\<close>
+                and V=\<open>20159 :: 16 word\<close> and z=z,
+             OF len16 V_eq N_std N_alpha1 N_alpha2 \<delta>_quality z_bound]
+    by simp_all
+  show \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>3329, 26, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+    using thm1 N_sint by simp
+  show \<open>sint out = sint z mod\<^sup>\<plusminus> 3329\<close>
+    using thm2 N_sint by simp
+qed
+
+
+
+text \<open>Specialisation to ML-DSA: \<^term>\<open>N = 8380417\<close>, \<^term>\<open>n = 32\<close>, \<^term>\<open>\<alpha> = 22\<close>, \<^term>\<open>\<delta> = 2\<close>.
+For this modulus, the rounding-quality factor satisfies
+\<^term>\<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^53 /\<^sub>\<rat> 8380417) \<le> 1/4\<close>, so the canonical-output theorem applies for the full
+signed 32-bit input range.\<close>
+
+theorem barrett_red_refined_neon_word_correct_ml_dsa:
+  fixes z :: \<open>32 word\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQDMULH t z 1074791297; \<comment> \<open>(@{lemma \<open>1074791297 = \<lfloor>2^(32 + 22 - 1) /\<^sub>\<rat> 8380417\<rceil>\<close> by eval})\<close>
+                    SRSHR   q t #22;
+                    MLS     r z q 8380417
+                  \<guillemotright> in r\<close>
+  
+  shows \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>8380417, 53, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+        \<comment> \<open>abstract description: refined Barrett at radix \<open>2^53\<close>\<close>
+    and \<open>sint out = sint z mod\<^sup>\<plusminus> 8380417\<close>
+        \<comment> \<open>output is the signed canonical residue\<close>
+proof -
+  have V_eq: \<open>sint (1074791297 :: 32 word) = \<lfloor>2^(32+22-1) /\<^sub>\<rat> sint (8380417 :: 32 word)\<rceil>\<close>
+    by eval
+  have N_std: \<open>StandardModulus (sint (8380417 :: 32 word)) 32\<close>
+    by unfold_locales eval+
+  have N_alpha1: \<open>(2::int)^22 < sint (8380417 :: 32 word)\<close>
+    by eval
+  have N_alpha2: \<open>sint (8380417 :: 32 word) < (2::int)^(22+1)\<close>
+    by eval
+  have \<delta>_quality: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(32+22-1) /\<^sub>\<rat> sint (8380417 :: 32 word)) \<le> 1/2^(2::nat)\<close>
+    by eval
+  have z_bound: \<open>\<bar>sint z\<bar> \<le> 2^(32-1-(2-(2::nat)))\<close>
+    using sint_in_signed_range[of 32 z] by (simp, linarith)
+  have len32: \<open>(32 :: nat) = LENGTH(32)\<close> by simp
+  have N_sint: \<open>sint (8380417 :: 32 word) = 8380417\<close> by eval
+  have thm1: \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>sint (8380417 :: 32 word), 32+22-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+   and thm2: \<open>sint out = sint z mod\<^sup>\<plusminus> sint (8380417 :: 32 word)\<close>
+    unfolding out_def
+    using barrett_red_refined_neon_word_correct
+            [where 'a=32 and n=32 and \<alpha>=22 and \<delta>=2 and N=\<open>8380417 :: 32 word\<close>
+                and V=\<open>1074791297 :: 32 word\<close> and z=z,
+             OF len32 V_eq N_std N_alpha1 N_alpha2 \<delta>_quality z_bound]
+    by simp_all
+  show \<open>sint out = bar\<^sup>\<plusminus>\<lbrakk>8380417, 53, \<lfloor>\<cdot>\<rceil>\<rbrakk> (sint z)\<close>
+    using thm1 N_sint by simp
+  show \<open>sint out = sint z mod\<^sup>\<plusminus> 8380417\<close>
+    using thm2 N_sint by simp
+qed
+
+text \<open>We conclude with a counterexample showing that without the hypothesis
+\<^term>\<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) \<le> 1/4\<close>, refined Barrett reduction only
+yields canonical outputs for \<^term>\<open>\<bar>sint z\<bar> \<le> 2^(n-2)\<close>:\<close>
+
+lemma refined_barrett_example_3947:
+  defines \<open>n \<equiv> (16 :: nat)\<close>
+      and \<open>\<alpha> \<equiv> (11 :: nat)\<close>
+      and \<open>\<delta> \<equiv> (1 :: nat)\<close>
+      and \<open>N \<equiv> (3947 :: 16 word)\<close>
+      and \<open>V \<equiv> (17002 :: 16 word)\<close>
+      and \<open>z \<equiv> (17762 :: 16 word)\<close>
+  shows \<open>sint V = \<lfloor>2^(n+\<alpha>-1) /\<^sub>\<rat> sint N\<rceil>\<close>
+    and \<open>StandardModulus (sint N) n\<close>
+    and \<open>2^\<alpha> < sint N\<close> \<open>sint N < 2^(\<alpha>+1)\<close>
+        \<comment>\<open>Assumptions of @{thm [source] barrett_red_refined_neon_word_correct} are satisfied,
+           except for \<^term>\<open>\<bar>sint z\<bar> \<le> 2^(n-1-(2-\<delta>))\<close>: We only have \<^term>\<open>\<bar>sint z\<bar> \<le> 2^(n-1)\<close>.\<close>
+    and \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) \<le> 1/2^\<delta>\<close>
+        \<comment> \<open>... and only the guaranteed quality bound is available\<close>
+    and \<open>\<bar>sint (let ASM \<guillemotleft>
+                  SQDMULH t z V;
+                  SRSHR   q t #\<alpha>;
+                  MLS     r z q N
+                \<guillemotright> in r)\<bar>\<^sub>\<rat> \<ge> sint N /\<^sub>\<rat> 2\<close>
+        \<comment> \<open>output is \<^emph>\<open>not\<close> signed canonical\<close>
+proof -
+  show \<open>sint V = \<lfloor>2^(n+\<alpha>-1) /\<^sub>\<rat> sint N\<rceil>\<close>
+    unfolding V_def n_def \<alpha>_def N_def by eval
+  show \<open>StandardModulus (sint N) n\<close>
+    unfolding N_def n_def by unfold_locales eval+
+  show \<open>2^\<alpha> < sint N\<close>
+    unfolding \<alpha>_def N_def by eval
+  show \<open>sint N < 2^(\<alpha>+1)\<close>
+    unfolding \<alpha>_def N_def by eval
+  show \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, 2^(n+\<alpha>-1) /\<^sub>\<rat> sint N) \<le> 1/2^\<delta>\<close>
+    unfolding n_def \<alpha>_def \<delta>_def N_def by eval
+  show \<open>\<bar>sint (let ASM \<guillemotleft>
+                  SQDMULH t z V;
+                  SRSHR   q t #\<alpha>;
+                  MLS     r z q N
+                \<guillemotright> in r)\<bar>\<^sub>\<rat> \<ge> sint N /\<^sub>\<rat> 2\<close>
+    unfolding N_def V_def z_def \<alpha>_def by eval
+qed
+
+end
+
+

--- a/proofs/isabelle/neon_ntt/Asm_Montgomery.thy
+++ b/proofs/isabelle/neon_ntt/Asm_Montgomery.thy
@@ -1,0 +1,898 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Asm_Montgomery
+  imports Word_Ops Montgomery_Doubling
+begin
+
+unbundle %invisible ASM_syntax
+
+chapter \<open>Neon kernels for Montgomery-style modular arithmetic \label{ch:asm_montgomery}\<close>
+
+
+text \<open>In this chapter we analyse three Neon ASM kernels for Montgomery-style
+modular multiplication and connect them to the corresponding abstract operators.
+In consequence, we obtain correctness and bounds statements for the kernel
+output.\<close>
+
+section \<open>Signed Montgomery multiplication\<close>
+
+
+
+definition %internal \<open>mont_mul_neon_int n N bT a b \<equiv>
+     (let R = (2::int)^n;
+          z1 = (2 * (a * b)) div R;             \<comment> \<open>SQDMULH z, a, b\<close>
+          k  = (a * bT) mod\<^sup>\<plusminus> R;                  \<comment> \<open>MUL k, a, bT\<close>
+          c  = (2 * (k * N)) div R               \<comment> \<open>SQDMULH c, k, N\<close>
+      in (z1 - c) div 2)\<close>                       \<comment> \<open>SHSUB z, z, c\<close>
+
+text %internal \<open>The integer-level kernel computes the same value as the abstract
+Montgomery doubling algorithm (Algorithm 7). The match is syntactic: both feed
+the precomputed product \<^term>\<open>b*T\<close> into the low-half multiply and recover the same
+Montgomery quotient.\<close>
+
+lemma %internal mont_mul_neon_int_eq_doubling:
+  fixes a b N T :: int and n :: nat
+  shows \<open>mont_mul_neon_int n N (b * T) a b = mont_mul_doubling N n T a b\<close>
+  unfolding mont_mul_neon_int_def mont_mul_doubling_def Let_def
+  by (simp add: algebra_simps)
+
+text %internal \<open>Composing this match with the Algorithm 7 correctness lemma yields
+the integer-level correctness of our kernel against the abstract subtractive
+Montgomery operator: provided \<^term>\<open>T\<close> is a multiplicative inverse of \<^term>\<open>N\<close> modulo
+\<^term>\<open>R\<close> and the modulus satisfies the standard cryptographic conditions, the
+kernel returns \<^term>\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk>(a*b)\<close>.\<close>
+
+lemma %internal (in StandardModulus) mont_mul_neon_int_correct:
+  fixes a b T :: int
+  assumes T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>mont_mul_neon_int n N (b * T) a b = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>
+  using mont_mul_neon_int_eq_doubling[of n N b T a]
+        mont_mul_doubling_eq[OF T_inv, of a b]
+  by simp
+
+text %internal \<open>A second form of the kernel exposes the halving subtract \<^verbatim>\<open>SHSUB\<close>
+explicitly, putting each of the four lines in one-to-one correspondence with a
+Neon mnemonic.\<close>
+
+lemma %internal mont_mul_neon_int_via_shsub:
+  fixes a b N bT :: int and n :: nat
+  shows \<open>mont_mul_neon_int n N bT a b
+           = shsub_int ((2 * (a * b)) div 2^n)
+                       ((2 * (((a * bT) mod\<^sup>\<plusminus> 2^n) * N)) div 2^n)\<close>
+  unfolding mont_mul_neon_int_def shsub_int_def Let_def by simp
+
+
+text \<open>The first \<^verbatim>\<open>SQDMULH\<close> needs \<^term>\<open>a\<close> and \<^term>\<open>b\<close> away from \<^term>\<open>-(2^(n-1)) :: int\<close>; the second
+needs the same for \<^term>\<open>N\<close>, granted by the standard precondition, and \<^term>\<open>\<bar>k\<bar> \<le> R div 2\<close>,
+automatic from \<^verbatim>\<open>MUL\<close>. \<^verbatim>\<open>SHSUB\<close> is non-saturating. The strict input bounds
+are exactly the non-saturation conditions.\<close>
+
+definition %internal mont_mul_neon_word
+  :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mont_mul_neon_word N bT a b \<equiv>
+     let ASM \<guillemotleft>
+       SQDMULH z1 a b;
+       MUL     k  a bT;
+       SQDMULH c  k N;
+       SHSUB   r  z1 c
+     \<guillemotright> in r\<close>
+
+lemma %internal sint_mont_mul_neon_word:
+  fixes N bT a b :: \<open>'a::len word\<close>
+    and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes
+    \<comment> \<open>\<open>b\<close> non-extreme suffices to avoid SQDMULH saturation\<close>
+    nondeg_b: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close>
+    \<comment> \<open>standard cryptographic precondition: \<open>1 < N\<close>, \<open>N < 2^(n-1)\<close>, \<open>odd N\<close>\<close>
+    and N_std: \<open>1 < sint N \<and> sint N < 2^(n-1) \<and> odd (sint N)\<close>
+  shows \<open>sint (mont_mul_neon_word N bT a b)
+           = mont_mul_neon_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+proof -
+  have N_lo: \<open>1 < sint N\<close> using N_std by simp
+  have N_lt: \<open>sint N < 2^(n-1)\<close> using N_std by simp
+  let ?z1 = \<open>sqdmulh_word a b\<close>
+  let ?k  = \<open>mul_word a bT\<close>
+  let ?c  = \<open>sqdmulh_word ?k N\<close>
+  let ?R  = \<open>(2::int) ^ LENGTH('a)\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have absN: \<open>\<bar>sint N\<bar> < 2^(n-1)\<close>
+    using N_lo N_lt by linarith
+  have not_extreme1: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint b = -(2^(n-1)))\<close>
+    using nondeg_b by linarith
+  have not_extreme2: \<open>\<not> (sint ?k = -(2^(n-1)) \<and> sint N = -(2^(n-1)))\<close>
+    using absN by linarith
+  have z1_int: \<open>sint ?z1 = sqdmulh_int (LENGTH('a)) (sint a) (sint b)\<close>
+    by (rule sint_sqdmulh_word[OF refl not_extreme1[unfolded n_def]])
+  have k_int: \<open>sint ?k = (sint a * sint bT) mod\<^sup>\<plusminus> ?R\<close>
+    by (rule sint_mul_word[OF refl])
+  have c_int: \<open>sint ?c = sqdmulh_int (LENGTH('a)) (sint ?k) (sint N)\<close>
+    by (rule sint_sqdmulh_word[OF refl not_extreme2[unfolded n_def]])
+  have \<open>sint (mont_mul_neon_word N bT a b) = shsub_int (sint ?z1) (sint ?c)\<close>
+    unfolding mont_mul_neon_word_def Let_def by (rule sint_shsub_word)
+  also have \<open>\<dots> = shsub_int (sqdmulh_int (LENGTH('a)) (sint a) (sint b))
+                            (sqdmulh_int (LENGTH('a)) ((sint a * sint bT) mod\<^sup>\<plusminus> ?R) (sint N))\<close>
+    using z1_int c_int k_int by simp
+  also have \<open>\<dots> = mont_mul_neon_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    unfolding mont_mul_neon_int_def shsub_int_def sqdmulh_int_def Let_def n_def
+    by (simp add: algebra_simps)
+  finally show ?thesis .
+qed
+
+text \<open>The four-instruction \<^verbatim>\<open>SQDMULH\<close>/\<^verbatim>\<open>MUL\<close>/\<^verbatim>\<open>SQDMULH\<close>/\<^verbatim>\<open>SHSUB\<close> sequence
+computes \<^term>\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N,n\<rbrakk>(a*b)\<close> on signed lanes.\<close>
+
+
+theorem mont_mul_neon_word_correct:
+  fixes N bT a b :: \<open>'a::len word\<close> and n :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes N_std: \<open>StandardModulus (sint N) (n-1)\<close>
+      and bT_eq: \<open>sint bT = (sint b * ((sint N)\<^sup>-\<^sup>1 mod 2^n)) mod\<^sup>\<plusminus> 2^n\<close>
+      and nondeg_b: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQDMULH z1 a b;
+                    MUL     k  a bT;
+                    SQDMULH c  k N;
+                    SHSUB   r  z1 c
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+        \<comment> \<open>abstract description\<close>
+    and \<open>(sint out * 2^n) mod sint N = (sint a * sint b) mod sint N\<close>
+        \<comment> \<open>correctness\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a * sint b\<bar>\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+        \<comment> \<open>fine output bound\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (2^(n-1))\<^sub>\<rat>\<close>
+
+        \<comment> \<open>coarse output bound\<close>
+proof -
+  interpret SM0: StandardModulus \<open>sint N\<close> \<open>n-1\<close> by (rule N_std)
+  have N_lo: \<open>1 < sint N\<close> using SM0.Ngt1 .
+  have N_lt: \<open>sint N < 2^(n-1)\<close> using SM0.N_lt_R .
+  have N_odd: \<open>odd (sint N)\<close> using SM0.Nodd .
+  have N_pos: \<open>0 < sint N\<close> using N_lo by linarith
+  have n_pos: \<open>n > 0\<close> using SM0.npos by simp
+  have N_std_conj: \<open>1 < sint N \<and> sint N < 2^(n-1) \<and> odd (sint N)\<close>
+    using N_lo N_lt N_odd by simp
+  define T where \<open>T \<equiv> (sint N)\<^sup>-\<^sup>1 mod (2^n)\<close>
+  have T_inv: \<open>(sint N * T) mod 2^n = 1 mod 2^n\<close>
+    unfolding T_def using mod_inverse_correct(3)[OF n_pos N_odd] .
+  have step1: \<open>sint (mont_mul_neon_word N bT a b)
+                 = mont_mul_neon_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    by (rule sint_mont_mul_neon_word[OF n_def nondeg_b N_std_conj])
+
+  have step2: \<open>mont_mul_neon_int n (sint N) (sint bT) (sint a) (sint b)
+                 = mont_mul_neon_int n (sint N) (sint b * T) (sint a) (sint b)\<close>
+  proof -
+    have n_ge_1: \<open>n \<ge> 1\<close> using n_pos by simp
+    hence stb: \<open>\<And>x. signed_take_bit (n-1) x = x mod\<^sup>\<plusminus> 2^n\<close>
+      using signed_take_bit_eq_smod by blast
+    have bT_smod: \<open>sint bT mod\<^sup>\<plusminus> 2^n = (sint b * T) mod\<^sup>\<plusminus> 2^n\<close>
+      using bT_eq unfolding T_def
+      by (metis signed_take_bit_int_eq_self_iff signed_take_bit_int_greater_eq_minus_exp
+                signed_take_bit_int_less_exp stb)
+
+    have key: \<open>(sint a * sint bT) mod\<^sup>\<plusminus> 2^n
+                 = (sint a * (sint b * T)) mod\<^sup>\<plusminus> 2^n\<close>
+      using bT_smod stb
+            signed_take_bit_mult[of \<open>n-1\<close> \<open>sint a\<close> \<open>sint bT\<close>]
+            signed_take_bit_mult[of \<open>n-1\<close> \<open>sint a\<close> \<open>sint b * T\<close>]
+      by metis
+    show ?thesis
+      unfolding mont_mul_neon_int_def Let_def using key by (simp add: n_def)
+  qed
+  have N_lt_R: \<open>2^n > sint N\<close>
+  proof -
+    have h: \<open>(2::int)^(n-1) < 2^n\<close>
+      using n_pos by (simp add: power_strict_increasing)
+    show ?thesis using h N_lt by linarith
+  qed
+  interpret SM: StandardModulus \<open>sint N\<close> n
+    by unfold_locales (use N_lo N_odd n_pos N_lt_R in auto)
+  have step3: \<open>mont_mul_neon_int n (sint N) (sint b * T) (sint a) (sint b)
+                 = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    using SM.mont_mul_neon_int_correct[OF T_inv] .
+
+  have abs_eq: \<open>sint out = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    unfolding out_def mont_mul_neon_word_def[symmetric]
+    using step1 step2 step3 by simp
+  show \<open>sint out = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    by (rule abs_eq)
+  show \<open>(sint out * 2^n) mod sint N = (sint a * sint b) mod sint N\<close>
+    using abs_eq SM.mont_sub_signed_correct[of \<open>sint a * sint b\<close>] by simp
+  have bd: \<open>2 * \<bar>sint out\<bar> * 2^n \<le> 2 * \<bar>sint a * sint b\<bar> + sint N * 2^n\<close>
+    using abs_eq SM.mont_sub_signed_bound_int[of \<open>sint a * sint b\<close>] by simp
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a * sint b\<bar>\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+  proof -
+    from bd have \<open>(2 * \<bar>sint out\<bar> * 2^n)\<^sub>\<rat> \<le> (2 * \<bar>sint a * sint b\<bar> + sint N * 2^n)\<^sub>\<rat>\<close>
+      by (metis of_int_le_iff)
+    thus ?thesis by (simp add: of_int_mult of_int_add of_int_abs field_simps)
+  qed
+
+
+
+
+
+  have bd_abs: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+                  \<le> 2 * \<bar>sint a * sint b\<bar> + sint N * 2^n\<close>
+    using SM.mont_sub_signed_bound_int[of \<open>sint a * sint b\<close>] .
+
+
+
+  have ab_bd: \<open>\<bar>sint a * sint b\<bar> < 2^(n-1) * 2^(n-1)\<close>
+  proof -
+    have h: \<open>\<bar>sint a * sint b\<bar> = \<bar>sint a\<bar> * \<bar>sint b\<bar>\<close> by (simp add: abs_mult)
+    have a_le: \<open>\<bar>sint a\<bar> \<le> 2^(n-1)\<close>
+      using sint_range_size[of a] by (simp add: word_size n_def, linarith)
+    have h2: \<open>\<bar>sint a\<bar> * \<bar>sint b\<bar> < 2^(n-1) * 2^(n-1)\<close>
+    proof -
+      have b_pos: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close> using nondeg_b by simp
+      have pow_pos: \<open>(0::int) < 2^(n-1)\<close> by simp
+      have \<open>\<bar>sint a\<bar> * \<bar>sint b\<bar> \<le> 2^(n-1) * \<bar>sint b\<bar>\<close>
+        using a_le by (intro mult_right_mono) auto
+      also have \<open>\<dots> < 2^(n-1) * 2^(n-1)\<close>
+        using b_pos pow_pos by (intro mult_strict_left_mono) auto
+      finally show ?thesis .
+    qed
+    show ?thesis using h h2 by simp
+  qed
+
+  have pow_split: \<open>(2::int)^(2*(n-1)) = 2^(n-1) * 2^(n-1)\<close>
+    by (metis power_add mult_2)
+  have N_R_bd: \<open>sint N * 2^n < 2^(n-1) * 2^n\<close>
+    using N_lt by (simp add: mult_strict_right_mono)
+  have R_split: \<open>(2::int)^n = 2 * 2^(n-1)\<close>
+    using n_pos by (cases n; auto)
+  have step: \<open>2 * \<bar>sint a * sint b\<bar> + sint N * 2^n < 2 * (2^(n-1) * 2^n)\<close>
+  proof -
+    have h1: \<open>2 * \<bar>sint a * sint b\<bar> < 2 * (2^(n-1) * 2^(n-1))\<close>
+      using ab_bd by simp
+    have h2: \<open>(2::int) * (2^(n-1) * 2^(n-1)) = 2^(n-1) * 2^n\<close>
+      using R_split by (simp add: algebra_simps)
+    have h3: \<open>2 * \<bar>sint a * sint b\<bar> < 2^(n-1) * 2^n\<close>
+      using h1 h2 by linarith
+    have h4: \<open>(2::int)^(n-1) * 2^n + 2^(n-1) * 2^n = 2 * (2^(n-1) * 2^n)\<close>
+      by simp
+    show ?thesis using h3 N_R_bd h4 by linarith
+  qed
+  have lhs_lt: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+                  < 2 * (2^(n-1) * 2^n)\<close>
+    using bd_abs step by linarith
+  have R_pos: \<open>(0::int) < 2^n\<close> by simp
+  have abs_lt: \<open>\<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> < 2^(n-1)\<close>
+  proof -
+    have eq: \<open>2 * (2^(n-1) * (2::int)^n) = (2 * 2^(n-1)) * 2^n\<close>
+      by (simp add: mult.assoc)
+    have lhs2: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+                   < (2 * 2^(n-1)) * 2^n\<close>
+      using lhs_lt eq by simp
+    have can: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar>
+                  < 2 * (2::int)^(n-1)\<close>
+      using lhs2 R_pos by (simp add: mult_less_cancel_right)
+    show ?thesis using can by simp
+  qed
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (2^(n-1))\<^sub>\<rat>\<close>
+    using abs_eq abs_lt by (metis of_int_abs of_int_less_iff)
+
+qed
+
+section \<open>Signed Montgomery multiplication (rounding variant)\<close>
+
+
+
+text \<open>Replacing the two \<^verbatim>\<open>SQDMULH\<close> instructions with their rounding counterparts
+\<^verbatim>\<open>SQRDMULH\<close> --- and keeping the trailing \<^verbatim>\<open>SHSUB\<close> --- yields a four-instruction
+kernel not explicitly discussed in \cite{NeonNTT}.\<close>
+
+
+definition %internal \<open>mont_mul_neon_rounding_int n N bT a b \<equiv>
+     (let R = (2::int)^n;
+          z1 = sqrdmulh_int n a b;                 \<comment> \<open>SQRDMULH z, a, b\<close>
+          k  = (a * bT) mod\<^sup>\<plusminus> R;                    \<comment> \<open>MUL k, a, bT\<close>
+          c  = sqrdmulh_int n k N                  \<comment> \<open>SQRDMULH c, k, N\<close>
+      in (z1 - c) div 2)\<close>                          \<comment> \<open>SHSUB z, z, c\<close>
+
+text %internal \<open>The rounding version uses the same positive-inverse encoding
+\<^term>\<open>(N * T) mod 2^n = 1 mod 2^n\<close> as the non-rounding variant; the integer
+expansion of \<open>SQRDMULH\<close>'s correction \<open>round(2(kN)/R)\<close> shifts by an
+\emph{exact} integer \<^term>\<open>2*q\<close>, with no rounding ambiguity. Hence the kernel
+returns \<^term>\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk>(a * b)\<close> unconditionally.\<close>
+
+lemma %internal (in StandardModulus) mont_mul_neon_rounding_int_correct:
+  fixes a b T :: int
+  assumes T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>mont_mul_neon_rounding_int n N (b * T) a b = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>(a * b * T) mod\<^sup>\<plusminus> ?R\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have R_dvd_u: \<open>?R dvd (a * b - ?k * N)\<close>
+    using mont_sub_signed_divisible[OF T_inv, of \<open>a * b\<close>] by simp
+  then obtain q where q: \<open>a * b - ?k * N = ?R * q\<close>
+    unfolding dvd_def by auto
+  have mont_eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b) = q\<close>
+    using mont_sub_signed_unfold[OF T_inv, of \<open>a * b\<close>]
+          q R_pos by simp
+  have ab_eq: \<open>2 * (a * b) = ?R * (2 * q) + 2 * (?k * N)\<close>
+    using q by (simp add: algebra_simps)
+  have c_eq: \<open>sqrdmulh_int n ?k N = sqrdmulh_int n a b - 2 * q\<close>
+  proof -
+    have eq1: \<open>2 * (?k * N) = 2 * (a * b) - ?R * (2 * q)\<close>
+      using ab_eq by (simp add: algebra_simps)
+    have \<open>sqrdmulh_int n ?k N = \<lfloor>(2 * (?k * N)) /\<^sub>\<rat> ?R\<rceil>\<close>
+      unfolding sqrdmulh_int_def by (simp add: ac_simps)
+    also have \<open>\<dots> = \<lfloor>(2 * (a * b) - ?R * (2 * q)) /\<^sub>\<rat> ?R\<rceil>\<close>
+      using eq1 by simp
+    also have \<open>(2 * (a * b) - ?R * (2 * q)) /\<^sub>\<rat> ?R
+                 = (2 * (a * b)) /\<^sub>\<rat> ?R - (2 * q)\<^sub>\<rat>\<close>
+      by (simp add: field_simps)
+    also have \<open>\<lfloor>(2 * (a * b)) /\<^sub>\<rat> ?R - (2 * q)\<^sub>\<rat>\<rceil>
+                 = \<lfloor>(2 * (a * b)) /\<^sub>\<rat> ?R\<rceil> - 2 * q\<close>
+      unfolding round_def
+      using floor_diff_of_int[of \<open>(2 * (a * b)) /\<^sub>\<rat> ?R + 1/2\<close> \<open>2 * q\<close>]
+      by (simp add: algebra_simps)
+    also have \<open>\<lfloor>(2 * (a * b)) /\<^sub>\<rat> ?R\<rceil> = sqrdmulh_int n a b\<close>
+      unfolding sqrdmulh_int_def by (simp add: mult.assoc)
+    finally show ?thesis .
+  qed
+  have \<open>mont_mul_neon_rounding_int n N (b * T) a b
+          = (sqrdmulh_int n a b - sqrdmulh_int n ?k N) div 2\<close>
+    unfolding mont_mul_neon_rounding_int_def Let_def
+    by (simp add: algebra_simps)
+  also have \<open>\<dots> = (2 * q) div 2\<close> using c_eq by simp
+  also have \<open>\<dots> = q\<close> by simp
+  finally show ?thesis using mont_eq by simp
+qed
+
+text %internal \<open>Lifting to fixed-width signed words follows the same template as
+\<^term>\<open>mont_mul_neon_word\<close>. The non-saturation conditions on the second
+\<^verbatim>\<open>SQRDMULH\<close> are dispatched by the one-sided variant
+\<^term>\<open>sqrdmulh_int_no_sat_one_side\<close>.\<close>
+
+definition %internal mont_mul_neon_rounding_word
+  :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mont_mul_neon_rounding_word N bT a b \<equiv>
+     let ASM \<guillemotleft>
+       SQRDMULH z1 a b;
+       MUL      k  a bT;
+       SQRDMULH c  k N;
+       SHSUB    r  z1 c
+     \<guillemotright> in r\<close>
+
+lemma %internal sint_mont_mul_neon_rounding_word:
+  fixes N bT a b :: \<open>'a::len word\<close>
+    and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes nondeg_b: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close>
+      and N_std: \<open>1 < sint N \<and> sint N < 2^(n-1) \<and> odd (sint N)\<close>
+  shows \<open>sint (mont_mul_neon_rounding_word N bT a b)
+           = mont_mul_neon_rounding_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+proof -
+  have N_lo: \<open>1 < sint N\<close> using N_std by simp
+  have N_lt: \<open>sint N < 2^(n-1)\<close> using N_std by simp
+  let ?z1 = \<open>sqrdmulh_word a b\<close>
+  let ?k  = \<open>mul_word a bT\<close>
+  let ?c  = \<open>sqrdmulh_word ?k N\<close>
+  let ?R  = \<open>(2::int) ^ LENGTH('a)\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have absN: \<open>\<bar>sint N\<bar> < 2^(n-1)\<close>
+    using N_lo N_lt by linarith
+  have not_extreme1: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint b = -(2^(n-1)))\<close>
+    using nondeg_b by linarith
+
+  have not_extreme2: \<open>\<not> (sint ?k = -(2^(n-1)) \<and> sint N = -(2^(n-1)))\<close>
+    using absN by linarith
+  have z1_int: \<open>sint ?z1 = sqrdmulh_int (LENGTH('a)) (sint a) (sint b)\<close>
+    by (rule sint_sqrdmulh_word[OF refl not_extreme1[unfolded n_def]])
+  have k_int: \<open>sint ?k = (sint a * sint bT) mod\<^sup>\<plusminus> ?R\<close>
+    by (rule sint_mul_word[OF refl])
+  have c_int: \<open>sint ?c = sqrdmulh_int (LENGTH('a)) (sint ?k) (sint N)\<close>
+    by (rule sint_sqrdmulh_word[OF refl not_extreme2[unfolded n_def]])
+  have \<open>sint (mont_mul_neon_rounding_word N bT a b) = shsub_int (sint ?z1) (sint ?c)\<close>
+    unfolding mont_mul_neon_rounding_word_def Let_def by (rule sint_shsub_word)
+  also have \<open>\<dots> = shsub_int (sqrdmulh_int (LENGTH('a)) (sint a) (sint b))
+                            (sqrdmulh_int (LENGTH('a)) ((sint a * sint bT) mod\<^sup>\<plusminus> ?R) (sint N))\<close>
+    using z1_int c_int k_int by simp
+  also have \<open>\<dots> = mont_mul_neon_rounding_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    unfolding mont_mul_neon_rounding_int_def shsub_int_def sqrdmulh_int_def Let_def n_def
+    by (simp add: algebra_simps)
+  finally show ?thesis .
+qed
+
+
+theorem mont_mul_neon_rounding_word_correct:
+  fixes N bT a b :: \<open>'a::len word\<close> and n :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes N_std: \<open>StandardModulus (sint N) (n-1)\<close>
+      and bT_eq: \<open>sint bT = (sint b * ((sint N)\<^sup>-\<^sup>1 mod 2^n)) mod\<^sup>\<plusminus> 2^n\<close>
+      and nondeg_b: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQRDMULH z1 a b;
+                    MUL      k  a bT;
+                    SQRDMULH c  k N;
+                    SHSUB    r  z1 c
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+        \<comment> \<open>abstract description\<close>
+    and \<open>(sint out * 2^n) mod sint N = (sint a * sint b) mod sint N\<close>
+        \<comment> \<open>correctness\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a * sint b\<bar>\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+        \<comment> \<open>fine output bound\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (2^(n-1))\<^sub>\<rat>\<close>
+
+        \<comment> \<open>coarse output bound\<close>
+
+proof -
+  interpret SM0: StandardModulus \<open>sint N\<close> \<open>n-1\<close> by (rule N_std)
+  have N_lo: \<open>1 < sint N\<close> using SM0.Ngt1 .
+  have N_lt: \<open>sint N < 2^(n-1)\<close> using SM0.N_lt_R .
+  have N_odd: \<open>odd (sint N)\<close> using SM0.Nodd .
+  have N_pos: \<open>0 < sint N\<close> using N_lo by linarith
+  have n_pos: \<open>n > 0\<close> using SM0.npos by simp
+  have N_std_conj: \<open>1 < sint N \<and> sint N < 2^(n-1) \<and> odd (sint N)\<close>
+    using N_lo N_lt N_odd by simp
+
+  define T where \<open>T \<equiv> (sint N)\<^sup>-\<^sup>1 mod (2^n)\<close>
+  have T_inv: \<open>(sint N * T) mod 2^n = 1 mod 2^n\<close>
+    unfolding T_def using mod_inverse_correct(3)[OF n_pos N_odd] .
+  have step1: \<open>sint (mont_mul_neon_rounding_word N bT a b)
+                 = mont_mul_neon_rounding_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    by (rule sint_mont_mul_neon_rounding_word[OF n_def nondeg_b N_std_conj])
+
+  have step2: \<open>mont_mul_neon_rounding_int n (sint N) (sint bT) (sint a) (sint b)
+                 = mont_mul_neon_rounding_int n (sint N) (sint b * T) (sint a) (sint b)\<close>
+  proof -
+    have n_ge_1: \<open>n \<ge> 1\<close> using n_pos by simp
+    hence stb: \<open>\<And>x. signed_take_bit (n-1) x = x mod\<^sup>\<plusminus> 2^n\<close>
+      using signed_take_bit_eq_smod by blast
+    have bT_smod: \<open>sint bT mod\<^sup>\<plusminus> 2^n = (sint b * T) mod\<^sup>\<plusminus> 2^n\<close>
+      using bT_eq unfolding T_def
+      by (metis signed_take_bit_int_eq_self_iff signed_take_bit_int_greater_eq_minus_exp
+                signed_take_bit_int_less_exp stb)
+
+    have key: \<open>(sint a * sint bT) mod\<^sup>\<plusminus> 2^n
+                 = (sint a * (sint b * T)) mod\<^sup>\<plusminus> 2^n\<close>
+      using bT_smod stb
+            signed_take_bit_mult[of \<open>n-1\<close> \<open>sint a\<close> \<open>sint bT\<close>]
+            signed_take_bit_mult[of \<open>n-1\<close> \<open>sint a\<close> \<open>sint b * T\<close>]
+      by metis
+    show ?thesis
+      unfolding mont_mul_neon_rounding_int_def Let_def using key by (simp add: n_def)
+  qed
+  have N_lt_R: \<open>2^n > sint N\<close>
+  proof -
+    have h: \<open>(2::int)^(n-1) < 2^n\<close>
+      using n_pos by (simp add: power_strict_increasing)
+    show ?thesis using h N_lt by linarith
+  qed
+  interpret SM: StandardModulus \<open>sint N\<close> n
+    by unfold_locales (use N_lo N_odd n_pos N_lt_R in auto)
+  have step3: \<open>mont_mul_neon_rounding_int n (sint N) (sint b * T) (sint a) (sint b)
+                  = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    using SM.mont_mul_neon_rounding_int_correct[OF T_inv] .
+
+  have abs_eq: \<open>sint out = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    unfolding out_def mont_mul_neon_rounding_word_def[symmetric]
+    using step1 step2 step3 by simp
+  show \<open>sint out = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    by (rule abs_eq)
+  show \<open>(sint out * 2^n) mod sint N = (sint a * sint b) mod sint N\<close>
+    using abs_eq SM.mont_sub_signed_correct[of \<open>sint a * sint b\<close>] by simp
+  have bd: \<open>2 * \<bar>sint out\<bar> * 2^n \<le> 2 * \<bar>sint a * sint b\<bar> + sint N * 2^n\<close>
+    using abs_eq SM.mont_sub_signed_bound_int[of \<open>sint a * sint b\<close>] by simp
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> \<bar>sint a * sint b\<bar>\<^sub>\<rat> / (2^n)\<^sub>\<rat> + (sint N)\<^sub>\<rat> / 2\<close>
+  proof -
+    from bd have \<open>(2 * \<bar>sint out\<bar> * 2^n)\<^sub>\<rat> \<le> (2 * \<bar>sint a * sint b\<bar> + sint N * 2^n)\<^sub>\<rat>\<close>
+      by (metis of_int_le_iff)
+    thus ?thesis by (simp add: of_int_mult of_int_add of_int_abs field_simps)
+  qed
+
+  have bd_abs: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+                  \<le> 2 * \<bar>sint a * sint b\<bar> + sint N * 2^n\<close>
+    using SM.mont_sub_signed_bound_int[of \<open>sint a * sint b\<close>] .
+
+  have ab_bd: \<open>\<bar>sint a * sint b\<bar> < 2^(n-1) * 2^(n-1)\<close>
+  proof -
+    have h: \<open>\<bar>sint a * sint b\<bar> = \<bar>sint a\<bar> * \<bar>sint b\<bar>\<close> by (simp add: abs_mult)
+    have a_le: \<open>\<bar>sint a\<bar> \<le> 2^(n-1)\<close>
+      using sint_range_size[of a] by (simp add: word_size n_def, linarith)
+    have h2: \<open>\<bar>sint a\<bar> * \<bar>sint b\<bar> < 2^(n-1) * 2^(n-1)\<close>
+    proof -
+      have b_pos: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close> using nondeg_b by simp
+      have pow_pos: \<open>(0::int) < 2^(n-1)\<close> by simp
+      have \<open>\<bar>sint a\<bar> * \<bar>sint b\<bar> \<le> 2^(n-1) * \<bar>sint b\<bar>\<close>
+        using a_le by (intro mult_right_mono) auto
+      also have \<open>\<dots> < 2^(n-1) * 2^(n-1)\<close>
+        using b_pos pow_pos by (intro mult_strict_left_mono) auto
+      finally show ?thesis .
+    qed
+    show ?thesis using h h2 by simp
+  qed
+  have N_R_bd: \<open>sint N * 2^n < 2^(n-1) * 2^n\<close>
+    using N_lt by (simp add: mult_strict_right_mono)
+
+  have R_split: \<open>(2::int)^n = 2 * 2^(n-1)\<close>
+    using n_pos by (cases n; auto)
+  have step: \<open>2 * \<bar>sint a * sint b\<bar> + sint N * 2^n < 2 * (2^(n-1) * 2^n)\<close>
+  proof -
+    have h1: \<open>2 * \<bar>sint a * sint b\<bar> < 2 * (2^(n-1) * 2^(n-1))\<close>
+      using ab_bd by simp
+    have h2: \<open>(2::int) * (2^(n-1) * 2^(n-1)) = 2^(n-1) * 2^n\<close>
+      using R_split by (simp add: algebra_simps)
+    have h3: \<open>2 * \<bar>sint a * sint b\<bar> < 2^(n-1) * 2^n\<close>
+      using h1 h2 by linarith
+    have h4: \<open>(2::int)^(n-1) * 2^n + 2^(n-1) * 2^n = 2 * (2^(n-1) * 2^n)\<close>
+      by simp
+    show ?thesis using h3 N_R_bd h4 by linarith
+  qed
+  have lhs_lt: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+                  < 2 * (2^(n-1) * 2^n)\<close>
+    using bd_abs step by linarith
+  have R_pos: \<open>(0::int) < 2^n\<close> by simp
+  have abs_lt: \<open>\<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> < 2^(n-1)\<close>
+  proof -
+    have eq: \<open>2 * (2^(n-1) * (2::int)^n) = (2 * 2^(n-1)) * 2^n\<close>
+      by (simp add: mult.assoc)
+    have lhs2: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+                   < (2 * 2^(n-1)) * 2^n\<close>
+      using lhs_lt eq by simp
+    have can: \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar>
+                  < 2 * (2::int)^(n-1)\<close>
+      using lhs2 R_pos by (simp add: mult_less_cancel_right)
+    show ?thesis using can by simp
+  qed
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> < (2^(n-1))\<^sub>\<rat>\<close>
+    using abs_eq abs_lt by (metis of_int_abs of_int_less_iff)
+
+qed
+
+section \<open>Doubled Montgomery multiplication\<close>
+
+
+
+text \<open>\cite[Algorithm~13, \S 3.2]{NeonNTT}: the three-instruction
+\<^verbatim>\<open>SQRDMULH\<close>/\<^verbatim>\<open>MUL\<close>/\<^verbatim>\<open>SQRDMLAH\<close> sequence doubles the result
+and computes \<^term>\<open>2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N,n\<rbrakk>(a*b)\<close> on signed lanes.\<close>
+
+
+definition %internal \<open>mont_mul_neon_rounding_doubled_int n N bT a b \<equiv>
+     (let R = (2::int)^n;
+          z = sqrdmulh_int n a b;                  \<comment> \<open>SQRDMULH z, a, b\<close>
+          k = (a * bT) mod\<^sup>\<plusminus> R;                     \<comment> \<open>MUL k, a, bT\<close>
+          c = sqrdmulh_int n k N                   \<comment> \<open>(rounding correction)\<close>
+      in z + c)\<close>                                   \<comment> \<open>SQRDMLAH z, k, N\<close>
+
+text %internal \<open>Up to renaming, the integer kernel coincides syntactically with
+\<^term>\<open>mont_mul_rounding_doubled_int\<close> from \<open>Montgomery_Doubling.thy\<close> when the precomputed
+twiddle is \<^term>\<open>bT = b*T\<close>. Composing the syntactic equality with
+\<^term>\<open>mont_mul_rounding_doubled_eq\<close> gives integer-level correctness.\<close>
+
+lemma %internal mont_mul_neon_rounding_doubled_int_eq_doubled:
+  fixes a b N T :: int and n :: nat
+  shows \<open>mont_mul_neon_rounding_doubled_int n N (b * T) a b
+           = mont_mul_rounding_doubled_int N n T a b\<close>
+  unfolding mont_mul_neon_rounding_doubled_int_def mont_mul_rounding_doubled_int_def
+            Let_def sqrdmulh_int_def
+  by (simp add: algebra_simps)
+
+lemma %internal (in StandardModulus) mont_mul_neon_rounding_doubled_int_correct:
+  fixes a b T :: int
+  assumes T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+      and parity: \<open>2 * a * b mod 2^n \<noteq> 2^(n-1)\<close>
+  shows \<open>mont_mul_neon_rounding_doubled_int n N (b * T) a b
+           = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>
+  using mont_mul_neon_rounding_doubled_int_eq_doubled[of n N b T a]
+        mont_mul_rounding_doubled_eq[OF T_inv parity]
+  by simp
+
+text %internal \<open>Discharging the non-tie hypothesis. With \<^term>\<open>\<bar>a\<bar> < (2::int)^(n-2)\<close> and
+\<^term>\<open>odd b\<close>, the only way \<^term>\<open>(2*a*b) mod 2^n = (2::int)^(n-1)\<close> would force
+\<^term>\<open>(2::int)^(n-2) dvd a\<close>, hence \<^term>\<open>a = 0\<close>; then \<open>2ab = 0 \<noteq> 2^(n-1) (mod 2^n)\<close>, a contradiction.\<close>
+
+lemma %internal parity_discharge:
+  fixes a b :: int and n :: nat
+  assumes \<open>n \<ge> 2\<close> and \<open>\<bar>a\<bar> < 2^(n-2)\<close> and \<open>odd b\<close>
+  shows \<open>2 * a * b mod 2^n \<noteq> 2^(n-1)\<close>
+proof
+  assume eq: \<open>2 * a * b mod 2^n = 2^(n-1)\<close>
+  have nge1: \<open>n \<ge> 1\<close> using assms(1) by linarith
+  have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close>
+    using nge1 by (cases n) auto
+  have H_eq: \<open>(2::int)^(n-1) = 2 * 2^(n-2)\<close>
+  proof -
+    have \<open>n - 1 = Suc (n - 2)\<close> using assms(1) by simp
+    thus ?thesis by simp
+  qed
+  have ab_eq: \<open>2 * a * b = 2^n * (2 * a * b div 2^n) + 2^(n-1)\<close>
+    using eq by (metis div_mod_decomp_int mult.commute)
+  define q where q_def: \<open>q = 2 * a * b div 2^n\<close>
+  have ab_eq2: \<open>2 * a * b = 2^n * q + 2^(n-1)\<close>
+    using ab_eq q_def by simp
+  have ab_eq3: \<open>2 * a * b = 2^(n-1) * (2 * q + 1)\<close>
+    using ab_eq2 R_eq by (simp add: algebra_simps)
+  have ab_eq4: \<open>a * b = 2^(n-2) * (2 * q + 1)\<close>
+    using ab_eq3 H_eq by simp
+  have H2_dvd_ab: \<open>(2::int)^(n-2) dvd a * b\<close>
+    using ab_eq4 by (metis dvd_triv_left)
+  have copr: \<open>coprime ((2::int)^(n-2)) b\<close>
+    using assms(3) by simp
+  have H2_dvd_a: \<open>(2::int)^(n-2) dvd a\<close>
+    using H2_dvd_ab copr coprime_dvd_mult_left_iff by blast
+  have a_zero: \<open>a = 0\<close>
+    using H2_dvd_a assms(2) dvd_imp_le_int by force
+  hence \<open>2 * a * b = 0\<close> by simp
+  hence \<open>(2::int)^(n-1) * (2 * q + 1) = 0\<close>
+    using ab_eq3 by simp
+  hence \<open>2 * q + 1 = 0\<close> by simp
+  thus False by presburger
+qed
+
+text %internal \<open>The word-level kernel uses \<^verbatim>\<open>SQRDMLAH\<close> to fuse the high-product and the
+correction. To turn the abstract \<^term>\<open>z + sqrdmulh_int n k N\<close> back into
+\<^term>\<open>sint\<close> of the \asminst{SQRDMLAH} output we need (a) non-saturation of the second
+\<^verbatim>\<open>SQRDMULH\<close> --- furnished by \<^term>\<open>sqrdmulh_int_no_sat_one_side\<close>; and (b)
+non-saturation of the \asminst{SQRDMLAH} itself --- the integer result fits inside
+the canonical signed range.\<close>
+
+definition %internal mont_mul_neon_rounding_doubled_word
+  :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mont_mul_neon_rounding_doubled_word N bT a b \<equiv>
+     let ASM \<guillemotleft>
+       SQRDMULH z a b;
+       MUL      k a bT;
+       SQRDMLAH r z k N
+     \<guillemotright> in r\<close>
+
+lemma %internal sint_mont_mul_neon_rounding_doubled_word:
+  fixes N bT a b :: \<open>'a::len word\<close>
+    and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes nondeg_a: \<open>\<bar>sint a\<bar> < 2^(n-1)\<close>
+      and nondeg_b: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close>
+      and N_std: \<open>1 < sint N \<and> sint N < 2^(n-1) \<and> odd (sint N)\<close>
+      \<comment> \<open>final SQRDMLAH does not saturate\<close>
+      and no_sat: \<open>-(2^(n-1)) \<le> mont_mul_neon_rounding_doubled_int n
+                                     (sint N) (sint bT) (sint a) (sint b)\<close>
+                  \<open>mont_mul_neon_rounding_doubled_int n
+                     (sint N) (sint bT) (sint a) (sint b) < 2^(n-1)\<close>
+  shows \<open>sint (mont_mul_neon_rounding_doubled_word N bT a b)
+           = mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+proof -
+  have N_lo: \<open>1 < sint N\<close> using N_std by simp
+  have N_lt: \<open>sint N < 2^(n-1)\<close> using N_std by simp
+  let ?z = \<open>sqrdmulh_word a b\<close>
+  let ?k = \<open>mul_word a bT\<close>
+  let ?R = \<open>(2::int) ^ LENGTH('a)\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have not_extreme1: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint b = -(2^(n-1)))\<close>
+    using nondeg_a by linarith
+  have z_int: \<open>sint ?z = sqrdmulh_int (LENGTH('a)) (sint a) (sint b)\<close>
+    by (rule sint_sqrdmulh_word[OF refl not_extreme1[unfolded n_def]])
+  have k_int: \<open>sint ?k = (sint a * sint bT) mod\<^sup>\<plusminus> ?R\<close>
+    by (rule sint_mul_word[OF refl])
+  have body_eq: \<open>sqrdmlah_int n (sint ?z) (sint ?k) (sint N)
+                   = mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    unfolding sqrdmlah_int_def mont_mul_neon_rounding_doubled_int_def Let_def
+    using z_int k_int by (simp add: n_def)
+  have lo: \<open>-(2^(n-1)) \<le> sqrdmlah_int n (sint ?z) (sint ?k) (sint N)\<close>
+    using body_eq no_sat(1) by simp
+  have hi: \<open>sqrdmlah_int n (sint ?z) (sint ?k) (sint N) < 2 ^ (n - 1)\<close>
+    using body_eq no_sat(2) by simp
+  have \<open>sint (mont_mul_neon_rounding_doubled_word N bT a b)
+          = sint (sqrdmlah_word ?z ?k N)\<close>
+    unfolding mont_mul_neon_rounding_doubled_word_def Let_def by (rule refl)
+  also have \<open>\<dots> = sqrdmlah_int n (sint ?z) (sint ?k) (sint N)\<close>
+    by (rule sint_sqrdmlah_word[OF n_def lo hi])
+  also have \<open>\<dots> = mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    using body_eq .
+  finally show ?thesis .
+qed
+
+
+
+theorem mont_mul_neon_rounding_doubled_word_correct:
+  fixes N bT a b :: \<open>'a::len word\<close> and n :: nat
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes N_std: \<open>StandardModulus (sint N) (n-2)\<close>
+      and bT_eq: \<open>sint bT = (sint b * ((- ((sint N)\<^sup>-\<^sup>1 mod 2^n)) mod 2^n)) mod\<^sup>\<plusminus> 2^n\<close>
+      and small_a: \<open>\<bar>sint a\<bar> < 2^(n-2)\<close>
+      and odd_b: \<open>odd (sint b)\<close>
+  defines \<open>out \<equiv> let ASM \<guillemotleft>
+                    SQRDMULH z a b;
+                    MUL      k a bT;
+                    SQRDMLAH r z k N
+                  \<guillemotright> in r\<close>
+  shows \<open>sint out = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+        \<comment> \<open>abstract description\<close>
+    and \<open>(sint out * 2^n) mod sint N = (2 * sint a * sint b) mod sint N\<close>
+        \<comment> \<open>correctness\<close>
+    and \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> (2^(n-1))\<^sub>\<rat>\<close>
+        \<comment> \<open>coarse output bound\<close>
+proof -
+  interpret SM0: StandardModulus \<open>sint N\<close> \<open>n-2\<close> by (rule N_std)
+  have N_lo: \<open>1 < sint N\<close> using SM0.Ngt1 .
+  have N_lt_n2: \<open>sint N < 2^(n-2)\<close> using SM0.N_lt_R .
+  have N_small: \<open>sint N \<le> 2^(n-2)\<close> using N_lt_n2 by linarith
+  have N_lt: \<open>sint N < 2^(n-1)\<close>
+    using N_lt_n2 power_increasing[of \<open>n-2\<close> \<open>n-1\<close> \<open>2::int\<close>] by linarith
+  have N_odd: \<open>odd (sint N)\<close> using SM0.Nodd .
+  have N_std_conj: \<open>1 < sint N \<and> sint N < 2^(n-1) \<and> odd (sint N)\<close>
+    using N_lo N_lt N_odd by simp
+  have N_pos: \<open>0 < sint N\<close> using N_lo by linarith
+  have nge2: \<open>n \<ge> 2\<close>
+  proof (rule ccontr)
+    assume \<open>\<not> (n \<ge> 2)\<close>
+    hence \<open>n \<le> 1\<close> by simp
+    hence \<open>n - 1 = 0\<close> by simp
+    hence \<open>(2::int)^(n-1) = 1\<close> by simp
+    thus False using N_lo N_lt by linarith
+  qed
+  have n_pos: \<open>n > 0\<close> using nge2 by linarith
+  have n_ge_1: \<open>n \<ge> 1\<close> using n_pos by simp
+  have nondeg_a: \<open>\<bar>sint a\<bar> < 2^(n-1)\<close>
+  proof -
+    have h: \<open>(2::int)^(n-2) \<le> 2^(n-1)\<close>
+      by (simp add: power_increasing)
+    show ?thesis using small_a h by linarith
+  qed
+  have nondeg_b: \<open>\<bar>sint b\<bar> < 2^(n-1)\<close>
+  proof -
+    have rb: \<open>-(2^(n-1)) \<le> sint b \<and> sint b < 2 ^ (n - 1)\<close>
+      using sint_in_signed_range[OF n_def, of b] .
+    have b_ne_min: \<open>sint b \<noteq> -(2^(n-1))\<close>
+    proof
+      assume \<open>sint b = -(2^(n-1))\<close>
+      moreover have \<open>even ((2::int)^(n-1))\<close> using nge2 by simp
+      ultimately have \<open>even (sint b)\<close> by simp
+      thus False using odd_b by simp
+    qed
+    show ?thesis using rb b_ne_min by linarith
+  qed
+  have parity: \<open>2 * sint a * sint b mod 2^n \<noteq> 2^(n-1)\<close>
+    by (rule parity_discharge[OF nge2 small_a odd_b])
+
+
+  have N_lt_R: \<open>2^n > sint N\<close>
+  proof -
+    have h: \<open>(2::int)^(n-1) < 2^n\<close>
+      using n_pos by (simp add: power_strict_increasing)
+    show ?thesis using h N_lt by linarith
+  qed
+  interpret SM: StandardModulus \<open>sint N\<close> n
+    by unfold_locales (use N_lo N_odd n_pos N_lt_R in auto)
+  define T where \<open>T \<equiv> (- ((sint N)\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  have T_inv: \<open>(sint N * T) mod 2^n = (- 1) mod 2^n\<close>
+    unfolding T_def using SM.mod_inverse_neg_correct by (simp add: mult.commute)
+  \<comment> \<open>Derive the SQRDMLAH non-saturation bound from \<open>|sint a| < 2^(n-2)\<close>,
+        \<open>|sint b| < 2^(n-1)\<close> and \<open>sint N \<le> 2^(n-2)\<close>.\<close>
+  have B: \<open>2 * \<bar>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n
+              \<le> 2 * \<bar>sint a * sint b\<bar> + sint N * 2^n\<close>
+    using SM.mont_add_signed_bound_int[of \<open>sint a * sint b\<close>] .
+  have ab_bd: \<open>\<bar>sint a * sint b\<bar> < 2^(n-2) * 2^(n-1)\<close>
+  proof -
+    have h1: \<open>\<bar>sint a * sint b\<bar> = \<bar>sint a\<bar> * \<bar>sint b\<bar>\<close> by (simp add: abs_mult)
+    have h2: \<open>\<bar>sint a\<bar> * \<bar>sint b\<bar> < 2^(n-2) * 2^(n-1)\<close>
+      using small_a nondeg_b by (intro mult_strict_mono) auto
+    show ?thesis using h1 h2 by simp
+  qed
+
+  have N_2n_eq: \<open>(2::int)^(n-2) * 2^n = 2^(2*n-2)\<close>
+  proof -
+    have \<open>(n-2) + n = 2*n - 2\<close> using nge2 by simp
+    thus ?thesis by (metis power_add)
+  qed
+  have ab_double_bd: \<open>2 * \<bar>sint a * sint b\<bar> < 2^(2*n-2)\<close>
+  proof -
+    have e1: \<open>(2::int)^(n-2) * 2^(n-1) = 2^(2*n-3)\<close>
+    proof -
+      have \<open>(n-2) + (n-1) = 2*n-3\<close> using nge2 by simp
+      thus ?thesis by (metis power_add)
+    qed
+    have e2: \<open>(2::int) * 2^(2*n-3) = 2^(2*n-2)\<close>
+    proof -
+      have \<open>2*n - 3 + 1 = 2*n - 2\<close> using nge2 by simp
+      thus ?thesis by (metis power_Suc Suc_eq_plus1)
+    qed
+    have \<open>2 * \<bar>sint a * sint b\<bar> < 2 * 2^(2*n-3)\<close>
+      using ab_bd e1 by linarith
+    thus ?thesis using e2 by linarith
+  qed
+  have rhs_eq: \<open>(2::int) * 2^(2*n-2) = 2^(n-1) * 2^n\<close>
+  proof -
+    have h1: \<open>(2::int) * 2^(2*n-2) = 2^(2*n-1)\<close>
+    proof -
+      have \<open>(2*n-2)+1 = 2*n - 1\<close> using nge2 by simp
+      thus ?thesis by (metis power_Suc Suc_eq_plus1)
+    qed
+    have h2: \<open>(2::int)^(n-1) * 2^n = 2^(2*n-1)\<close>
+    proof -
+      have \<open>(n-1)+n = 2*n-1\<close> using nge2 by simp
+      thus ?thesis by (metis power_add)
+    qed
+    show ?thesis using h1 h2 by simp
+  qed
+  have N2n: \<open>sint N * 2^n \<le> 2^(n-2) * 2^n\<close>
+    using N_small by simp
+  have sum_bd: \<open>2 * \<bar>sint a * sint b\<bar> + sint N * 2^n < 2 * 2^(2*n-2)\<close>
+    using ab_double_bd N2n N_2n_eq by linarith
+  have lhs_lt: \<open>2 * \<bar>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> * 2^n < 2^(n-1) * 2^n\<close>
+    using B sum_bd rhs_eq by linarith
+  have R_pos: \<open>(0::int) < 2^n\<close> by simp
+  have no_sat: \<open>\<bar>2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<bar> < 2^(n-1)\<close>
+    using lhs_lt R_pos by (simp add: mult_less_cancel_right)
+  \<comment> \<open>Step 1: integer kernel applied to the precomputed twiddle = abstract doubled \<open>mont_add\<close>.\<close>
+  have step_int_b: \<open>mont_mul_neon_rounding_doubled_int n (sint N) (sint b * T) (sint a) (sint b)
+                      = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    using SM.mont_mul_neon_rounding_doubled_int_correct[OF T_inv parity] .
+
+  \<comment> \<open>Step 2: the integer kernel only depends on \<open>bT\<close> through \<open>(a*bT) mod\<^sup>\<plusminus> R\<close>;
+        rewriting \<open>sint bT\<close> to \<open>sint b * T\<close> modulo signed reduction
+        is the same calculation as for the \asminst{SHSUB} kernel.\<close>
+  have step_bT_eq: \<open>mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)
+                      = mont_mul_neon_rounding_doubled_int n (sint N) (sint b * T) (sint a) (sint b)\<close>
+  proof -
+    have stb: \<open>\<And>x. signed_take_bit (n-1) x = x mod\<^sup>\<plusminus> 2^n\<close>
+      using signed_take_bit_eq_smod[OF n_ge_1] by blast
+    have bT_smod: \<open>sint bT mod\<^sup>\<plusminus> 2^n = (sint b * T) mod\<^sup>\<plusminus> 2^n\<close>
+      using bT_eq unfolding T_def
+      by (metis signed_take_bit_int_eq_self_iff signed_take_bit_int_greater_eq_minus_exp
+                signed_take_bit_int_less_exp stb)
+
+
+    have key: \<open>(sint a * sint bT) mod\<^sup>\<plusminus> 2^n
+                 = (sint a * (sint b * T)) mod\<^sup>\<plusminus> 2^n\<close>
+      using bT_smod stb
+            signed_take_bit_mult[of \<open>n-1\<close> \<open>sint a\<close> \<open>sint bT\<close>]
+            signed_take_bit_mult[of \<open>n-1\<close> \<open>sint a\<close> \<open>sint b * T\<close>]
+      by metis
+    show ?thesis
+      unfolding mont_mul_neon_rounding_doubled_int_def Let_def
+      using key by (simp add: n_def)
+  qed
+  have step_int: \<open>mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)
+                    = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    using step_bT_eq step_int_b by simp
+  \<comment> \<open>Step 3: lift via \<open>sint_mont_mul_neon_rounding_doubled_word\<close>; the
+        non-saturation of \asminst{SQRDMLAH} was derived from the input bounds.\<close>
+  have lo: \<open>-(2^(n-1))
+              \<le> mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    using step_int no_sat by linarith
+  have hi: \<open>mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)
+              < 2^(n-1)\<close>
+    using step_int no_sat by linarith
+  have step_word: \<open>sint (mont_mul_neon_rounding_doubled_word N bT a b)
+                     = mont_mul_neon_rounding_doubled_int n (sint N) (sint bT) (sint a) (sint b)\<close>
+    by (rule sint_mont_mul_neon_rounding_doubled_word[OF n_def nondeg_a nondeg_b N_std_conj lo hi])
+
+  have abs_eq: \<open>sint out = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    unfolding out_def mont_mul_neon_rounding_doubled_word_def[symmetric]
+    using step_word step_int by simp
+  show \<open>sint out = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b)\<close>
+    by (rule abs_eq)
+  have mont_eq: \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b) * 2^n) mod sint N
+                    = (sint a * sint b) mod sint N\<close>
+    using SM.mont_add_signed_correct[of \<open>sint a * sint b\<close>] .
+  show \<open>(sint out * 2^n) mod sint N = (2 * sint a * sint b) mod sint N\<close>
+  proof -
+    have e1: \<open>sint out * 2^n
+                = 2 * (mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b) * 2^n)\<close>
+      using abs_eq by simp
+    have e2: \<open>(2 * (mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>sint N, n\<rbrakk> (sint a * sint b) * 2^n)) mod sint N
+                = (2 * (sint a * sint b)) mod sint N\<close>
+      using mont_eq by (metis mod_mult_right_eq)
+    show ?thesis using e1 e2 by (simp add: mult.assoc)
+  qed
+  have rng: \<open>-(2^(n-1)) \<le> sint out \<and> sint out < 2^(n-1)\<close>
+    unfolding out_def
+    using sint_in_signed_range[OF n_def] by blast
+
+  show \<open>\<bar>(sint out)\<^sub>\<rat>\<bar> \<le> (2^(n-1))\<^sub>\<rat>\<close>
+  proof -
+    have \<open>\<bar>sint out\<bar> \<le> 2^(n-1)\<close> using rng by linarith
+    thus ?thesis by (metis of_int_abs of_int_le_iff)
+  qed
+
+qed
+
+
+end

--- a/proofs/isabelle/neon_ntt/Barrett_Bound_Quality.thy
+++ b/proofs/isabelle/neon_ntt/Barrett_Bound_Quality.thy
@@ -1,0 +1,470 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Barrett_Bound_Quality
+  imports Barrett_Montgomery "HOL-Library.Code_Target_Numeral"
+begin
+
+chapter \<open>Quality of the Barrett bounds \label{ch:barrett_bound_quality}\<close>
+
+text %internal \<open>To avoid hardcoding values, we introduce some helper antiquotation for evaluating
+and pretty-printing rationals in decimal form:\<close>
+setup %internal \<open>
+  let
+    fun fmt_decimal {digits, percentage} (p, q) =
+      let
+        val p1 = if percentage then p * 100 else p
+        val sfx = if percentage then "%" else ""
+        val sign = if (p1 < 0) <> (q < 0) andalso p1 <> 0 then "-" else ""
+        val ap = abs p1 val aq = abs q
+        val whole = ap div aq
+        val rem = ap mod aq
+        fun pow10 0 = 1 | pow10 n = 10 * pow10 (n-1)
+        val sc = pow10 digits
+        val frac = (rem * sc) div aq
+        val exact = (rem * sc) mod aq = 0
+        fun pad n s = if size s >= n then s else pad n ("0" ^ s)
+        val frac_str = pad digits (string_of_int frac)
+        val body =
+          if digits = 0 then sign ^ string_of_int whole
+          else sign ^ string_of_int whole ^ "." ^ frac_str
+        val approx = if exact then "" else "\<approx> "
+      in approx ^ body ^ sfx end
+
+    fun dest_pq t =
+      case t of
+        Const (\<^const_name>\<open>Product_Type.Pair\<close>, _) $ p $ q =>
+          (snd (HOLogic.dest_number p), snd (HOLogic.dest_number q))
+      | _ => raise TERM ("dest_pq: not a pair", [t])
+
+    fun upd_digits n (_, p) = (n, p)
+    val upd_pct = fn (d, _) => (d, true)
+
+    val one_arg =
+          (Parse.nat >> (fn n => upd_digits n))
+       || (Parse.name >> (fn s =>
+             if s = "percentage" then upd_pct
+             else error ("Unknown decimal option: " ^ s)))
+
+    val parse_opts =
+      Scan.optional (Scan.lift (Args.parens (Parse.enum "," one_arg))) []
+      >> (fn fs => fold I fs (4, false))
+      >> (fn (d, p) => {digits = d, percentage = p})
+  in
+    Document_Output.antiquotation_pretty_source_embedded \<^binding>\<open>decimal\<close>
+      (parse_opts -- Args.term)
+      (fn ctxt => fn (opts, t) =>
+         let
+           val qot = \<^Const>\<open>quotient_of\<close> $ t
+           val v = Value_Command.value ctxt qot
+           val pq = dest_pq v
+         in Pretty.str (fmt_decimal opts pq) end)
+  end
+  \<close>
+
+context %internal BarrettContext
+begin
+text \<open>The purpose of this chapter is to empirically evaluate the quality of the bounds
+of @{thm [source] barrett_bound_eps_narrow}. In particular, we will exhibit concrete instantiations
+of @{locale BarrettContext} demonstrating that @{thm [source] barrett_bound_eps_narrow} is tight
+and cannot be improved further (for generic moduli).\<close>
+end %internal
+
+text\<open>Throughout, we work in the context of @{locale BarrettContext}:\<close>
+
+context BarrettContext
+begin
+
+section \<open>Empirical maxima and analytic bounds\<close>
+
+text \<open>We define, in \<^locale>\<open>BarrettContext\<close>, the maximum achieved Barrett
+magnitude over the input range @{term "{-(2^(n-1)).. 2^(n-1)}"} (signed and unsigned),
+and the matching analytic upper bound recorded in \autoref{ch:barrett_montgomery}.\<close>
+
+definition \<open>bar_signed_max \<equiv>  MAX z\<in>{-(2^(n-1))..2^(n-1)}. \<bar>bar\<^sup>\<plusminus> \<lbrakk>N,n,f\<rbrakk> z\<bar>\<close>
+definition \<open>bar_unsigned_max \<equiv> MAX z\<in>{-(2^(n-1))..2^(n-1)}. \<bar>bar\<^sup>+ \<lbrakk>N,n,f\<rbrakk> z\<bar>\<close>
+definition \<open>bar_signed_bound \<equiv> \<lfloor>N\<^sub>\<rat> * (\<epsilon>(f, R /\<^sub>\<rat> N) + 1) / 2\<rfloor>\<close>
+definition \<open>bar_unsigned_bound \<equiv> \<lfloor>N\<^sub>\<rat> * (\<epsilon>(f, R /\<^sub>\<rat> N) + 2) / 2 - N /\<^sub>\<rat> R\<rfloor>\<close>
+
+text \<open>A pointwise integer-form upper bound on \<^term>\<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar>\<close>,
+obtained by floor-applying the rational bound
+@{thm [source] barrett_bound_eps_narrow} at the canonical residue
+\<^term>\<open>\<epsilon>(f, R /\<^sub>\<rat> N)\<close>. Used as the early-termination predicate for the
+exhaustive sweeps below.\<close>
+
+definition \<open>bar_signed_bnd_at z \<equiv> \<lfloor>\<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<rfloor>\<close>
+definition \<open>bar_unsigned_bnd_at z \<equiv> \<lfloor>\<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<rfloor>\<close>
+
+text\<open>The following is merely a restatement of @{thm [source] barrett_montgomery_bounds_eps}:\<close>
+                             
+lemma bar_bnd_at_correct_mono:
+  shows \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> bar_signed_bnd_at \<bar>z\<bar>\<close>
+    and \<open>\<bar>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> bar_unsigned_bnd_at \<bar>z\<bar>\<close>
+    and \<open>0 \<le> a \<Longrightarrow> a \<le> b \<Longrightarrow> bar_signed_bnd_at a \<le> bar_signed_bnd_at b\<close>
+    and \<open>0 \<le> a \<Longrightarrow> a \<le> b \<Longrightarrow> bar_unsigned_bnd_at a \<le> bar_unsigned_bnd_at b\<close>
+proof -
+  have \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> bar_signed_bnd_at z\<close>
+    unfolding bar_signed_bnd_at_def
+    using floor_mono[OF barrett_montgomery_bounds_eps(1)[of z]]
+    by (metis floor_of_int of_int_abs)
+  moreover have \<open>bar_signed_bnd_at z = bar_signed_bnd_at \<bar>z\<bar>\<close>
+    unfolding bar_signed_bnd_at_def by simp
+  ultimately show \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> bar_signed_bnd_at \<bar>z\<bar>\<close> by simp
+next
+  have \<open>\<bar>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> bar_unsigned_bnd_at z\<close>
+    unfolding bar_unsigned_bnd_at_def
+    using floor_mono[OF barrett_montgomery_bounds_eps(2)[of z]]
+    by (metis floor_of_int of_int_abs)
+  moreover have \<open>bar_unsigned_bnd_at z = bar_unsigned_bnd_at \<bar>z\<bar>\<close>
+    unfolding bar_unsigned_bnd_at_def by simp
+  ultimately show \<open>\<bar>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> bar_unsigned_bnd_at \<bar>z\<bar>\<close> by simp
+next
+  fix a b :: int assume \<open>0 \<le> a\<close> \<open>a \<le> b\<close>
+  hence abs_le: \<open>\<bar>a\<bar>\<^sub>\<rat> \<le> \<bar>b\<bar>\<^sub>\<rat>\<close> by simp
+  have nn: \<open>0 \<le> N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)\<close> using Npos by simp
+  have \<open>\<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2
+        \<le> \<bar>b\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+    using abs_le nn R_pos_rat by (simp add: divide_right_mono mult_right_mono)
+  thus \<open>bar_signed_bnd_at a \<le> bar_signed_bnd_at b\<close>
+    unfolding bar_signed_bnd_at_def by (rule floor_mono)
+next
+  fix a b :: int assume \<open>0 \<le> a\<close> \<open>a \<le> b\<close>
+  hence abs_le: \<open>\<bar>a\<bar>\<^sub>\<rat> \<le> \<bar>b\<bar>\<^sub>\<rat>\<close> by simp
+  have nn: \<open>0 \<le> N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)\<close> using Npos by simp
+  have \<open>\<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R
+        \<le> \<bar>b\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+    using abs_le nn R_pos_rat by (simp add: divide_right_mono mult_right_mono)
+  thus \<open>bar_unsigned_bnd_at a \<le> bar_unsigned_bnd_at b\<close>
+    unfolding bar_unsigned_bnd_at_def by (rule floor_mono)
+qed
+
+lemmas %internal correct_signed   = bar_bnd_at_correct_mono(1)
+lemmas %internal correct_unsigned = bar_bnd_at_correct_mono(2)
+lemmas %internal mono_signed      = bar_bnd_at_correct_mono(3)
+lemmas %internal mono_unsigned    = bar_bnd_at_correct_mono(4)
+
+section \<open>Computable maxima via exhaustive sweep with early termination\<close>
+
+text \<open>Naive computation of @{thm [show_question_marks=false] (rhs) bar_signed_max_def} is impractical for larger values
+of @{term N} and @{term n}. Instead, we use the following stand-alone helper computing the maximum absolute 
+value of an integer function \<open>f\<close> over a symmetric interval @{term "{-max_abs..max_abs}"} with the help of an
+\emph{early termination} condition: every \<open>K\<close> inward steps, the recursion checks whether a user-supplied bound 
+\<^term>\<open>f_bnd\<close> on the un-swept inner radius is already dominated by the current candidate maximum, and if so 
+returns immediately. The recursion sweeps inward from \<^term>\<open>max_abs\<close> toward \<^term>\<open>0\<close>, processing the symmetric
+pair @{term "(g i, g (-i))"} per step.\<close>
+
+end \<comment>\<open>... temporarily leaving the context of @{locale BarrettContext}\<close>
+
+function max_abs_with_bound_core ::
+  \<open>(int \<Rightarrow> int) \<Rightarrow> (int \<Rightarrow> int) \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> int \<Rightarrow> int \<Rightarrow> int\<close>
+where
+  \<comment>\<open>Base case: no steps left; return the running maximum.\<close>
+  \<open>max_abs_with_bound_core f f_bnd 0       K i cur = cur\<close>
+| \<open>max_abs_with_bound_core f f_bnd (Suc k) K i cur =
+   (let cur' = max (max cur \<bar>f i\<bar>) \<bar>f (-i)\<bar>;  \<comment>\<open>update with symmetric pair\<close>
+        tail_radius = i - 1;
+        checkpoint = (K = 0 \<or> k mod K = 0);    \<comment>\<open>consult early-exit every \<open>K\<close> steps\<close>
+        can_skip = (checkpoint \<and> tail_radius \<ge> 0 \<and> f_bnd tail_radius \<le> cur')
+    in if can_skip then cur'
+       else max_abs_with_bound_core f f_bnd k K tail_radius cur')\<close>
+  by pat_completeness auto
+termination %internal by (relation \<open>measure (\<lambda>(_,_,k,_,_,_). k)\<close>) auto
+
+definition \<open>max_abs_with_bound f f_bnd max_abs K \<equiv>
+  \<comment>\<open>Sweep \<open>[-max_abs..max_abs]\<close> from the outside in, starting with \<open>cur = 0\<close>.\<close>
+  max_abs_with_bound_core f f_bnd (max_abs + 1) K (int max_abs) 0\<close>
+
+text %internal \<open>Strengthened induction lemma for \<^const>\<open>max_abs_with_bound_core\<close>.
+Reading: at recursion depth \<open>Suc k\<close> with index \<open>i\<close> (where \<open>nat i = k\<close>) and
+accumulator \<open>cur\<close>, the result is the maximum of \<open>cur\<close> and \<open>Max \<bar>f\<bar>\<close> over
+\<open>[-i..i]\<close>.
+
+The early-exit branch is justified by monotonicity of the bound: if
+\<open>f_bnd tail_radius \<le> cur'\<close> then for every \<open>z\<close> with \<open>\<bar>z\<bar> \<le> tail_radius\<close> we have
+\<open>\<bar>f z\<bar> \<le> f_bnd \<bar>z\<bar> \<le> f_bnd tail_radius \<le> cur'\<close>, so the un-swept inner range
+cannot improve \<open>cur'\<close>. The continue branch uses the IH on the smaller index.\<close>
+
+lemma %internal max_abs_with_bound_core_correct:
+  fixes f f_bnd :: \<open>int \<Rightarrow> int\<close>
+  assumes bnd_correct: \<open>\<And>x. \<bar>f x\<bar> \<le> f_bnd \<bar>x\<bar>\<close>
+      and bnd_mono:    \<open>\<And>a b. 0 \<le> a \<Longrightarrow> a \<le> b \<Longrightarrow> f_bnd a \<le> f_bnd b\<close>
+  shows \<open>\<And>i cur. i \<ge> 0 \<Longrightarrow> nat i = k \<Longrightarrow>
+           max_abs_with_bound_core f f_bnd (Suc k) K i cur =
+           max cur (MAX z\<in>{-i..i}. \<bar>f z\<bar>)\<close>
+proof (induction k)
+  case 0
+  then show ?case by simp
+next
+  case (Suc k)
+  then have i_pos: \<open>i \<ge> 1\<close> by linarith
+  define cur' where \<open>cur' = max (max cur \<bar>f i\<bar>) \<bar>f (-i)\<bar>\<close>
+  define tail_radius where \<open>tail_radius = i - 1\<close>
+  have tr_nn: \<open>tail_radius \<ge> 0\<close> using i_pos tail_radius_def by simp
+  have nat_tr: \<open>nat tail_radius = k\<close> using Suc.prems tail_radius_def i_pos by simp
+  let ?M = \<open>MAX z\<in>{-tail_radius..tail_radius}. \<bar>f z\<bar>\<close>
+  have split: \<open>(MAX z\<in>{-i..i}. \<bar>f z\<bar>) = max (max \<bar>f i\<bar> \<bar>f (-i)\<bar>) ?M\<close>
+    using i_pos tail_radius_def
+    by (subgoal_tac \<open>{-i..i} = insert i (insert (-i) {-tail_radius..tail_radius})\<close>)
+       (auto simp: Max.insert max.assoc)
+  have unfold: \<open>max_abs_with_bound_core f f_bnd (Suc (Suc k)) K i cur =
+                  (if (K = 0 \<or> Suc k mod K = 0) \<and> tail_radius \<ge> 0 \<and> f_bnd tail_radius \<le> cur'
+                   then cur'
+                   else max_abs_with_bound_core f f_bnd (Suc k) K tail_radius cur')\<close>
+    by (simp only: max_abs_with_bound_core.simps(2) Let_def cur'_def tail_radius_def)
+  show ?case
+  proof (cases \<open>(K = 0 \<or> Suc k mod K = 0) \<and> tail_radius \<ge> 0 \<and> f_bnd tail_radius \<le> cur'\<close>)
+    case True
+    have inner_bound: \<open>\<And>z. z \<in> {-tail_radius..tail_radius} \<Longrightarrow> \<bar>f z\<bar> \<le> cur'\<close>
+    proof -
+      fix z assume zin: \<open>z \<in> {-tail_radius..tail_radius}\<close>
+      have abs_le: \<open>\<bar>z\<bar> \<le> tail_radius\<close> using zin tr_nn by auto
+      have \<open>\<bar>f z\<bar> \<le> f_bnd \<bar>z\<bar>\<close> using bnd_correct by blast
+      also have \<open>\<dots> \<le> f_bnd tail_radius\<close> using bnd_mono[OF abs_ge_zero abs_le] .
+      also have \<open>\<dots> \<le> cur'\<close> using True by simp
+      finally show \<open>\<bar>f z\<bar> \<le> cur'\<close> .
+    qed
+    have max_le: \<open>?M \<le> cur'\<close>
+      using inner_bound tr_nn by (intro Max.boundedI) auto
+    have \<open>max cur (MAX z\<in>{-i..i}. \<bar>f z\<bar>) = cur'\<close>
+    proof -
+      have step1: \<open>max cur (MAX z\<in>{-i..i}. \<bar>f z\<bar>) = max cur' ?M\<close>
+        unfolding split cur'_def by (simp add: max.assoc)
+      show ?thesis using step1 max_le by simp
+    qed
+    thus ?thesis using unfold True by simp
+  next
+    case False
+    have IH: \<open>max_abs_with_bound_core f f_bnd (Suc k) K tail_radius cur' =
+              max cur' ?M\<close>
+      using Suc.IH[OF tr_nn nat_tr] .
+    show ?thesis
+    proof -
+      have rhs_eq: \<open>max cur (MAX z\<in>{-i..i}. \<bar>f z\<bar>) = max cur' ?M\<close>
+        using split cur'_def by (metis max.assoc)
+      have lhs_eq: \<open>max_abs_with_bound_core f f_bnd (Suc (Suc k)) K i cur =
+                    max_abs_with_bound_core f f_bnd (Suc k) K tail_radius cur'\<close>
+        using unfold False by (metis (full_types))
+      show ?thesis using lhs_eq IH rhs_eq by metis
+    qed
+  qed
+qed
+
+text\<open>The following lemma shows that for a correct early-termination function, the function
+@{term max_abs_with_bound} indeed computes a maximum absolute value over a symmetric interval:\<close>
+
+lemma max_abs_with_bound_eq:
+  assumes bnd_correct: \<open>\<And>x. \<bar>f x\<bar> \<le> f_bnd \<bar>x\<bar>\<close>
+      and bnd_mono:    \<open>\<And>a b. 0 \<le> a \<Longrightarrow> a \<le> b \<Longrightarrow> f_bnd a \<le> f_bnd b\<close>
+  shows \<open>max_abs_with_bound f f_bnd max_abs K =
+           (MAX z\<in>{-(int max_abs) .. int max_abs}. \<bar>f z\<bar>)\<close>
+proof -
+  \<comment>\<open>Switch the natural number range to the integer interval.\<close>
+  define M where \<open>M = int max_abs\<close>
+  have M_nn: \<open>M \<ge> 0\<close> using M_def by simp
+  have nat_eq: \<open>(max_abs + 1) = Suc max_abs\<close> by simp
+  have nat_max: \<open>nat M = max_abs\<close> using M_def by simp
+  \<comment>\<open>Specialise the strengthened induction lemma at recursion depth \<open>Suc max_abs\<close>.\<close>
+  note core_correct =
+    max_abs_with_bound_core_correct
+      [where f=f and f_bnd=f_bnd and K=K and k=max_abs,
+       OF bnd_correct bnd_mono M_nn nat_max]
+  have core_eq: \<open>\<And>cur. max_abs_with_bound_core f f_bnd (Suc max_abs) K M cur =
+                       max cur (MAX z\<in>{-M..M}. \<bar>f z\<bar>)\<close>
+    using core_correct by blast
+  \<comment>\<open>Unfold the wrapper to the core call with \<open>cur = 0\<close>.\<close>
+  have \<open>max_abs_with_bound f f_bnd max_abs K =
+        max_abs_with_bound_core f f_bnd (Suc max_abs) K M 0\<close>
+    unfolding max_abs_with_bound_def using nat_eq M_def by simp
+  \<comment>\<open>Apply the induction lemma to expose the \<open>Max\<close>-form result.\<close>
+  also have \<open>\<dots> = max 0 (MAX z\<in>{-M..M}. \<bar>f z\<bar>)\<close>
+    using core_eq by blast
+  \<comment>\<open>Drop the outer \<open>max 0\<close>: every \<open>\<bar>f z\<bar>\<close> is nonnegative, and the interval is nonempty.\<close>
+  also have \<open>\<dots> = (MAX z\<in>{-M..M}. \<bar>f z\<bar>)\<close>
+  proof -
+    have ne: \<open>{-M..M} \<noteq> {}\<close> using M_nn by auto
+    have nn: \<open>\<forall>x \<in> (\<lambda>z. \<bar>f z\<bar>) ` {-M..M}. x \<ge> 0\<close> by auto
+    have nonempty_img: \<open>(\<lambda>z. \<bar>f z\<bar>) ` {-M..M} \<noteq> {}\<close> using ne by simp
+    have fin: \<open>finite ((\<lambda>z. \<bar>f z\<bar>) ` {-M..M})\<close> by simp
+    from Max_in[OF fin nonempty_img] nn
+      have \<open>(MAX z\<in>{-M..M}. \<bar>f z\<bar>) \<ge> 0\<close> by blast
+    thus ?thesis by simp
+  qed
+  finally show ?thesis using M_def by simp
+qed
+
+context BarrettContext begin \<comment>\<open>... re-entering @{locale BarrettContext}\<close>
+
+text\<open>Applying this to the Barrett context, we obtain the following efficient formula for computing
+the maximum absolute value of a Barrett reduction in the interval @{term "{-(2^(n-1))..2^(n-1)}"}.
+We will register those lemmas as \<^emph>\<open>code equations\<close> when evaluating @{term bar_signed_max} and 
+@{term bar_unsigned_max} in concrete instantiations of @{locale BarrettContext}.\<close>
+
+corollary bar_signed_max_eq:
+  \<open>bar_signed_max = max_abs_with_bound bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> bar_signed_bnd_at (2^(n-1)) K\<close>
+proof -
+  have intpow: \<open>int (2 ^ (n - 1)) = (2 ^ (n - 1) :: int)\<close> by simp
+  show ?thesis
+    unfolding bar_signed_max_def
+    using max_abs_with_bound_eq
+       [where f = \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk>\<close>
+          and f_bnd = bar_signed_bnd_at
+          and max_abs = \<open>2^(n-1)\<close>
+          and K = K,
+        OF bar_bnd_at_correct_mono(1) bar_bnd_at_correct_mono(3)] intpow
+    by simp
+qed
+
+corollary bar_unsigned_max_eq:
+  \<open>bar_unsigned_max = max_abs_with_bound bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> bar_unsigned_bnd_at (2^(n-1)) K\<close>
+proof -
+  have intpow: \<open>int (2 ^ (n - 1)) = (2 ^ (n - 1) :: int)\<close> by simp
+  show ?thesis
+    unfolding bar_unsigned_max_def
+    using max_abs_with_bound_eq
+       [where f = \<open>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk>\<close>
+          and f_bnd = bar_unsigned_bnd_at
+          and max_abs = \<open>2^(n-1)\<close>
+          and K = K,
+        OF bar_bnd_at_correct_mono(2) bar_bnd_at_correct_mono(4)] intpow by simp
+qed
+
+text \<open>For each sample we instantiate \<^locale>\<open>BarrettContext\<close> with concrete
+\<open>(N, n, f)\<close> and tag @{thm [source] bar_unsigned_max_eq} and @{thm [source] bar_signed_max_eq}
+as code equations so that \<open>value\<close> evaluates \<open>bar_*_max\<close>-constants by an exhaustive sweep with early
+termination using \<^const>\<open>max_abs_with_bound\<close>.\<close>
+
+end \<comment>\<open>Leaving the context of @{locale BarrettContext}\<close>
+
+section \<open>Example 1: \<open>N = 97\<close>, \<open>n = 8\<close> (prime, illustrative 8-bit modulus)\<close>
+
+text\<open>We start with a small prime \<^term>\<open>N=97\<close> and \<^term>\<open>n=8\<close> to illustrate the
+methodology on a modulus where the bounds and achieved maxima are easy to inspect
+by hand.
+
+Here and in the other examples, we use \isakeyword{global\_interpretation} to instantiate
+\<^locale>\<open>BarrettContext\<close> with concrete \<open>(N, n, f)\<close>. The command discharges the
+locale's assumptions once and propagates every locale conclusion to the global
+namespace; the qualifier (here \<open>BC_97_8\<close>) prefixes every fact and definition
+introduced by the locale, preventing accidental shadowing.
+
+The \isakeyword{defines} clause has a special role: each entry binds a global
+constant to a locale-internal definition, so e.g.\ \<^term>\<open>bar_signed_max_97_8\<close> becomes
+a top-level constant whose definitional equation is the locale definition specialised
+to the chosen \<open>(N, n, f)\<close>. Without this clause we would still get the qualified name
+\<open>BC_97_8.bar_signed_max\<close>, but it would not unfold during code generation: the code
+generator treats locale constants as opaque. \<close>
+
+global_interpretation BC_97_8: BarrettContext 97 8 round
+  defines bar_signed_max_97_8      = \<open>BC_97_8.bar_signed_max\<close>
+      and bar_unsigned_max_97_8    = \<open>BC_97_8.bar_unsigned_max\<close>
+      and bar_signed_bound_97_8    = \<open>BC_97_8.bar_signed_bound\<close>
+      and bar_unsigned_bound_97_8  = \<open>BC_97_8.bar_unsigned_bound\<close>
+      and bar_signed_bnd_at_97_8   = \<open>BC_97_8.bar_signed_bnd_at\<close>
+      and bar_unsigned_bnd_at_97_8 = \<open>BC_97_8.bar_unsigned_bnd_at\<close>
+  by standard (auto simp add: is_int_approx_round)
+
+declare %internal BC_97_8.bar_signed_max_eq[where K=1000000, code]
+declare %internal BC_97_8.bar_unsigned_max_eq[where K=1000000, code]
+
+text\<open>\noindent We can now evaluate the theoretical bounds against the attained maxima:\<close>
+
+lemma BC_97_8_bounds:
+    \<comment>\<open>Signed theoretical bound vs attained maximum\<close>
+  shows \<open>bar_signed_max_97_8 = 66\<close>
+    and \<open>bar_signed_bound_97_8 = 66\<close>
+    \<comment>\<open>Unsigned theoretical bound vs attained maximum\<close>
+    and \<open>bar_unsigned_max_97_8 = 108\<close>
+    and \<open>bar_unsigned_bound_97_8 = 114\<close>
+  by eval+
+
+text %internal \<open>Register the above equations as code equations instead of the ones that were used
+to compute them, so we can refer to them without re-evaluation:\<close>
+
+declare %internal [[code drop: bar_signed_max_97_8 bar_unsigned_max_97_8]]
+declare %internal BC_97_8_bounds[code]
+
+text \<open>The signed theoretical bound is achieved exactly. The unsigned bound is
+not attained, but with
+  @{decimal (percentage, 1) "(bar_unsigned_bound_97_8 - bar_unsigned_max_97_8) /\<^sub>\<rat> bar_unsigned_bound_97_8"}
+of slack.\<close>
+
+section \<open>Example 2: \<open>N = 3329\<close>, \<open>n = 16\<close> (ML-KEM modulus)\<close>
+
+text\<open>In this section, we look at \<^term>\<open>N=3329\<close>, the modulus underlying ML-KEM, together
+with \<^term>\<open>n=16\<close> (ML-KEM is computed in 16-bit arithmetic). As before, we first instantiate
+the Barrett context:\<close>
+
+global_interpretation BC_3329_16: BarrettContext 3329 16 round
+  defines bar_signed_max_3329_16      = \<open>BC_3329_16.bar_signed_max\<close>
+      and bar_unsigned_max_3329_16    = \<open>BC_3329_16.bar_unsigned_max\<close>
+      and bar_signed_bound_3329_16    = \<open>BC_3329_16.bar_signed_bound\<close>
+      and bar_unsigned_bound_3329_16  = \<open>BC_3329_16.bar_unsigned_bound\<close>
+      and bar_signed_bnd_at_3329_16   = \<open>BC_3329_16.bar_signed_bnd_at\<close>
+      and bar_unsigned_bnd_at_3329_16 = \<open>BC_3329_16.bar_unsigned_bnd_at\<close>
+  by standard (auto simp add: is_int_approx_round)
+
+declare %internal BC_3329_16.bar_signed_max_eq[where K=1000, code]
+declare %internal BC_3329_16.bar_unsigned_max_eq[where K=1000, code]
+
+text\<open>\noindent We can now evaluate the theoretical bounds against the attained maxima:\<close>
+
+lemma BC_3329_16_bounds:
+    \<comment>\<open>Signed theoretical bound vs attained maximum\<close>
+  shows \<open>bar_signed_max_3329_16 = 2160\<close>
+    and \<open>bar_signed_bound_3329_16 = 2186\<close>
+    \<comment>\<open>Unsigned theoretical bound vs attained maximum\<close>
+    and \<open>bar_unsigned_max_3329_16 = 3798\<close>
+    and \<open>bar_unsigned_bound_3329_16 = 3850\<close>
+  by eval+
+
+text %internal \<open>Register the above equations as code equations instead of the ones that were used
+to compute them, so we can refer to them without re-evaluation:\<close>
+
+declare %internal [[code drop: bar_signed_max_3329_16 bar_unsigned_max_3329_16]]
+declare %internal BC_3329_16_bounds[code]
+
+text \<open>Neither the signed nor the unsigned theoretical bound is attained, but with
+  @{decimal (percentage, 1) "(bar_signed_bound_3329_16 - bar_signed_max_3329_16) /\<^sub>\<rat> bar_signed_bound_3329_16"} (signed) and
+  @{decimal (percentage, 1) "(bar_unsigned_bound_3329_16 - bar_unsigned_max_3329_16) /\<^sub>\<rat> bar_unsigned_bound_3329_16"}  (unsigned) of slack.\<close>
+
+section \<open>Example 3: \<open>N = 8380417\<close>, \<open>n = 32\<close> (ML-DSA modulus)\<close>
+
+text\<open>In this section, we look at \<^term>\<open>N=8380417\<close>, the modulus underlying ML-DSA, together
+with \<^term>\<open>n=32\<close> (ML-DSA is computed in 32-bit arithmetic). As before, we first instantiate
+the Barrett context:\<close>
+
+global_interpretation BC_8380417_32: BarrettContext 8380417 32 round
+  defines bar_signed_max_8380417_32      = \<open>BC_8380417_32.bar_signed_max\<close>
+      and bar_unsigned_max_8380417_32    = \<open>BC_8380417_32.bar_unsigned_max\<close>
+      and bar_signed_bound_8380417_32    = \<open>BC_8380417_32.bar_signed_bound\<close>
+      and bar_unsigned_bound_8380417_32  = \<open>BC_8380417_32.bar_unsigned_bound\<close>
+      and bar_signed_bnd_at_8380417_32   = \<open>BC_8380417_32.bar_signed_bnd_at\<close>
+      and bar_unsigned_bnd_at_8380417_32 = \<open>BC_8380417_32.bar_unsigned_bnd_at\<close>
+  by standard (auto simp add: is_int_approx_round)
+
+declare %internal BC_8380417_32.bar_signed_max_eq[where K=1000000, code]
+declare %internal BC_8380417_32.bar_unsigned_max_eq[where K=1000000, code]
+
+text\<open>\noindent We can now evaluate the theoretical bounds against the attained maxima:\<close>
+
+lemma BC_8380417_32_bounds:
+    \<comment>\<open>Signed theoretical bound vs attained maximum\<close>
+  shows \<open>bar_signed_max_8380417_32 = 6283521\<close>
+    and \<open>bar_signed_bound_8380417_32 = 6283521\<close>
+    \<comment>\<open>Unsigned theoretical bound vs attained maximum\<close>
+    and \<open>bar_unsigned_max_8380417_32 = 10469648\<close>
+    and \<open>bar_unsigned_bound_8380417_32 = 10473729\<close>
+  by eval+
+
+text %internal \<open>Register the above equations as code equations instead of the ones that were used
+to compute them, so we can refer to them without re-evaluation:\<close>
+
+declare %internal [[code drop: bar_signed_max_8380417_32 bar_unsigned_max_8380417_32]]
+declare %internal BC_8380417_32_bounds[code]
+
+text \<open>The signed theoretical bound is achieved exactly. The unsigned bound is
+not attained, but with
+  @{decimal (percentage, 3) "(bar_unsigned_bound_8380417_32 - bar_unsigned_max_8380417_32) /\<^sub>\<rat> bar_unsigned_bound_8380417_32"}
+of slack.\<close>
+end
+

--- a/proofs/isabelle/neon_ntt/Barrett_Montgomery.thy
+++ b/proofs/isabelle/neon_ntt/Barrett_Montgomery.thy
@@ -1,0 +1,532 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Barrett_Montgomery
+  imports Barrett_Reduction Montgomery_Reduction
+begin
+
+chapter \<open>Barrett \<^latex>\<open>$\leftrightarrow$\<close> Montgomery bridge \label{ch:barrett_montgomery}\<close>
+
+text \<open>This chapter establishes the equivalence of Barrett and Montgomery reduction
+and multiplication on a suitably twisted input, and derives the corresponding
+output absolute bounds for Barrett from the Montgomery ones.\<close>
+
+text \<open>Throughout the chapter, we fix an integer approximation \<open>f=\<lbrakk>_\<rbrakk>\<close>, an odd modulus \<^term>\<open>N\<close>, 
+and an exponent \<^term>\<open>n\<close> with \<^term>\<open>2^n > N\<close>. We abbreviate \<^term>\<open>R = 2^n\<close>. This will be indicated
+in by the \<^verbatim>\<open>(in BarrettContext)\<close> below.\<close>
+
+section \<open>Bridge: Barrett reduction and multiplication as Montgomery\<close>
+
+text %internal \<open>Parametric bridge core, covering signed/unsigned via the rounding mode \<^term>\<open>g\<close>
+and reduction/multiplication via \<^term>\<open>c = R\<close> resp. \<^term>\<open>c = b*R\<close>. Reads as: under
+\<^term>\<open>q*R = x*c\<close> and \<^term>\<open>R dvd c\<close>, the Barrett-style expression \<^term>\<open>q - N*g(x\<^sub>\<rat>*magic\<^sub>\<rat>/R\<^sub>\<rat>)\<close>
+equals the additive Montgomery body on \<^term>\<open>x*r\<close>, where \<^term>\<open>r = c - N*magic\<close>.\<close>
+lemma %internal (in BarrettContext) bridge_core:
+  fixes magic c x q Tneg :: int and g :: \<open>rat \<Rightarrow> int\<close>
+  assumes Tneg_inv: \<open>(N * Tneg) mod R = (- 1) mod R\<close>
+      and c_mod: \<open>c mod R = 0\<close>
+      and q_eq: \<open>q * R = x * c\<close>
+      and shift: \<open>shift_compat g\<close>
+  defines \<open>r \<equiv> c - N * magic\<close>
+  shows \<open>q - N * g (x * magic /\<^sub>\<rat> R)
+         = (x * r + (x * r * Tneg) mod\<lbrakk>g\<rbrakk> R * N) div R\<close>
+proof -
+  \<comment> \<open>Algebraic key: \<open>magic \<equiv> r\<cdot>Tneg (mod R)\<close>, hence \<open>x\<cdot>magic \<equiv> x\<cdot>r\<cdot>Tneg (mod R)\<close>.\<close>
+  have key0: \<open>(N * (magic - r * Tneg)) mod R = 0\<close>
+  proof -
+    have \<open>N * (magic - r * Tneg) = N * magic - r * (N * Tneg)\<close>
+      by (simp add: algebra_simps)
+    hence \<open>(N * (magic - r * Tneg)) mod R
+           = (N * magic - r * ((N * Tneg) mod R)) mod R\<close>
+      by (metis mod_diff_right_eq mod_mult_right_eq)
+    also have \<open>\<dots> = (N * magic - r * ((-1) mod R)) mod R\<close>
+      using Tneg_inv by simp
+    also have \<open>\<dots> = (N * magic - r * (-1)) mod R\<close>
+      by (metis mod_diff_right_eq mod_mult_right_eq)
+    also have \<open>N * magic - r * (-1) = c\<close> using r_def by simp
+    finally show ?thesis using c_mod by simp
+  qed
+  have coprime_NR: \<open>coprime N R\<close>
+    using Nodd by (simp add: coprime_power_right_iff)
+  have \<open>R dvd (magic - r * Tneg)\<close>
+    using key0 coprime_NR
+    by (simp add: mod_eq_0_iff_dvd coprime_dvd_mult_right_iff coprime_commute)
+  hence magic_cong: \<open>magic mod R = (r * Tneg) mod R\<close>
+    by (simp add: mod_eq_dvd_iff)
+  have xmagic_cong: \<open>(x * magic) mod R = (x * r * Tneg) mod R\<close>
+    using magic_cong
+    by (metis (mono_tags, opaque_lifting) mod_mult_right_eq mult.assoc)
+  \<comment> \<open>Apply \<open>shift_compat g\<close> to lift the congruence into \<open>mod\<lbrakk>g\<rbrakk>\<close>.\<close>
+  have shift_eq: \<open>(x * magic) mod\<lbrakk>g\<rbrakk> R = (x * r * Tneg) mod\<lbrakk>g\<rbrakk> R\<close>
+  proof -
+    from xmagic_cong have \<open>R dvd ((x * magic) - (x * r * Tneg))\<close>
+      by (simp add: mod_eq_dvd_iff)
+    then obtain k where k: \<open>(x * magic) - (x * r * Tneg) = R * k\<close>
+      unfolding dvd_def by auto
+    hence \<open>x * magic = (x * r * Tneg) + R * k\<close> by simp
+    thus ?thesis
+      using mod_approx_shift[OF shift R_pos, of \<open>x * r * Tneg\<close> k] by simp
+  qed
+  \<comment> \<open>Multiply the LHS by \<open>R\<close> and combine.\<close>
+  let ?z = \<open>x * magic\<close>
+  have arg_eq: \<open>g (x\<^sub>\<rat> * magic\<^sub>\<rat> / R\<^sub>\<rat>) = g (?z\<^sub>\<rat> / R\<^sub>\<rat>)\<close>
+    by (simp add: of_int_mult)
+  have z_split: \<open>R * g (?z\<^sub>\<rat> / R\<^sub>\<rat>) = ?z - ?z mod\<lbrakk>g\<rbrakk> R\<close>
+    unfolding mod_approx_def by simp
+  have lhs_R: \<open>(q - N * g (x\<^sub>\<rat> * magic\<^sub>\<rat> / R\<^sub>\<rat>)) * R
+               = x * r + N * (?z mod\<lbrakk>g\<rbrakk> R)\<close>
+  proof -
+    have \<open>(q - N * g (?z\<^sub>\<rat> / R\<^sub>\<rat>)) * R = q * R - N * (R * g (?z\<^sub>\<rat> / R\<^sub>\<rat>))\<close>
+      by (simp add: algebra_simps)
+    also have \<open>\<dots> = q * R - N * (?z - ?z mod\<lbrakk>g\<rbrakk> R)\<close> using z_split by simp
+    also have \<open>\<dots> = x * c - N * ?z + N * (?z mod\<lbrakk>g\<rbrakk> R)\<close>
+      using q_eq by (simp add: algebra_simps)
+    also have \<open>\<dots> = x * (c - N * magic) + N * (?z mod\<lbrakk>g\<rbrakk> R)\<close>
+      by (simp add: algebra_simps)
+    also have \<open>\<dots> = x * r + N * (?z mod\<lbrakk>g\<rbrakk> R)\<close> using r_def by simp
+    finally show ?thesis using arg_eq by simp
+  qed
+  have \<open>(q - N * g (x\<^sub>\<rat> * magic\<^sub>\<rat> / R\<^sub>\<rat>)) * R
+        = x * r + N * ((x * r * Tneg) mod\<lbrakk>g\<rbrakk> R)\<close>
+    using lhs_R shift_eq by simp
+  hence \<open>q - N * g (x\<^sub>\<rat> * magic\<^sub>\<rat> / R\<^sub>\<rat>)
+         = (x * r + N * ((x * r * Tneg) mod\<lbrakk>g\<rbrakk> R)) div R\<close>
+    using R_pos by (metis nonzero_mult_div_cancel_right not_less_iff_gr_or_eq)
+  thus ?thesis by (simp add: mult.commute)
+qed
+
+text \<open>Barrett reduction returns a new representative of \<^term>\<open>z mod N\<close>, while Montgomery
+reduction returns a representative of \<^term>\<open>z*R\<^sup>-\<^sup>1 mod N\<close>. They cannot literally be equal:
+Any equivalence must absorb a factor of \<^term>\<open>R\<close> somewhere. The equivalence identities
+use a \<^term>\<open>R mod\<lbrakk>f\<rbrakk> N\<close>-twist on the Montgomery input. The most direct proof is
+obtained by carefully unravelling the definitions;
+\autoref{ch:bridge_conceptual} offers a conceptual explanation.\<close>
+
+text %internal \<open>The bridge identities follow by instantiating the parametric core
+with \<^term>\<open>g = round\<close> or \<^term>\<open>floor\<close>, and \<open>c = R, x = z, q = z\<close> (reduction) or
+\<^term>\<open>c = b*R\<close>, \<^term>\<open>x = a\<close>, \<^term>\<open>q = a*b\<close> (multiplication).\<close>
+
+theorem (in BarrettContext) barrett_montgomery_bridge:
+  shows \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N))\<close>
+    and \<open>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N))\<close>
+    and \<open>barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * ((b * R) mod\<lbrakk>f\<rbrakk> N))\<close>
+    and \<open>barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> (a * ((b * R) mod\<lbrakk>f\<rbrakk> N))\<close>
+proof -
+  have bR_mod: \<open>(b * R) mod R = 0\<close> for b :: int by simp
+  have q_mul: \<open>(a * b) * R = a * (b * R)\<close> for a b :: int by (simp add: algebra_simps)
+  have arg_eq: \<open>(b * R) /\<^sub>\<rat> N = b\<^sub>\<rat> * R\<^sub>\<rat> / N\<^sub>\<rat>\<close> for b :: int by (simp add: of_int_mult)
+  have MS: \<open>barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * ((b * R) mod\<lbrakk>f\<rbrakk> N))\<close> for a b :: int
+    using bridge_core[OF mod_inverse_neg_correct bR_mod[of b] q_mul[of a b] shift_compat_round, of \<open>f (b\<^sub>\<rat> * R\<^sub>\<rat> / N\<^sub>\<rat>)\<close>]
+          mont_add_signed_unfold[OF mod_inverse_neg_correct, of \<open>a * ((b * R) mod\<lbrakk>f\<rbrakk> N)\<close>]
+          arg_eq[of b]
+    by (simp add: barrett_mul_signed_def Let_def mod_approx_def algebra_simps)
+  have MU: \<open>barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> (a * ((b * R) mod\<lbrakk>f\<rbrakk> N))\<close> for a b :: int
+    using bridge_core[OF mod_inverse_neg_correct bR_mod[of b] q_mul[of a b] shift_compat_floor, of \<open>f (b\<^sub>\<rat> * R\<^sub>\<rat> / N\<^sub>\<rat>)\<close>]
+          mont_add_unsigned_unfold[OF mod_inverse_neg_correct, of \<open>a * ((b * R) mod\<lbrakk>f\<rbrakk> N)\<close>]
+          arg_eq[of b]
+    by (simp add: barrett_mul_unsigned_def Let_def mod_approx_def algebra_simps)
+  show \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N))\<close>
+    using MS[of z 1] barrett_red_as_mul(1) by simp
+  show \<open>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N))\<close>
+    using MU[of z 1] barrett_red_as_mul(2) by simp
+  show \<open>barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * ((b * R) mod\<lbrakk>f\<rbrakk> N))\<close>
+    by (rule MS)
+  show \<open>barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> (a * ((b * R) mod\<lbrakk>f\<rbrakk> N))\<close>
+    by (rule MU)
+qed
+
+lemmas %internal (in BarrettContext) barrett_montgomery_bridge_red_signed   = barrett_montgomery_bridge(1)
+lemmas %internal (in BarrettContext) barrett_montgomery_bridge_red_unsigned = barrett_montgomery_bridge(2)
+lemmas %internal (in BarrettContext) barrett_montgomery_bridge_mul_signed   = barrett_montgomery_bridge(3)
+lemmas %internal (in BarrettContext) barrett_montgomery_bridge_mul_unsigned = barrett_montgomery_bridge(4)
+
+section \<open>Bounds for Barrett reduction and multiplication\<close>
+
+text \<open>We now derive absolute bounds for Barrett reduction and multiplication
+by combining the bridge lemmas above with the absolute bounds for additive
+Montgomery reduction and multiplication.
+
+It should be noted that the signed Barrett reductions/multiplications satisfy a tighter output
+bound than the unsigned variants, as for signed vs.\ unsigned Montgomery reduction.\<close>
+
+theorem (in BarrettContext) barrett_montgomery_bounds:
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> * \<bar>R mod\<lbrakk>f\<rbrakk> N\<bar> /\<^sub>\<rat> R + N /\<^sub>\<rat> 2\<close>
+  and \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> * \<bar>R mod\<lbrakk>f\<rbrakk> N\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+  and \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar> * \<bar>(b * R) mod\<lbrakk>f\<rbrakk> N\<bar> /\<^sub>\<rat> R + N /\<^sub>\<rat> 2\<close>
+  and \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar> * \<bar>(b * R) mod\<lbrakk>f\<rbrakk> N\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+proof -
+  have MS: \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> (\<bar>a\<bar> * \<bar>(b * R) mod\<lbrakk>f\<rbrakk> N\<bar>) /\<^sub>\<rat> R + N /\<^sub>\<rat> 2\<close> for a b
+    using mont_add_signed_bound[of \<open>a * ((b * R) mod\<lbrakk>f\<rbrakk> N)\<close>]
+    unfolding barrett_montgomery_bridge_mul_signed by (simp add: abs_mult of_int_mult)
+  have MU: \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> (\<bar>a\<bar> * \<bar>(b * R) mod\<lbrakk>f\<rbrakk> N\<bar>) /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close> for a b
+    using mont_add_unsigned_bound[of \<open>a * ((b * R) mod\<lbrakk>f\<rbrakk> N)\<close>]
+    unfolding barrett_montgomery_bridge_mul_unsigned by (simp add: abs_mult of_int_mult)
+  show \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> (\<bar>z\<bar> * \<bar>R mod\<lbrakk>f\<rbrakk> N\<bar>) /\<^sub>\<rat> R + N /\<^sub>\<rat> 2\<close> for z
+    using MS[of z 1] barrett_red_as_mul(1) by simp
+  show \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> (\<bar>z\<bar> * \<bar>R mod\<lbrakk>f\<rbrakk> N\<bar>) /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close> for z
+    using MU[of z 1] barrett_red_as_mul(2) by simp
+  show \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> (\<bar>a\<bar> * \<bar>(b * R) mod\<lbrakk>f\<rbrakk> N\<bar>) /\<^sub>\<rat> R + N /\<^sub>\<rat> 2\<close> for a b
+    by (rule MS)
+  show \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> (\<bar>a\<bar> * \<bar>(b * R) mod\<lbrakk>f\<rbrakk> N\<bar>) /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close> for a b
+    by (rule MU)
+qed
+
+lemmas %internal (in BarrettContext) barrett_red_signed_bound      = barrett_montgomery_bounds(1)
+lemmas %internal (in BarrettContext) barrett_red_unsigned_bound    = barrett_montgomery_bounds(2)
+lemmas %internal (in BarrettContext) barrett_mul_signed_bound = barrett_montgomery_bounds(3)
+lemmas %internal (in BarrettContext) barrett_mul_unsigned_bound    = barrett_montgomery_bounds(4)
+
+text \<open>The bounds above are stated in terms of \<^term>\<open>\<bar>2^n mod\<lbrakk>f\<rbrakk> N\<bar>\<close>, the magnitude
+of the residue of \<^term>\<open>2^n\<close> under \<open>\<lbrakk>_\<rbrakk>\<close>-rounding. This residue equals \<^term>\<open>N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)\<close>
+for reduction and \<^term>\<open>N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)\<close> for multiplication, hence giving the
+following  pointwise bounds:\<close>
+
+theorem (in BarrettContext) barrett_montgomery_bounds_eps:
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+  and \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+  and \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+  and \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+proof -
+  have lift: \<open>\<bar>c mod\<lbrakk>f\<rbrakk> N\<bar>\<^sub>\<rat> = N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N)\<close> for c :: int
+    using mod_approx_bound_eps_at[OF Npos, of f c] by simp
+  show \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close> for z
+    using barrett_montgomery_bounds(1)[of z] lift[of R] by (simp add: of_int_mult abs_mult)
+  show \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close> for z
+    using barrett_montgomery_bounds(2)[of z] lift[of R] by (simp add: of_int_mult abs_mult)
+  show \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close> for a b
+    using barrett_montgomery_bounds(3)[of a b] lift[of \<open>b * R\<close>] by (simp add: of_int_mult abs_mult)
+  show \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close> for a b
+    using barrett_montgomery_bounds(4)[of a b] lift[of \<open>b * R\<close>] by (simp add: of_int_mult abs_mult)
+qed
+
+text %internal \<open>Specialising the pointwise errors to the uniform quality \<^term>\<open>\<epsilon>(f)\<close> provides a uniform
+bound:\<close>
+
+corollary %internal (in BarrettContext) barrett_montgomery_bounds_eps_uniform:
+  assumes \<open>is_int_approx_quality f e\<close>
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+  and \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+  and \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+  and \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+proof -
+  have slope: \<open>\<bar>w\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, x)) / R\<^sub>\<rat> \<le> \<bar>w\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat>\<close> for w x
+    using quality_at_le[OF assms] Npos by (simp add: divide_right_mono mult_left_mono)
+  show \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+    using barrett_montgomery_bounds_eps(1)[of z] slope[of z \<open>R /\<^sub>\<rat> N\<close>] by linarith
+  show \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+    using barrett_montgomery_bounds_eps(2)[of z] slope[of z \<open>R /\<^sub>\<rat> N\<close>] by linarith
+  show \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+    using barrett_montgomery_bounds_eps(3)[of a b] slope[of a \<open>b * R /\<^sub>\<rat> N\<close>] by linarith
+  show \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+    using barrett_montgomery_bounds_eps(4)[of a b] slope[of a \<open>b * R /\<^sub>\<rat> N\<close>] by linarith
+qed
+
+lemmas %internal (in BarrettContext) barrett_red_signed_bound_eps      = barrett_montgomery_bounds_eps_uniform(1)
+lemmas %internal (in BarrettContext) barrett_red_unsigned_bound_eps    = barrett_montgomery_bounds_eps_uniform(2)
+lemmas %internal (in BarrettContext) barrett_mul_signed_bound_eps = barrett_montgomery_bounds_eps_uniform(3)
+lemmas %internal (in BarrettContext) barrett_mul_unsigned_bound_eps    = barrett_montgomery_bounds_eps_uniform(4)
+
+text \<open>When the input magnitude is at most \<open>2^(n-1) = R /\<^sub>\<rat> 2\<close>, the slope term is at
+most half of \<^term>\<open>N\<^sub>\<rat> * \<epsilon>(f, x)\<close>, yielding the following narrowed bounds:\<close>
+
+theorem (in BarrettContext) barrett_bound_eps_narrow:
+  shows \<open>\<bar>z\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, R /\<^sub>\<rat> N) + 1)/2\<close>
+    and \<open>\<bar>z\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, R /\<^sub>\<rat> N) + 2)/2 - N/\<^sub>\<rat>R\<close>
+    and \<open>\<bar>a\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b*R)/\<^sub>\<rat> N) + 1)/2\<close>
+    and \<open>\<bar>a\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b*R)/\<^sub>\<rat> N) + 2)/2 - N/\<^sub>\<rat>R\<close>
+proof -
+  have half: \<open>\<And>w :: int. \<bar>w\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>w\<bar>\<^sub>\<rat> / R\<^sub>\<rat> \<le> 1/2\<close>
+  proof -
+    fix w :: int assume A: \<open>\<bar>w\<bar> \<le> 2^(n-1)\<close>
+    have \<open>\<bar>w\<bar>\<^sub>\<rat> \<le> ((2^(n-1) :: int))\<^sub>\<rat>\<close>
+      using A of_int_le_iff by fastforce
+    hence \<open>\<bar>w\<bar>\<^sub>\<rat> / R\<^sub>\<rat> \<le> ((2^(n-1) :: int)\<^sub>\<rat>) / R\<^sub>\<rat>\<close>
+      by (simp add: divide_right_mono)
+    also have \<open>((2^(n-1) :: int)\<^sub>\<rat>) / R\<^sub>\<rat> = 1/2\<close>
+      using R_eq by (simp add: of_int_power)
+    finally show \<open>\<bar>w\<bar>\<^sub>\<rat> / R\<^sub>\<rat> \<le> 1/2\<close> .
+  qed
+  have slope1: \<open>\<And>w c :: int. \<bar>w\<bar> \<le> 2^(n-1) \<Longrightarrow>
+                  \<bar>w\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N)) / R\<^sub>\<rat> \<le> N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N) / 2\<close>
+  proof -
+    fix w c :: int assume A: \<open>\<bar>w\<bar> \<le> 2^(n-1)\<close>
+    have nn: \<open>0 \<le> N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N)\<close> using Npos by simp
+    have \<open>\<bar>w\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N)) / R\<^sub>\<rat> = (\<bar>w\<bar>\<^sub>\<rat> / R\<^sub>\<rat>) * (N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N))\<close>
+      by (simp add: field_simps)
+    also have \<open>\<dots> \<le> (1/2) * (N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N))\<close>
+      using half[OF A] nn by (rule mult_right_mono)
+    finally show \<open>\<bar>w\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N)) / R\<^sub>\<rat> \<le> N\<^sub>\<rat> * \<epsilon>(f, c /\<^sub>\<rat> N) / 2\<close> by simp
+  qed
+  have MS: \<open>\<bar>a\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b * R) /\<^sub>\<rat> N) + 1) / 2\<close> for a b
+  proof -
+    assume A: \<open>\<bar>a\<bar> \<le> 2^(n-1)\<close>
+    have \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+      using barrett_montgomery_bounds_eps(3)[of a b] .
+    also have \<open>\<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> \<le> N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N) / 2\<close>
+      using slope1[OF A, of \<open>b * R\<close>] .
+    finally show \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b * R) /\<^sub>\<rat> N) + 1) / 2\<close>
+      by (simp add: distrib_left)
+  qed
+  have MU: \<open>\<bar>a\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b * R) /\<^sub>\<rat> N) + 2) / 2 - N /\<^sub>\<rat> R\<close> for a b
+  proof -
+    assume A: \<open>\<bar>a\<bar> \<le> 2^(n-1)\<close>
+    have \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+      using barrett_montgomery_bounds_eps(4)[of a b] .
+    also have \<open>\<bar>a\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N)) / R\<^sub>\<rat> \<le> N\<^sub>\<rat> * \<epsilon>(f, (b * R) /\<^sub>\<rat> N) / 2\<close>
+      using slope1[OF A, of \<open>b * R\<close>] .
+    finally show \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b * R) /\<^sub>\<rat> N) + 2) / 2 - N /\<^sub>\<rat> R\<close>
+      by (simp add: add_divide_distrib distrib_left)
+  qed
+  show \<open>\<bar>z\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, R /\<^sub>\<rat> N) + 1) / 2\<close> for z
+    using MS[of z 1] barrett_red_as_mul(1) by simp
+  show \<open>\<bar>z\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, R /\<^sub>\<rat> N) + 2) / 2 - N /\<^sub>\<rat> R\<close> for z
+    using MU[of z 1] barrett_red_as_mul(2) by simp
+  show \<open>\<bar>a\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b * R) /\<^sub>\<rat> N) + 1) / 2\<close> for a b
+    by (rule MS)
+  show \<open>\<bar>a\<bar> \<le> 2^(n-1) \<Longrightarrow> \<bar>(barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(f, (b * R) /\<^sub>\<rat> N) + 2) / 2 - N /\<^sub>\<rat> R\<close> for a b
+    by (rule MU)
+qed
+
+
+text\<open>In \autoref{ch:barrett_bound_quality} we will demonstrate by example that the right hand sides @{thm [show_question_marks=false] (rhs) BarrettContext.barrett_bound_eps_narrow(1)} etc. of
+@{thm [source] BarrettContext.barrett_bound_eps_narrow} are \<^emph>\<open>tight\<close>.\<close>
+
+text \<open>The pointwise version of @{thm [source] BarrettContext.barrett_bound_eps_narrow}
+above lets us specialise to the three cases of practical interest --- signed
+Barrett multiplication with round-to-nearest-even and with round-to-nearest, and
+unsigned Barrett multiplication with round-to-nearest. When the second
+operand \<^term>\<open>b\<close> satisfies \<^term>\<open>b \<noteq> 0\<close> and \<^term>\<open>\<bar>b\<bar> < N\<close>, then \<^term>\<open>b\<close> is not
+divisible by \<^term>\<open>N\<close>, and since \<^term>\<open>N\<close> is odd, neither is \<^term>\<open>b * R\<close> nor
+\<^term>\<open>2 * b * R\<close>. So the pointwise rounding error at \<^term>\<open>(b * R) /\<^sub>\<rat> N\<close> is
+strictly below the uniform quality, yielding strict output bounds.\<close>
+
+theorem (in StandardModulus) barrett_mul_narrow:
+  assumes \<open>\<bar>a\<bar> \<le> 2^(n-1)\<close>
+      and \<open>\<bar>b\<bar> < N\<close> and \<open>b \<noteq> 0\<close>
+  shows \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> < N\<^sub>\<rat>\<close>
+    and \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar>  < 3 * N /\<^sub>\<rat> 4\<close>
+    and \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar>  < 5 * N /\<^sub>\<rat> 4\<close>
+proof -
+  \<comment> \<open>\<^term>\<open>b\<close> is nonzero with absolute value below \<^term>\<open>N\<close>, so it lies
+       strictly between two consecutive multiples of \<^term>\<open>N\<close> and is therefore
+       not divisible by \<^term>\<open>N\<close>.\<close>
+  have N_not_dvd_b: \<open>\<not> N dvd b\<close>
+  proof
+    assume \<open>N dvd b\<close>
+    then obtain k :: int where bk: \<open>b = N * k\<close> by auto
+    from bk assms(3) have \<open>k \<noteq> 0\<close> by auto
+    hence \<open>\<bar>k\<bar> \<ge> 1\<close> by simp
+    hence \<open>\<bar>b\<bar> \<ge> N\<close> using bk Npos by (simp add: abs_mult)
+    thus False using assms(2) by simp
+  qed
+  \<comment> \<open>\<^term>\<open>N\<close> is odd and \<open>> 1\<close>, so it does not divide \<^term>\<open>R = 2^n\<close>;
+       and being coprime to both \<^term>\<open>R\<close> and \<^term>\<open>2\<close>, it does not divide
+       \<^term>\<open>b * R\<close> or \<^term>\<open>2 * b * R\<close>.\<close>
+  have N_not_dvd_R: \<open>\<not> N dvd R\<close>
+  proof
+    assume A: \<open>N dvd R\<close>
+    from A prime_int_iff[of 2] obtain i where \<open>\<bar>N\<bar> = (2::int)^i\<close>
+      using divides_primepow[of \<open>2::int\<close> N n] by auto
+    hence \<open>N = (2::int)^i\<close> using Npos by simp
+    hence \<open>even N \<or> N = 1\<close> by (cases i) auto
+    thus False using Nodd Ngt1 by auto
+  qed
+  have N_not_dvd_bR: \<open>\<not> N dvd b * R\<close>
+    using N_not_dvd_b N_not_dvd_R Nodd
+    by (metis coprime_commute coprime_left_2_iff_odd
+              coprime_dvd_mult_left_iff coprime_power_right_iff)
+  have N_not_dvd_2bR: \<open>\<not> N dvd 2 * b * R\<close>
+    using N_not_dvd_bR Nodd
+    by (metis coprime_dvd_mult_right_iff coprime_commute coprime_left_2_iff_odd
+              mult.assoc)
+  define x where \<open>x = (b * R) /\<^sub>\<rat> N\<close>
+  \<comment> \<open>So neither \<^term>\<open>(b * R) /\<^sub>\<rat> N\<close> nor \<^term>\<open>2 * (b * R) /\<^sub>\<rat> N\<close> is an integer.\<close>
+  have twoX_notint: \<open>2 * x \<notin> \<int>\<close>
+  proof
+    assume \<open>2 * x \<in> \<int>\<close>
+    then obtain m :: int where m: \<open>2 * x = m\<^sub>\<rat>\<close> using Ints_cases by blast
+    have \<open>(2 * b * R)\<^sub>\<rat> = (m * N)\<^sub>\<rat>\<close>
+      using m Npos unfolding x_def by (simp add: field_simps)
+    hence \<open>2 * b * R = m * N\<close> by (metis of_int_eq_iff of_int_mult)
+    thus False using N_not_dvd_2bR by (metis dvd_triv_right)
+  qed
+  have x_notint: \<open>x \<notin> \<int>\<close>
+  proof
+    assume \<open>x \<in> \<int>\<close>
+    then obtain k :: int where k: \<open>x = k\<^sub>\<rat>\<close> using Ints_cases by blast
+    have \<open>(b * R)\<^sub>\<rat> = (N * k)\<^sub>\<rat>\<close>
+      using k Npos unfolding x_def by (simp add: field_simps)
+    hence \<open>b * R = N * k\<close> by (metis of_int_eq_iff)
+    thus False using N_not_dvd_bR by simp
+  qed
+  \<comment> \<open>So the pointwise rounding errors at \<^term>\<open>x\<close> are strictly below the
+       uniform qualities, by \<open>quality_at_strict_round\<close> and
+       \<open>quality_at_strict_round_even\<close>.\<close>
+  have eps_round_strict: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, x) < 1/2\<close>
+    using quality_at_strict_round[OF twoX_notint] quality_round by simp
+  have eps_round_even_strict: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2, x) < 1\<close>
+    using quality_at_strict_round_even[OF x_notint] quality_round_even by simp
+  \<comment> \<open>Specialise the Barrett locale at the two concrete approximations.\<close>
+  interpret R_even: BarrettContext N n \<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close>
+    by unfold_locales (rule is_int_approx_round_even)
+  interpret R_round: BarrettContext N n \<open>\<lfloor>\<cdot>\<rceil>\<close>
+    by unfold_locales (rule is_int_approx_round)
+  \<comment> \<open>Lift a strict pointwise quality to a strict output bound.\<close>
+  have step: \<open>\<bar>v\<bar> < N\<^sub>\<rat> * (e' + c) / 2\<close>
+    if h1: \<open>\<bar>v\<bar> \<le> N\<^sub>\<rat> * (e + c) / 2\<close> and h2: \<open>e < e'\<close> for v e e' c
+  proof -
+    have \<open>N\<^sub>\<rat> * (e + c) < N\<^sub>\<rat> * (e' + c)\<close>
+      using h2 N_pos_rat by (simp add: mult_strict_left_mono)
+    thus ?thesis using h1 by linarith
+  qed
+  have B1: \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2, x) + 1) / 2\<close>
+    using R_even.barrett_bound_eps_narrow(3)[OF assms(1)] unfolding x_def by simp
+  have B2: \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(\<lfloor>\<cdot>\<rceil>, x) + 1) / 2\<close>
+    using R_round.barrett_bound_eps_narrow(3)[OF assms(1)] unfolding x_def by simp
+  have B3: \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(\<lfloor>\<cdot>\<rceil>, x) + 2) / 2\<close>
+  proof -
+    have \<open>0 \<le> N /\<^sub>\<rat> R\<close> using Npos R_pos by simp
+    moreover have \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * (\<epsilon>(\<lfloor>\<cdot>\<rceil>, x) + 2) / 2 - N /\<^sub>\<rat> R\<close>
+      using R_round.barrett_bound_eps_narrow(4)[OF assms(1)] unfolding x_def by simp
+    ultimately show ?thesis by linarith
+  qed
+  show \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> < N\<^sub>\<rat>\<close>
+    using step[OF B1 eps_round_even_strict] by simp
+  show \<open>\<bar>(barM\<^sup>\<plusminus> \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> < (3 * N) /\<^sub>\<rat> 4\<close>
+    using step[OF B2 eps_round_strict] by simp
+  show \<open>\<bar>(barM\<^sup>+ \<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> < (5 * N) /\<^sub>\<rat> 4\<close>
+    using step[OF B3 eps_round_strict] by simp
+qed
+
+text \<open>Specializing at \<^term>\<open>b=1\<close>, we obtain the same bounds for Barrett reduction:\<close>
+
+theorem (in StandardModulus) barrett_red_narrow:
+  assumes \<open>\<bar>z\<bar> \<le> 2^(n-1)\<close>
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<^sub>2\<rbrakk> z)\<^sub>\<rat>\<bar> < N\<^sub>\<rat>\<close>
+    and \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk> z)\<^sub>\<rat>\<bar> < 3 * N /\<^sub>\<rat> 4\<close>
+    and \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, \<lfloor>\<cdot>\<rceil>\<rbrakk> z)\<^sub>\<rat>\<bar> < 5 * N /\<^sub>\<rat> 4\<close>
+  using barrett_mul_narrow[OF assms, of 1] Ngt1 barrett_red_as_mul
+  by simp_all
+
+section \<open>Bounds for refined Barrett reduction\<close>
+
+text \<open>We have seen that the output quality of Barrett reduction improves
+as \<^term>\<open>n\<close> grows. For refined Barrett
+reduction, the goal is to choose \<^term>\<open>n\<close> large enough that the output
+is in fact \<^emph>\<open>signed canonical\<close>. For practical purposes growing
+\<^term>\<open>n\<close> alone is not sufficient: one also needs to
+take into account the quality of the approximation \<open>\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<close>.\<close>
+
+lemma (in BarrettContext) barrett_montgomery_bounds_quality_pow:
+  assumes \<open>\<epsilon>(f, R /\<^sub>\<rat> N) \<le> 1/2^\<delta>\<close>
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) + N\<^sub>\<rat> / 2\<close>
+    and \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+proof -
+  have z_nn: \<open>\<bar>z\<bar>\<^sub>\<rat> \<ge> 0\<close> by simp
+  have N_nn: \<open>N\<^sub>\<rat> \<ge> 0\<close> by simp
+  have R_pos: \<open>R\<^sub>\<rat> > 0\<close> by simp
+  have step: \<open>\<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) / R\<^sub>\<rat> \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>)\<close>
+  proof -
+    have zN_nn: \<open>\<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> \<ge> 0\<close> using z_nn N_nn by simp
+    have \<open>\<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N) \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> * (1/2^\<delta>)\<close>
+      using mult_left_mono[OF assms zN_nn] .
+    hence \<open>\<bar>z\<bar>\<^sub>\<rat> * (N\<^sub>\<rat> * \<epsilon>(f, R /\<^sub>\<rat> N)) \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / 2^\<delta>\<close>
+      by (simp add: algebra_simps)
+    thus ?thesis using R_pos by (simp add: divide_right_mono field_simps)
+  qed
+  show \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) + N\<^sub>\<rat> / 2\<close>
+    using barrett_montgomery_bounds_eps(1)[of z] step by linarith
+  show \<open>\<bar>(bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>
+    using barrett_montgomery_bounds_eps(2)[of z] step by linarith
+qed
+
+text \<open>If we additionally specialise the input \<^term>\<open>z\<close> to be bounded by
+\<^term>\<open>2^(n-1-\<gamma>)\<close> --- that is, we assume \<^term>\<open>\<gamma>\<close> bits of slack for
+\<^term>\<open>\<gamma> \<ge> 0\<close> --- we obtain the following bound:\<close>
+
+lemma (in BarrettContext) barrett_red_signed_bound_slack:
+  assumes \<open>\<epsilon>(f, R /\<^sub>\<rat> N) \<le> 1/2^\<delta>\<close>
+      and \<open>\<bar>z\<bar> \<le> 2^(n-1-\<gamma>)\<close>
+      and \<open>\<gamma> \<le> n-1\<close>
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> / 2^(\<gamma>+\<delta>+1) + N\<^sub>\<rat> / 2\<close>
+proof -
+  have R_pos: \<open>R\<^sub>\<rat> > 0\<close> by simp
+  have N_nn: \<open>N\<^sub>\<rat> \<ge> 0\<close> by simp
+  have step1: \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) + N\<^sub>\<rat> / 2\<close>
+    using barrett_montgomery_bounds_quality_pow(1)[OF assms(1)] .
+  have z_rat: \<open>\<bar>z\<bar>\<^sub>\<rat> \<le> (2::rat)^(n-1-\<gamma>)\<close>
+    using assms(2) by (metis of_int_abs of_int_le_iff of_int_numeral of_int_power)
+  have \<open>\<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> \<le> (2::rat)^(n-1-\<gamma>) * N\<^sub>\<rat>\<close>
+    using mult_right_mono[OF z_rat N_nn] .
+  hence slope_le: \<open>\<bar>z\<bar>\<^sub>\<rat> * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) \<le> (2::rat)^(n-1-\<gamma>) * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>)\<close>
+    using R_pos by (simp add: divide_right_mono)
+  have R_eq: \<open>R\<^sub>\<rat> = (2::rat)^n\<close> by simp
+  have n_eq: \<open>n = (n-1-\<gamma>) + (\<gamma>+1)\<close> using assms(3) npos by simp
+  have R_split: \<open>(2::rat)^n = 2^(n-1-\<gamma>) * 2^(\<gamma>+1)\<close>
+    using n_eq by (metis power_add)
+  have slope_simp: \<open>(2::rat)^(n-1-\<gamma>) * N\<^sub>\<rat> / (R\<^sub>\<rat> * 2^\<delta>) = N\<^sub>\<rat> / 2^(\<gamma>+\<delta>+1)\<close>
+  proof -
+    have \<open>R\<^sub>\<rat> * (2::rat)^\<delta> = 2^(n-1-\<gamma>) * 2^(\<gamma>+1) * 2^\<delta>\<close>
+      using R_eq R_split by simp
+    also have \<open>\<dots> = 2^(n-1-\<gamma>) * 2^(\<gamma>+\<delta>+1)\<close>
+      by (simp add: power_add algebra_simps)
+    finally have \<open>R\<^sub>\<rat> * (2::rat)^\<delta> = 2^(n-1-\<gamma>) * 2^(\<gamma>+\<delta>+1)\<close> .
+    thus ?thesis by simp
+  qed
+  show ?thesis using step1 slope_le slope_simp by linarith
+qed
+
+text \<open>Finally, we obtain the following statement about canonicity of refined
+Barrett reduction. Observe how approximation quality and restricted input
+bounds contribute equally and can be balanced on a case-by-case basis.\<close>
+
+corollary (in BarrettContext) barrett_red_signed_canonical:
+  assumes eps_le: \<open>\<epsilon>(f, R /\<^sub>\<rat> N) \<le> 1/2^\<delta>\<close>
+      and z_le:   \<open>\<bar>z\<bar> \<le> 2^(n-1-\<gamma>)\<close>
+      and \<gamma>_le:   \<open>\<gamma> \<le> n-1\<close>
+      and N_lt:   \<open>N < 2^(\<gamma>+\<delta>)\<close>
+  shows \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> < N /\<^sub>\<rat> 2\<close>
+proof -
+  have slope: \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> / 2^(\<gamma>+\<delta>+1) + N\<^sub>\<rat> / 2\<close>
+    using barrett_red_signed_bound_slack[OF eps_le z_le \<gamma>_le] .
+  have N_lt_rat: \<open>N\<^sub>\<rat> < (2::rat)^(\<gamma>+\<delta>)\<close>
+    using N_lt by (metis of_int_less_iff of_int_numeral of_int_power)
+  have \<open>N\<^sub>\<rat> / 2^(\<gamma>+\<delta>+1) < (2::rat)^(\<gamma>+\<delta>) / 2^(\<gamma>+\<delta>+1)\<close>
+    using N_lt_rat by (simp add: divide_strict_right_mono)
+  also have \<open>(2::rat)^(\<gamma>+\<delta>) / 2^(\<gamma>+\<delta>+1) = 1/2\<close>
+    by (simp add: power_add)
+  finally have slope_lt: \<open>N\<^sub>\<rat> / 2^(\<gamma>+\<delta>+1) < 1/2\<close> .
+  have total: \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> < (N\<^sub>\<rat> + 1) / 2\<close>
+  proof -
+    have \<open>N\<^sub>\<rat> / 2^(\<gamma>+\<delta>+1) + N\<^sub>\<rat> / 2 < 1/2 + N\<^sub>\<rat> / 2\<close>
+      using slope_lt by linarith
+    also have \<open>1/2 + N\<^sub>\<rat> / 2 = (N\<^sub>\<rat> + 1) / 2\<close>
+      by (simp add: field_simps)
+    finally show ?thesis using slope by linarith
+  qed
+  have int_bound: \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> (N - 1) div 2\<close>
+  proof -
+    have even_Np1: \<open>(2::int) dvd (N + 1)\<close> using Nodd by simp
+    have Np1_half: \<open>of_int ((N + 1) div 2) = (N\<^sub>\<rat> + 1) / 2\<close>
+      using of_int_div[OF even_Np1] by simp
+    have \<open>of_int \<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> < (of_int ((N + 1) div 2) :: rat)\<close>
+      using total Np1_half by simp
+    hence \<open>\<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> < (N + 1) div 2\<close>
+      by (simp add: of_int_less_iff)
+    thus ?thesis by linarith
+  qed
+  have even_Nm1: \<open>(2::int) dvd (N - 1)\<close> using Nodd by simp
+  have Nm1_half: \<open>of_int ((N - 1) div 2) = ((N\<^sub>\<rat> - 1) / 2 :: rat)\<close>
+    using of_int_div[OF even_Nm1] by simp
+  have \<open>\<bar>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat>\<bar> = of_int \<bar>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar>\<close> by simp
+  also have \<open>\<dots> \<le> of_int ((N - 1) div 2 :: int)\<close>
+    using int_bound by auto
+  also have \<open>(of_int ((N - 1) div 2) :: rat) = (N\<^sub>\<rat> - 1) / 2\<close>
+    using Nm1_half .
+  also have \<open>(N\<^sub>\<rat> - 1) / 2 < N /\<^sub>\<rat> 2\<close> using Ngt1 by simp
+  finally show ?thesis .
+qed
+
+
+end
+

--- a/proofs/isabelle/neon_ntt/Barrett_Reduction.thy
+++ b/proofs/isabelle/neon_ntt/Barrett_Reduction.thy
@@ -1,0 +1,311 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Barrett_Reduction
+  imports Montgomery_Reduction
+begin
+
+chapter \<open>Barrett reduction and multiplication \label{ch:barrett_red}\<close>
+
+text \<open>This chapter introduces the abstract Barrett reduction and multiplication
+operators together with an approximation-error bound. Output absolute bounds are
+deferred to \autoref{ch:barrett_montgomery}, where they follow sharply from the
+Barrett--Montgomery bridge.\<close>
+
+section \<open>Barrett reduction\<close>
+
+text \<open>Barrett reduction \cite[\S 2.4.1]{NeonNTT} replaces division by
+the modulus \<^term>\<open>N\<close> with a multiply-shift: with \<^term>\<open>R = (2::int)^n\<close> and \<^term>\<open>R > N\<close> and precomputed
+\<open>\<lbrakk>R/N\<rbrakk>\<close>, the quotient \<^term>\<open>z/N\<close> is approximated as \<open>z\<sqdot>\<lbrakk>R/N\<rbrakk>/R\<close>, and the residue
+recovered as \<open>z - N\<sqdot>\<lfloor>z\<sqdot>\<lbrakk>R/N\<rbrakk>/R\<rceil>\<close>.\<close>
+
+text \<open>There are two variants, differing only in how the outer quotient is rounded: the
+\emph{signed} variant applies round-to-nearest \<open>\<lfloor>\<cdot>\<rceil>\<close>, recovering \<^term>\<open>z mod\<^sup>\<plusminus> N\<close>;
+the \emph{unsigned} variant applies floor \<open>\<lfloor>\<cdot>\<rfloor>\<close>, recovering \<^term>\<open>z mod\<^sup>+ N\<close>. Both
+are parameterised by the inner approximation \<^term>\<open>f\<close> of \<^term>\<open>R /\<^sub>\<rat> N\<close>.\<close>
+
+definition barrett_red_signed (\<open>bar\<^sup>\<plusminus> \<lbrakk>_,_,_\<rbrakk>\<close>) where
+  \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z \<equiv> z - N * \<lfloor>z * \<lbrakk>2^n /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> 2^n\<rceil>\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+definition barrett_red_unsigned (\<open>bar\<^sup>+ \<lbrakk>_,_,_\<rbrakk>\<close>) where
+  \<open>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z \<equiv> z - N * \<lfloor>z * \<lbrakk>2^n /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> 2^n\<rfloor>\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+text \<open>We bundle the standing assumptions of this and the next chapter into a
+locale \<open>BarrettContext\<close> = \<open>StandardModulus\<close> (a positive odd modulus \<^term>\<open>N\<close> and a
+splitting exponent \<^term>\<open>n\<close> with \<^term>\<open>R = (2::int)^n\<close> and \<^term>\<open>R > N\<close>) plus \<open>IntegerApproximation\<close> (an
+integer approximation \<open>\<lbrakk>_\<rbrakk>\<close> of the rationals).\<close>
+
+locale BarrettContext = StandardModulus + IntegerApproximation
+
+text \<open>\cite[Fact~2]{NeonNTT} provides a coarse bound for the
+approximation error between the signed variant and the canonical signed residue:\<close>
+
+theorem (in BarrettContext) barrett_red_signed_fact2:
+  shows \<open>\<bar>z mod\<^sup>\<plusminus> N - bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z\<bar> \<le> N * \<lceil>\<bar>z\<bar> /\<^sub>\<rat> R\<rceil>\<close>
+proof -
+  define s :: rat where \<open>s = (f (R /\<^sub>\<rat> N))\<^sub>\<rat>\<close>
+  define a :: rat where \<open>a = z /\<^sub>\<rat> N\<close>
+  define b :: rat where \<open>b = z\<^sub>\<rat> * s / R\<^sub>\<rat>\<close>
+  have approx: \<open>\<bar>R /\<^sub>\<rat> N - s\<bar> \<le> 1\<close>
+    using f_approx unfolding is_int_approx_def s_def by simp
+  have diff_eq: \<open>z mod\<^sup>\<plusminus> N - barrett_red_signed N n f z = N * (\<lfloor>b\<rceil> - \<lfloor>a\<rceil>)\<close>
+    unfolding barrett_red_signed_def mod_approx_def a_def b_def s_def
+    by (simp add: algebra_simps)
+  have ba_diff_eq: \<open>b - a = z\<^sub>\<rat> * (s - R /\<^sub>\<rat> N) / R\<^sub>\<rat>\<close>
+    unfolding a_def b_def by (simp add: field_simps)
+  have e0: \<open>\<bar>z\<^sub>\<rat> * (s - R /\<^sub>\<rat> N) / R\<^sub>\<rat>\<bar> = \<bar>z\<^sub>\<rat> * (s - R /\<^sub>\<rat> N)\<bar> / \<bar>R\<^sub>\<rat>\<bar>\<close>
+    by (simp add: abs_divide)
+  have e1: \<open>\<bar>z\<^sub>\<rat> * (s - R /\<^sub>\<rat> N)\<bar> = \<bar>z\<^sub>\<rat>\<bar> * \<bar>s - R /\<^sub>\<rat> N\<bar>\<close>
+    by (simp add: abs_mult)
+  have ba_abs_eq: \<open>\<bar>b - a\<bar> = \<bar>z\<^sub>\<rat>\<bar> * \<bar>s - R /\<^sub>\<rat> N\<bar> / R\<^sub>\<rat>\<close>
+    using ba_diff_eq e0 e1 by simp
+  have approx': \<open>\<bar>s - R /\<^sub>\<rat> N\<bar> \<le> 1\<close> using approx by (simp add: abs_minus_commute)
+  have iz_nn: \<open>0 \<le> \<bar>z\<^sub>\<rat>\<bar>\<close> by simp
+  have prod_le: \<open>\<bar>z\<^sub>\<rat>\<bar> * \<bar>s - R /\<^sub>\<rat> N\<bar> \<le> \<bar>z\<^sub>\<rat>\<bar> * 1\<close>
+    using approx' iz_nn by (rule mult_left_mono)
+  have prod_le': \<open>\<bar>z\<^sub>\<rat>\<bar> * \<bar>s - R /\<^sub>\<rat> N\<bar> \<le> \<bar>z\<^sub>\<rat>\<bar>\<close> using prod_le by simp
+  have abs_iz: \<open>\<bar>z\<^sub>\<rat>\<bar> = \<bar>z\<bar>\<^sub>\<rat>\<close> by simp
+  have ba_bound1: \<open>\<bar>z\<^sub>\<rat>\<bar> * \<bar>s - R /\<^sub>\<rat> N\<bar> / R\<^sub>\<rat> \<le> \<bar>z\<^sub>\<rat>\<bar> / R\<^sub>\<rat>\<close>
+    using prod_le' by (simp add: divide_right_mono)
+  have ba_bound: \<open>\<bar>b - a\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> R\<close>
+  proof -
+    have \<open>\<bar>b - a\<bar> = \<bar>z\<^sub>\<rat>\<bar> * \<bar>s - R /\<^sub>\<rat> N\<bar> / R\<^sub>\<rat>\<close> by (rule ba_abs_eq)
+    also have \<open>\<dots> \<le> \<bar>z\<^sub>\<rat>\<bar> / R\<^sub>\<rat>\<close> by (rule ba_bound1)
+    also have \<open>\<dots> = \<bar>z\<bar> /\<^sub>\<rat> R\<close> using abs_iz by simp
+    finally show ?thesis .
+  qed
+  have round_diff_lem: \<open>\<And>x y::rat. x \<le> y \<Longrightarrow> \<lfloor>y\<rceil> - \<lfloor>x\<rceil> \<le> \<lceil>y - x\<rceil>\<close>
+  proof -
+    fix x y :: rat
+    assume xy: \<open>x \<le> y\<close>
+    have d_le: \<open>y - x \<le> \<lceil>y - x\<rceil>\<^sub>\<rat>\<close> by (rule le_of_int_ceiling)
+    from d_le have step1: \<open>y \<le> x + \<lceil>y - x\<rceil>\<^sub>\<rat>\<close> by linarith
+    have step2: \<open>y + 1/2 \<le> (x + 1/2) + \<lceil>y - x\<rceil>\<^sub>\<rat>\<close> using step1 by linarith
+    from step2 have flo_le: \<open>\<lfloor>y + 1/2\<rfloor> \<le> \<lfloor>(x + 1/2) + \<lceil>y - x\<rceil>\<^sub>\<rat>\<rfloor>\<close>
+      by (rule floor_mono)
+    have flo_eq: \<open>\<lfloor>(x + 1/2) + \<lceil>y - x\<rceil>\<^sub>\<rat>\<rfloor> = \<lfloor>x + 1/2\<rfloor> + \<lceil>y - x\<rceil>\<close>
+      using floor_add_int[of \<open>x + 1/2\<close> \<open>\<lceil>y - x\<rceil>\<close>] by simp
+    from flo_le flo_eq have \<open>\<lfloor>y\<rceil> \<le> \<lfloor>x\<rceil> + \<lceil>y - x\<rceil>\<close> by (simp add: round_def)
+    thus \<open>\<lfloor>y\<rceil> - \<lfloor>x\<rceil> \<le> \<lceil>y - x\<rceil>\<close> by simp
+  qed
+  have round_diff_bound: \<open>\<bar>\<lfloor>b\<rceil> - \<lfloor>a\<rceil>\<bar> \<le> \<lceil>\<bar>b - a\<bar>\<rceil>\<close>
+  proof (cases \<open>a \<le> b\<close>)
+    case True
+    have h1: \<open>\<lfloor>b\<rceil> - \<lfloor>a\<rceil> \<le> \<lceil>b - a\<rceil>\<close> using round_diff_lem[OF True] .
+    have h2: \<open>\<lfloor>a\<rceil> - \<lfloor>b\<rceil> \<le> 0\<close> using True round_mono by simp
+    have h3: \<open>\<lceil>\<bar>b - a\<bar>\<rceil> = \<lceil>b - a\<rceil>\<close> using True by simp
+    have h4: \<open>0 \<le> \<lceil>b - a\<rceil>\<close> using True by simp
+    show ?thesis using h1 h2 h3 h4 by linarith
+  next
+    case False
+    hence ba: \<open>b \<le> a\<close> by simp
+    have h1: \<open>\<lfloor>a\<rceil> - \<lfloor>b\<rceil> \<le> \<lceil>a - b\<rceil>\<close> using round_diff_lem[OF ba] .
+    have h2: \<open>\<lfloor>b\<rceil> - \<lfloor>a\<rceil> \<le> 0\<close> using ba round_mono by simp
+    have h3: \<open>\<lceil>\<bar>b - a\<bar>\<rceil> = \<lceil>a - b\<rceil>\<close> using ba by (simp add: abs_minus_commute)
+    have h4: \<open>0 \<le> \<lceil>a - b\<rceil>\<close> using ba by simp
+    show ?thesis using h1 h2 h3 h4 by linarith
+  qed
+  have ceil_le: \<open>\<lceil>\<bar>b - a\<bar>\<rceil> \<le> \<lceil>\<bar>z\<bar> /\<^sub>\<rat> R\<rceil>\<close>
+    using ba_bound by (rule ceiling_mono)
+  have abs_diff_bound: \<open>\<bar>z mod\<^sup>\<plusminus> N - barrett_red_signed N n f z\<bar> \<le> N * \<lceil>\<bar>z\<bar> /\<^sub>\<rat> R\<rceil>\<close>
+  proof -
+    have e: \<open>\<bar>z mod\<^sup>\<plusminus> N - barrett_red_signed N n f z\<bar> = N * \<bar>\<lfloor>b\<rceil> - \<lfloor>a\<rceil>\<bar>\<close>
+      using diff_eq Npos by (simp add: abs_mult)
+    have N_nn: \<open>N \<ge> 0\<close> using Npos by simp
+    have \<open>N * \<bar>\<lfloor>b\<rceil> - \<lfloor>a\<rceil>\<bar> \<le> N * \<lceil>\<bar>b - a\<bar>\<rceil>\<close>
+      using round_diff_bound N_nn by (rule mult_left_mono)
+    also have \<open>\<dots> \<le> N * \<lceil>\<bar>z\<bar> /\<^sub>\<rat> R\<rceil>\<close>
+      using ceil_le N_nn by (rule mult_left_mono)
+    finally show ?thesis using e by simp
+  qed
+  show ?thesis
+    using abs_diff_bound by simp
+qed
+
+section \<open>Barrett multiplication\<close>
+
+text \<open>In NTTs one operand of each modular multiplication is a fixed twiddle.
+Barrett multiplication \cite[\S 3.1.2]{NeonNTT} folds \<^term>\<open>b\<close> into the
+magic constant \<open>\<lbrakk>b\<sqdot>R/N\<rbrakk>\<close>, collapsing reduction to a single multiply-shift
+\<open>a\<sqdot>\<lbrakk>b\<sqdot>R/N\<rbrakk>/R\<close> with representative \<open>a\<sqdot>b - N\<sqdot>\<lfloor>a\<sqdot>\<lbrakk>b\<sqdot>R/N\<rbrakk>/R\<rceil>\<close>.\<close>
+
+definition barrett_mul_signed (\<open>barM\<^sup>\<plusminus> \<lbrakk>_,_,_\<rbrakk>\<langle>_,_\<rangle>\<close>) where
+  \<open>barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> \<equiv> a * b - N * \<lfloor>a * \<lbrakk>b * 2^n /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> 2^n\<rceil>\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+definition barrett_mul_unsigned (\<open>barM\<^sup>+ \<lbrakk>_,_,_\<rbrakk>\<langle>_,_\<rangle>\<close>) where
+  \<open>barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>a, b\<rangle> \<equiv> a * b - N * \<lfloor>a * \<lbrakk>b * 2^n /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> 2^n\<rfloor>\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+text\<open>Barrett reduction is recovered as Barrett multiplication with \<^term>\<open>b=1\<close>:\<close>
+
+lemma barrett_red_as_mul:
+  shows \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z = barM\<^sup>\<plusminus> \<lbrakk>N, n, f\<rbrakk>\<langle>z, 1\<rangle>\<close>
+    and \<open>bar\<^sup>+\<lbrakk>N, n, f\<rbrakk> z = barM\<^sup>+ \<lbrakk>N, n, f\<rbrakk>\<langle>z, 1\<rangle>\<close>
+  by (simp_all add: barrett_red_signed_def barrett_mul_signed_def
+                    barrett_red_unsigned_def barrett_mul_unsigned_def)
+
+
+section \<open>Refined Barrett reduction\<close>
+
+text \<open>The output quality of Barrett reduction improves as the radix \<^term>\<open>2^n\<close>
+grows, so one is naturally led to consider radices that fall
+\<^emph>\<open>between\<close> word boundaries. This section establishes a way to compute such
+reductions in a two-step fashion: a word-sized truncating high-half multiply,
+followed by a rounding right shift on the lane-width word.\<close>
+
+definition barrett_red_refined :: \<open>int \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> int \<Rightarrow> int \<Rightarrow> int\<close> where
+  \<open>barrett_red_refined N n \<alpha> V z \<equiv>
+     let t = (2 * z * V) div 2^n;
+         q = \<lfloor>t /\<^sub>\<rat> 2^\<alpha>\<rceil>
+     in z - q * N\<close>
+
+text \<open>Key identity: for an integer \<^term>\<open>q :: int\<close>, the value \<^term>\<open>q /\<^sub>\<rat> 2^k + 1/\<^sub>\<rat>2\<close>
+has denominator \<^term>\<open>2^k\<close>, so adding a perturbation less than \<open>1/2^k\<close> cannot
+cross an integer boundary.\<close>
+
+lemma floor_then_round_shift:
+  fixes x :: int and n k :: nat
+  assumes \<open>k \<ge> 1\<close>
+  shows \<open>\<lfloor>(x div 2^n)\<^sub>\<rat> / (2^k)\<^sub>\<rat>\<rceil> = \<lfloor>x /\<^sub>\<rat> 2^(n+k)\<rceil>\<close>
+proof -
+  define q where \<open>q = x div 2^n\<close>
+  define r where \<open>r = x mod 2^n\<close>
+  have xqr: \<open>x = q * 2^n + r\<close> unfolding q_def r_def by (rule div_mult_mod_eq[symmetric])
+  have r_ge: \<open>0 \<le> r\<close> unfolding r_def by simp
+  have r_lt: \<open>r < 2^n\<close> unfolding r_def by simp
+  have q_eq: \<open>x div 2^n = q\<close> unfolding q_def by simp
+  have k_pos: \<open>(2::int)^k > 0\<close> by simp
+  have nk_pos: \<open>(2::int)^(n+k) > 0\<close> by simp
+  have two_k_pos: \<open>(2::int) * 2^k > 0\<close> by simp
+  have two_nk_pos: \<open>(2::int) * 2^(n+k) > 0\<close> by simp
+  have n_pos: \<open>(2::int)^n > 0\<close> by simp
+  have lhs_eq: \<open>\<lfloor>(of_int q :: rat) / of_int ((2::int)^k)\<rceil> = (2*q + 2^k) div (2 * 2^k)\<close>
+  proof -
+    have step1: \<open>\<lfloor>(of_int q :: rat) / of_int ((2::int)^k)\<rceil> = \<lfloor>(of_int q :: rat) / of_int ((2::int)^k) + 1/2\<rfloor>\<close>
+      by (simp add: round_def)
+    have step2: \<open>(of_int q :: rat) / of_int ((2::int)^k) + 1/2 = of_int (2*q + 2^k) / (of_int (2 * 2^k) :: rat)\<close>
+      using k_pos by (simp add: field_simps of_int_mult)
+    have step3: \<open>\<lfloor>of_int (2*q + 2^k) / (of_int (2 * 2^k) :: rat)\<rfloor> = (2*q + 2^k) div (2 * 2^k)\<close>
+      using two_k_pos floor_divide_of_int_eq[of \<open>2*q + 2^k\<close> \<open>2 * 2^k\<close>] by simp
+    show ?thesis using step1 step2 step3 by simp
+  qed
+  have rhs_eq: \<open>\<lfloor>(of_int x :: rat) / of_int ((2::int)^(n+k))\<rceil> = (2*x + 2^(n+k)) div (2 * 2^(n+k))\<close>
+  proof -
+    have step1: \<open>\<lfloor>(of_int x :: rat) / of_int ((2::int)^(n+k))\<rceil> = \<lfloor>(of_int x :: rat) / of_int ((2::int)^(n+k)) + 1/2\<rfloor>\<close>
+      by (simp add: round_def)
+    have step2: \<open>(of_int x :: rat) / of_int ((2::int)^(n+k)) + 1/2 = of_int (2*x + 2^(n+k)) / (of_int (2 * 2^(n+k)) :: rat)\<close>
+      using nk_pos by (simp add: field_simps of_int_mult)
+    have step3: \<open>\<lfloor>of_int (2*x + 2^(n+k)) / (of_int (2 * 2^(n+k)) :: rat)\<rfloor> = (2*x + 2^(n+k)) div (2 * 2^(n+k))\<close>
+      using two_nk_pos floor_divide_of_int_eq[of \<open>2*x + 2^(n+k)\<close> \<open>2 * 2^(n+k)\<close>] by simp
+    show ?thesis using step1 step2 step3 by simp
+  qed
+  have scale: \<open>(2*q + 2^k) div (2 * 2^k) = (2*q + 2^k) * 2^n div ((2 * 2^k) * 2^n)\<close>
+    using n_pos div_mult_mult2[of \<open>2^n\<close> \<open>2*q + 2^k\<close> \<open>2*2^k\<close>] by simp
+  have denom_eq: \<open>(2::int) * 2^k * 2^n = 2 * 2^(n+k)\<close>
+    by (simp add: power_add)
+  have num_eq: \<open>(2*q + 2^k) * (2::int)^n = 2*x - 2*r + 2^(n+k)\<close>
+    using xqr by (simp add: algebra_simps power_add)
+  have lhs_as_div: \<open>(2*q + 2^k) div (2 * 2^k) = (2*x - 2*r + 2^(n+k)) div (2 * 2^(n+k))\<close>
+    using scale num_eq denom_eq by simp
+  have key: \<open>(2*x - 2*r + 2^(n+k)) div (2 * 2^(n+k)) = (2*x + 2^(n+k)) div (2 * 2^(n+k))\<close>
+  proof -
+    define A where \<open>A = 2*x - 2*r + (2::int)^(n+k)\<close>
+    define D where \<open>D = (2::int) * 2^(n+k)\<close>
+    have D_pos: \<open>D > 0\<close> unfolding D_def by simp
+    have rhs_split: \<open>2*x + (2::int)^(n+k) = A + 2*r\<close>
+      unfolding A_def by simp
+    have two_r_ge: \<open>0 \<le> 2*r\<close> using r_ge by simp
+    have two_r_lt_D: \<open>2*r < D\<close>
+    proof -
+      have \<open>2*r < 2 * 2^n\<close> using r_lt by simp
+      also have \<open>2 * (2::int)^n \<le> 2 * 2^(n+k)\<close>
+        using assms by (simp add: power_add)
+      finally show ?thesis unfolding D_def .
+    qed
+    have A_eq: \<open>A = (2*q + 2^k) * 2^n\<close>
+      unfolding A_def using xqr by (simp add: algebra_simps power_add)
+    have D_eq: \<open>D = (2*2^k) * (2::int)^n\<close>
+      unfolding D_def by (simp add: power_add)
+    have A_mod_D: \<open>A mod D = ((2*q + 2^k) mod (2*2^k)) * 2^n\<close>
+      using A_eq D_eq mod_mult_mult2[of \<open>2*q + 2^k\<close> \<open>2^n\<close> \<open>2*2^k\<close>] by simp
+    define m where \<open>m = (2*q + (2::int)^k) mod (2 * 2^k)\<close>
+    have m_eq: \<open>A mod D = m * 2^n\<close> using A_mod_D unfolding m_def by simp
+    have m_ge: \<open>m \<ge> 0\<close> unfolding m_def using two_k_pos by simp
+    have m_lt: \<open>m < 2 * 2^k\<close> unfolding m_def using two_k_pos by simp
+    have m_even: \<open>even m\<close>
+    proof -
+      have \<open>even ((2*q + (2::int)^k) mod (2 * 2^k)) = even (2*q + (2::int)^k)\<close>
+        using dvd_mod_iff[of 2 \<open>2*2^k\<close> \<open>2*q + 2^k\<close>] by simp
+      moreover have \<open>even (2*q + (2::int)^k)\<close>
+        using assms by simp
+      ultimately show ?thesis unfolding m_def by simp
+    qed
+    have m_le: \<open>m \<le> 2*2^k - 2\<close> using m_lt m_even by presburger
+    have mod_bound: \<open>A mod D + 2*r < D\<close>
+    proof -
+      have \<open>m * 2^n \<le> (2*2^k - 2) * 2^n\<close>
+        using m_le n_pos by (intro mult_right_mono) auto
+      also have \<open>\<dots> = D - 2 * 2^n\<close> unfolding D_eq by (simp add: algebra_simps)
+      finally have \<open>A mod D \<le> D - 2*2^n\<close> using m_eq by simp
+      moreover have \<open>2*r < 2*2^n\<close> using r_lt by simp
+      ultimately show ?thesis by linarith
+    qed
+    have div_eq: \<open>(A + 2*r) div D = A div D\<close>
+    proof -
+      have \<open>(A + 2*r) div D = A div D + (2*r) div D + (A mod D + (2*r) mod D) div D\<close>
+        using div_add1_eq[of A \<open>2*r\<close> D] by simp
+      moreover have \<open>(2*r) div D = 0\<close>
+        using two_r_ge two_r_lt_D D_pos by (simp add: div_pos_pos_trivial)
+      moreover have \<open>(2*r) mod D = 2*r\<close>
+        using two_r_ge two_r_lt_D D_pos by (simp add: mod_pos_pos_trivial)
+      moreover have \<open>(A mod D + 2*r) div D = 0\<close>
+      proof -
+        have \<open>A mod D + 2*r < D\<close> by (rule mod_bound)
+        moreover have \<open>A mod D + 2*r \<ge> 0\<close>
+          using D_pos pos_mod_sign[of D A] two_r_ge by simp
+        ultimately show ?thesis using D_pos by (simp add: div_pos_pos_trivial)
+      qed
+      ultimately show ?thesis by simp
+    qed
+    show ?thesis using rhs_split div_eq unfolding A_def D_def by simp
+  qed
+  show ?thesis using lhs_eq rhs_eq lhs_as_div key q_eq by simp
+qed
+
+text \<open>The refined kernel equals Barrett reduction at the effective radix
+\<^term>\<open>2^(n+\<alpha>-1) :: int\<close>.\<close>
+
+lemma barrett_red_refined_eq:
+  assumes \<open>\<alpha> \<ge> 1\<close>
+  assumes \<open>V = \<lfloor>2^(n+\<alpha>-1) /\<^sub>\<rat> N\<rceil>\<close>
+  shows \<open>barrett_red_refined N n \<alpha> V z = bar\<^sup>\<plusminus>\<lbrakk>N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> z\<close>
+proof -
+  have key: \<open>\<lfloor>((2*z*V) div 2^n)\<^sub>\<rat> / (2^\<alpha>)\<^sub>\<rat>\<rceil> = \<lfloor>(2*z*V) /\<^sub>\<rat> 2^(n+\<alpha>)\<rceil>\<close>
+    by (rule floor_then_round_shift[OF assms(1)])
+  have power_eq: \<open>(2::int)^(n+\<alpha>) = 2 * 2^(n+\<alpha>-1)\<close>
+    using assms(1) by (simp add: power_eq_if)
+  have \<open>barrett_red_refined N n \<alpha> V z = z - \<lfloor>(2*z*V) /\<^sub>\<rat> 2^(n+\<alpha>)\<rceil> * N\<close>
+    unfolding barrett_red_refined_def Let_def
+    using key by simp
+  also have \<open>\<dots> = z - \<lfloor>(z*V) /\<^sub>\<rat> 2^(n+\<alpha>-1)\<rceil> * N\<close>
+  proof -
+    have \<open>(2*z*V :: int) /\<^sub>\<rat> 2^(n+\<alpha>) = (z*V) /\<^sub>\<rat> 2^(n+\<alpha>-1)\<close>
+      using power_eq by (simp add: of_int_mult)
+    thus ?thesis by simp
+  qed
+  also have \<open>\<dots> = z - N * \<lfloor>z\<^sub>\<rat> * V\<^sub>\<rat> / (2^(n+\<alpha>-1))\<^sub>\<rat>\<rceil>\<close>
+    by (simp add: of_int_mult algebra_simps)
+  also have \<open>\<dots> = z - N * \<lfloor>z\<^sub>\<rat> * \<lfloor>2^(n+\<alpha>-1) /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> / (2^(n+\<alpha>-1))\<^sub>\<rat>\<rceil>\<close>
+    using assms(2) by simp
+  also have \<open>\<dots> = bar\<^sup>\<plusminus>\<lbrakk>N, n+\<alpha>-1, \<lfloor>\<cdot>\<rceil>\<rbrakk> z\<close>
+    unfolding barrett_red_signed_def by simp
+  finally show ?thesis .
+qed
+
+text \<open>As in the standard Barrett section, output bounds are deferred to the
+Barrett--Montgomery bridge chapter (\autoref{ch:barrett_montgomery}); the
+instantiation as the Neon \<^verbatim>\<open>SQDMULH\<close>/\<^verbatim>\<open>SRSHR\<close>/\<^verbatim>\<open>MLS\<close> sequence
+(\cite[Algorithm~11]{NeonNTT}) is deferred to \autoref{ch:asm_barrett}.\<close>
+
+end
+
+

--- a/proofs/isabelle/neon_ntt/Bridge_Conceptual.thy
+++ b/proofs/isabelle/neon_ntt/Bridge_Conceptual.thy
@@ -1,0 +1,716 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+
+theory Bridge_Conceptual
+  imports Barrett_Montgomery
+begin
+
+chapter \<open>A conceptual view of the Barrett--Montgomery bridge \label{ch:bridge_conceptual}\<close>
+
+text \<open>
+The \autoref{ch:barrett_montgomery} bridge was proved by direct algebraic
+manipulation. This chapter recasts it as a corollary of a (trivial) duality
+between Euclidean and 2-adic \emph{rounding} of a rational number, plus some
+arithmetic properties of the 2-adic side.
+
+Rounding can be described as the process of expressing a continuum as the sum of
+something discrete and something small (relatively compact); the choice of
+absolute value on \<^term>\<open>\<rat>\<close> determines the roles. The Euclidean absolute
+value gives \<open>\<lfloor>\<cdot>\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>] : \<rat> \<rightarrow> \<int>\<close>, with error in \<open>[-\<onehalf>, \<onehalf>)\<close>: this is the
+rounding underlying Barrett. The 2-adic absolute value gives
+\<open>\<lfloor>\<cdot>\<rceil>\<^sub>[\<^sub>2\<^sub>] : \<rat> \<rightarrow> \<int>[\<onehalf>] \<inter> [-\<onehalf>, \<onehalf>)\<close>, with error in the odd-denominator
+rationals \<open>\<int>\<^sub>(\<^sub>2\<^sub>) \<inter> \<rat>\<close>: this is the rounding underlying Montgomery. The
+duality is the swap: each rounding's target sits inside the other's error set.
+On the dyadic rationals \<open>\<int>[\<onehalf>]\<close> the two roundings sum to the identity. This,
+together with basic arithmetic properties of 2-adic rounding, establishes the
+Barrett--Montgomery bridge.
+
+We treat only the signed variant; the unsigned variant follows the same recipe
+with floor-rounding.
+\<close>
+
+
+section \<open>Barrett arithmetic via Euclidean rounding\<close>
+
+text \<open>
+For the Euclidean metric, the rounding target is \<^term>\<open>\<int>\<close> and the error lies in
+\<open>[-\<onehalf>, \<onehalf>)\<close>. The half-open right end is forced by HOL's \<^const>\<open>round\<close>
+(round half-up): at \<open>q = \<onehalf>\<close> the error is \<open>-\<onehalf>\<close>.
+\<close>
+
+definition \<open>euclid_target q \<equiv> snd (quotient_of q) = 1\<close>
+definition \<open>euclid_error q \<equiv> - (1/2) \<le> q \<and> q < 1/2\<close>
+
+text %internal \<open>The Euclidean target is exactly \<^term>\<open>\<int>\<close> (in the \<^term>\<open>\<rat>\<close>-quotient sense).\<close>
+
+lemma %internal euclid_target_iff_int:
+  \<open>euclid_target q \<longleftrightarrow> (\<exists>k::int. q = k\<^sub>\<rat>)\<close>
+proof
+  assume H: \<open>euclid_target q\<close>
+  obtain a b where ab: \<open>quotient_of q = (a, b)\<close> by (cases \<open>quotient_of q\<close>) auto
+  with H have b1: \<open>b = 1\<close> unfolding euclid_target_def by simp
+  have qF: \<open>q = Fract a b\<close>
+    using ab Fract_quotient_of[of q] by (metis fst_conv snd_conv)
+  with b1 have \<open>q = Fract a 1\<close> by simp
+  hence \<open>q = a\<^sub>\<rat>\<close> by (simp add: Fract_of_int_eq)
+  thus \<open>\<exists>k::int. q = k\<^sub>\<rat>\<close> by blast
+next
+  assume \<open>\<exists>k::int. q = k\<^sub>\<rat>\<close>
+  then obtain k where qk: \<open>q = k\<^sub>\<rat>\<close> by blast
+  have \<open>quotient_of (k\<^sub>\<rat>) = (k, 1)\<close> by simp
+  thus \<open>euclid_target q\<close> unfolding euclid_target_def using qk by simp
+qed
+
+lemma %internal euclid_target_of_int [simp]: \<open>euclid_target (k\<^sub>\<rat>)\<close>
+  unfolding euclid_target_def by simp
+
+lemma %internal round_error_window:
+  shows lower: \<open>- (1/2) \<le> q - \<lfloor>q\<rceil>\<^sub>\<rat>\<close> and upper: \<open>q - \<lfloor>q\<rceil>\<^sub>\<rat> < 1/2\<close>
+proof -
+  let ?h = \<open>q + 1/2\<close>
+  let ?n = \<open>\<lfloor>?h\<rfloor>\<close>
+  have e1: \<open>?n\<^sub>\<rat> \<le> ?h\<close> by (rule of_int_floor_le)
+  have e2: \<open>?h < ?n\<^sub>\<rat> + 1\<close> by linarith
+  have unf: \<open>round q = ?n\<close> unfolding round_def ..
+  show \<open>- (1/2) \<le> q - \<lfloor>q\<rceil>\<^sub>\<rat>\<close> using e1 unf by linarith
+  show \<open>q - \<lfloor>q\<rceil>\<^sub>\<rat> < 1/2\<close> using e2 unf by linarith
+qed
+
+text\<open>Every rational has a unique decomposition with respect to Euclidean rounding:\<close>
+
+theorem euclidean_decomposition_unique:
+  shows \<open>\<exists>!m. euclid_target m \<and> euclid_error (q - m)\<close>
+proof (rule ex1I)
+  show \<open>euclid_target (\<lfloor>q\<rceil>\<^sub>\<rat> :: rat) \<and> euclid_error (q - \<lfloor>q\<rceil>\<^sub>\<rat>)\<close>
+    using round_error_window[of q] unfolding euclid_error_def by simp
+next
+  fix m assume H: \<open>euclid_target m \<and> euclid_error (q - m)\<close>
+  show \<open>m = \<lfloor>q\<rceil>\<^sub>\<rat>\<close>
+    using H euclid_target_iff_int unfolding euclid_error_def
+    by (metis add.commute diff_le_eq diff_less_eq minus_diff_eq minus_le_iff round_unique)
+qed
+
+definition round_E (\<open>\<lfloor>_\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>]\<close>) where \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>] \<equiv> THE m. euclid_target m \<and> euclid_error (q - m)\<close>
+
+text \<open>\noindent Of course, \<open>[\<infinity>]\<close> is just ordinary rounding:\<close>
+
+lemma round_E_eq_round: \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>] = \<lfloor>q\<rceil>\<^sub>\<rat>\<close>
+  by (rule the1_equality[OF euclidean_decomposition_unique, folded round_E_def])
+     (use round_error_window[of q] in \<open>simp add: euclid_error_def\<close>)
+
+text \<open>\noindent Finally, Barrett reduction is --- by definition --- based on Euclidean rounding of
+\<^term>\<open>z * f (R /\<^sub>\<rat> N) /\<^sub>\<rat> R\<close> scaled by \<^term>\<open>N\<close> and subtracted from \<^term>\<open>z\<close>.\<close>
+
+lemma (in BarrettContext) bar_signed_as_round_E:
+  shows \<open>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat> = z\<^sub>\<rat> - N\<^sub>\<rat> * \<lfloor>z * \<lbrakk>2^n /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> 2^n\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>]\<close>
+  by (simp add: barrett_red_signed_def Let_def round_E_eq_round)
+
+section \<open>Montgomery arithmetic via 2-adic rounding\<close>
+
+text \<open>
+For the 2-adic metric, the rounding target is \<open>\<int>[\<onehalf>] \<inter> [-\<onehalf>, \<onehalf>)\<close> (a transversal of
+\<open>\<rat>\<^sub>2 / \<int>\<^sub>2\<close>) and the error set is the odd-denominator rationals
+\<open>\<int>\<^sub>(\<^sub>2\<^sub>) \<inter> \<rat>\<close>. Compared to the Euclidean side the targets and errors swap:
+\<^term>\<open>\<int>\<close> now sits inside the error set, and \<open>[-\<onehalf>, \<onehalf>)\<close> now contains the
+target. We need a little more arithmetic groundwork than the Euclidean side.
+\<close>
+
+definition %internal \<open>is_power_of_two k \<equiv> (\<exists>m::nat. k = 2^m)\<close>
+
+definition Dyadic ("\<int>\<^sub>[\<^sub>1\<^sub>'/\<^sub>2\<^sub>]")
+  where \<open>\<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<equiv> {q. is_power_of_two (snd (quotient_of q))}\<close>
+
+definition TwoAdicIntegral ("\<int>\<^sub>[\<^sub>2\<^sub>]")
+  where \<open>\<int>\<^sub>[\<^sub>2\<^sub>] \<equiv> {q. odd (snd (quotient_of q))}\<close>
+
+lemma %internal Dyadic_iff:
+  "q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<longleftrightarrow> is_power_of_two (snd (quotient_of q))"
+  by (simp add: Dyadic_def)
+
+lemma %internal TwoAdicIntegral_iff:
+  "q \<in> \<int>\<^sub>[\<^sub>2\<^sub>] \<longleftrightarrow> odd (snd (quotient_of q))"
+  by (simp add: TwoAdicIntegral_def)
+
+text\<open>We will use the following congruence relation to embed modular
+arithmetic modulo \<^term>\<open>R\<close> into the intermediate subring \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close> between \<^term>\<open>\<int>\<close>
+and \<^term>\<open>\<rat>\<close>. Note that it does not degenerate because we left \<^term>\<open>2\<close> non-invertible
+in \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close>.\<close>
+
+abbreviation cong_R_two_adic :: "rat \<Rightarrow> rat \<Rightarrow> int \<Rightarrow> bool"
+      ("[_ = _] '( mod _ \<int>\<^sub>[\<^sub>2\<^sub>]')" [50, 50, 50] 50)
+      where "[x = y] (mod R \<int>\<^sub>[\<^sub>2\<^sub>]) \<equiv> ((x - y) / R\<^sub>\<rat>) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]"
+
+text\<open>Our 2-adic rounding target is the (2-adically) discrete set of dyadic numbers in the
+interval \<^term>\<open>{-1/2..<1/2}\<close>:\<close>
+
+definition TwoAdicTarget ("'[-\<onehalf>, \<onehalf>')\<^sub>[\<^sub>1\<^sub>'/\<^sub>2\<^sub>]") where
+  \<open>[-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<equiv> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<inter> {-(1/2)..<(1/2)}\<close>
+
+lemma %internal two_adic_target_iff:
+  \<open>q \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<longleftrightarrow> q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> - (1/2) \<le> q \<and> q < 1/2\<close>
+  by (simp add: TwoAdicTarget_def)
+
+lemma %internal int_dyadic [simp]: \<open>k\<^sub>\<rat> \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  unfolding Dyadic_iff is_power_of_two_def
+  by (rule exI[where x=0]) simp
+
+lemma %internal two_adic_integral_of_int [simp]: \<open>k\<^sub>\<rat> \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  unfolding TwoAdicIntegral_def by simp
+
+lemma %internal dyadic_and_integral_iff_int:
+  \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<inter> \<int>\<^sub>[\<^sub>2\<^sub>] \<longleftrightarrow> (\<exists>k::int. q = k\<^sub>\<rat>)\<close>
+  by (auto simp: Dyadic_iff TwoAdicIntegral_iff is_power_of_two_def Fract_of_int_eq Fract_quotient_of)
+     (metis power_0 not0_implies_Suc power_Suc even_mult_iff dvd_refl Fract_of_int_eq Fract_quotient_of)
+
+text %internal \<open>Equivalent characterisation of \<^term>\<open>\<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> as ``some power of \<open>2\<close>
+multiplied into \<^term>\<open>\<int>\<close>''.\<close>
+
+lemma %internal dyadic_iff_pow_int:
+  \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<longleftrightarrow> (\<exists>n::nat. 2^n * q \<in> \<int>)\<close>
+proof -
+  obtain a b where ab: \<open>quotient_of q = (a, b)\<close> and b_pos: \<open>b > 0\<close>
+    and copr: \<open>coprime a b\<close> and qfrac: \<open>q = a /\<^sub>\<rat> b\<close>
+    using quotient_of_denom_pos quotient_of_coprime Fract_quotient_of[of q]
+    by (metis Fract_of_int_quotient prod.collapse)
+  show ?thesis
+  proof
+    assume \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+    thus \<open>\<exists>n::nat. 2^n * q \<in> \<int>\<close>
+    proof -
+      assume H: \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+      obtain m where bm: \<open>b = 2^m\<close>
+        using H ab unfolding Dyadic_iff is_power_of_two_def by force
+      have \<open>2^m * q = a\<^sub>\<rat>\<close> using qfrac bm b_pos by simp
+      thus ?thesis using Ints_of_int by metis
+    qed
+  next
+    have \<open>prime (2::int)\<close> by simp
+    moreover assume \<open>\<exists>n::nat. 2^n * q \<in> \<int>\<close>
+    ultimately show \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+    proof -
+      assume prime2: \<open>prime (2::int)\<close> and exH: \<open>\<exists>n::nat. 2^n * q \<in> \<int>\<close>
+      obtain m k where mk: \<open>2^m * q = k\<^sub>\<rat>\<close> using exH Ints_cases by metis
+      hence \<open>2^m * (a\<^sub>\<rat> / b\<^sub>\<rat>) = k\<^sub>\<rat>\<close> using qfrac by simp
+      hence rat_eq: \<open>(2^m * a)\<^sub>\<rat> = (k * b)\<^sub>\<rat>\<close>
+        using b_pos by (simp add: of_int_mult field_simps)
+      have eq: \<open>2^m * a = k * b\<close> using rat_eq by (metis of_int_eq_iff)
+      hence \<open>b dvd 2^m * a\<close> by (metis dvd_triv_right)
+      hence \<open>b dvd 2^m\<close>
+        using copr coprime_dvd_mult_left_iff coprime_commute by (metis mult.commute)
+      hence \<open>\<exists>m'. b = 2^m'\<close>
+        using prime2 divides_primepow b_pos
+        by (metis abs_of_pos normalize_int_def)
+      thus \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> using ab unfolding Dyadic_iff is_power_of_two_def by auto
+    qed
+  qed
+qed
+
+lemma %internal int_div_pow2_dyadic [simp]:
+  shows \<open>a /\<^sub>\<rat> (2^n) \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  by (metis nonzero_mult_div_cancel_left of_int_numeral of_int_power dyadic_iff_pow_int Ints_of_int
+    power_eq_0_iff times_divide_eq_right zero_neq_numeral)
+
+text %internal \<open>Closure: \<^term>\<open>\<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> is closed under subtraction.\<close>
+
+lemma %internal dyadic_diff:
+  assumes \<open>q1 \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> and \<open>q2 \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  shows \<open>q1 - q2 \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+proof -
+  obtain n1 where ints1: \<open>2^n1 * q1 \<in> \<int>\<close>
+    using assms(1) dyadic_iff_pow_int by blast
+  obtain n2 where ints2: \<open>2^n2 * q2 \<in> \<int>\<close>
+    using assms(2) dyadic_iff_pow_int by blast
+  let ?n = \<open>n1 + n2\<close>
+  have ints1': \<open>2^?n * q1 \<in> \<int>\<close>
+    using Ints_mult[OF Ints_of_int[of \<open>2^n2\<close>] ints1]
+    by (simp add: power_add of_int_mult algebra_simps)
+  have ints2': \<open>2^?n * q2 \<in> \<int>\<close>
+    using Ints_mult[OF Ints_of_int[of \<open>2^n1\<close>] ints2]
+    by (simp add: power_add of_int_mult algebra_simps)
+  have \<open>2^?n * (q1 - q2) \<in> \<int>\<close>
+    using ints1' ints2' by (simp add: right_diff_distrib)
+  thus \<open>q1 - q2 \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> using dyadic_iff_pow_int by blast
+qed
+
+lemma %internal dyadic_minus_int:
+  assumes \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  shows \<open>(q - k\<^sub>\<rat>) \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+proof -
+  have \<open>(k\<^sub>\<rat>) \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> by simp
+  thus ?thesis using dyadic_diff[OF assms] by simp
+qed
+
+text %internal \<open>Closure: rationals with odd denominator are closed under subtraction.\<close>
+
+lemma %internal quotient_of_to_Fract:
+  assumes \<open>quotient_of q = (a, b)\<close>
+  shows \<open>q = Fract a b\<close>
+proof -
+  have \<open>Fract (fst (quotient_of q)) (snd (quotient_of q)) = q\<close>
+    by (rule Fract_quotient_of)
+  thus ?thesis using assms by simp
+qed
+
+lemma %internal two_adic_integral_diff:
+  assumes \<open>q1 \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close> and \<open>q2 \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  shows \<open>q1 - q2 \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  obtain a1 b1 a2 b2 where ab1: \<open>quotient_of q1 = (a1, b1)\<close> and ab2: \<open>quotient_of q2 = (a2, b2)\<close>
+    by (cases \<open>quotient_of q1\<close>; cases \<open>quotient_of q2\<close>) auto
+  obtain a b where ab: \<open>quotient_of (q1 - q2) = (a, b)\<close>
+    by (cases \<open>quotient_of (q1 - q2)\<close>) auto
+  have \<open>odd (b1 * b2)\<close> \<open>b1 * b2 > 0\<close>
+    using assms ab1 ab2 quotient_of_denom_pos
+    unfolding TwoAdicIntegral_iff by (auto intro: mult_pos_pos)
+  moreover have \<open>Rat.normalize (a1 * b2 - a2 * b1, b1 * b2) = (a, b)\<close>
+    using ab ab1 ab2 by (simp add: rat_minus_code)
+  ultimately have \<open>odd b\<close>
+    by (auto simp: Rat.normalize_def Let_def split: if_splits)
+       (metis dvd_div_mult_self gcd_dvd2 even_mult_iff)
+  thus ?thesis unfolding TwoAdicIntegral_iff using ab by simp
+qed
+
+text \<open>A rational with odd denominator (in lowest terms) lies in \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close>.\<close>
+
+lemma two_adic_integral_div_odd:
+  assumes \<open>N > 0\<close> and \<open>odd N\<close>
+  shows \<open>a /\<^sub>\<rat> N \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  unfolding TwoAdicIntegral_iff using assms
+  by (simp add: Fract_of_int_quotient[symmetric] Rat.quotient_of_Fract Rat.normalize_def Let_def)
+     (metis dvd_mult_div_cancel even_mult_iff gcd_dvd2)
+
+text %internal \<open>\<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close> is closed under multiplication by an integer: if \<^term>\<open>q\<close> has odd
+denominator (in lowest terms) then so does \<^term>\<open>c\<^sub>\<rat> * q\<close> (any common factor between
+\<^term>\<open>c\<close> and the denominator only shrinks the denominator).\<close>
+
+lemma %internal two_adic_integral_int_mult:
+  assumes \<open>q \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  shows \<open>c\<^sub>\<rat> * q \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  obtain a b where ab: \<open>quotient_of q = (a, b)\<close>
+    by (cases \<open>quotient_of q\<close>) auto
+  from assms ab have b_odd: \<open>odd b\<close> unfolding TwoAdicIntegral_iff by simp
+  have b_pos: \<open>b > 0\<close> using quotient_of_denom_pos[OF ab] .
+  have q_eq: \<open>q = a /\<^sub>\<rat> b\<close>
+    using ab Fract_quotient_of[of q] b_pos
+    by (metis Fract_of_int_quotient fst_conv snd_conv)
+  have \<open>c\<^sub>\<rat> * q = (c * a) /\<^sub>\<rat> b\<close>
+    using b_pos q_eq by (simp add: of_int_mult)
+  thus ?thesis
+    using two_adic_integral_div_odd[OF b_pos b_odd, of \<open>c * a\<close>] by simp
+qed
+
+text %internal \<open>The 2-adic congruence \<^term>\<open>[a = b] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close> scales by an integer
+factor: if \<^term>\<open>a\<close> and \<^term>\<open>b\<close> agree mod \<^term>\<open>R\<close> in \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close>, so do \<^term>\<open>c\<^sub>\<rat> * a\<close> and \<^term>\<open>c\<^sub>\<rat> * b\<close>.
+The proof factors \<^term>\<open>c\<close> out of the difference and uses closure of \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close> under
+integer multiplication.\<close>
+
+lemma %internal cong_R_two_adic_scale:
+  assumes \<open>[a = b] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+  shows \<open>[c\<^sub>\<rat> * a = c\<^sub>\<rat> * b] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+proof -
+  have eq: \<open>(c\<^sub>\<rat> * a - c\<^sub>\<rat> * b) / R\<^sub>\<rat> = c\<^sub>\<rat> * ((a - b) / R\<^sub>\<rat>)\<close>
+    by (simp add: field_simps)
+  have \<open>c\<^sub>\<rat> * ((a - b) / R\<^sub>\<rat>) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using two_adic_integral_int_mult[OF assms] by simp
+  thus ?thesis unfolding eq by simp
+qed
+
+text %internal \<open>\<^term>\<open>R dvd (z - z mod\<^sup>\<plusminus> R)\<close>: a basic property of signed mod, used in
+existence below.\<close>
+
+lemma %internal R_dvd_z_minus_smod:
+  shows \<open>R dvd (z - (z mod\<^sup>\<plusminus> R))\<close>
+  unfolding mod_approx_def by simp
+
+text %internal \<open>Uniqueness of the 2-adic decomposition: if two \<open>m\<^sub>i\<close> both lie in
+\<^term>\<open>[-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> with \<^term>\<open>q - m\<^sub>i \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>, then \<^term>\<open>m\<^sub>1 = m\<^sub>2\<close>. The argument
+takes \<^term>\<open>m\<^sub>1 - m\<^sub>2\<close>, observes it lies in both \<^term>\<open>\<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> (closure under subtraction)
+and \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close> (closure of odd-denominator rationals under subtraction);
+the intersection is \<^term>\<open>\<int>\<close>, and the bounds \<open>|m\<^sub>i| < \<onehalf>\<close> force the integer to be \<^term>\<open>0\<close>.\<close>
+
+lemma %internal twoadic_uniqueness:
+  assumes \<open>m1 \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> \<open>m2 \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+      and \<open>q - m1 \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close> \<open>(q - m2) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    shows \<open>m1 = m2\<close>
+proof -
+  from assms(1) have d1: \<open>m1 \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> and lb1: \<open>- (1/2) \<le> m1\<close> and ub1: \<open>m1 < 1/2\<close>
+    unfolding two_adic_target_iff by auto
+  from assms(2) have d2: \<open>m2 \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> and lb2: \<open>- (1/2) \<le> m2\<close> and ub2: \<open>m2 < 1/2\<close>
+    unfolding two_adic_target_iff by auto
+  have d_diff: \<open>(m1 - m2) \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> using dyadic_diff[OF d1 d2] .
+  have step: \<open>(q - m2) - (q - m1) = m1 - m2\<close> by (simp add: algebra_simps)
+  have e_diff: \<open>(m1 - m2) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using two_adic_integral_diff[OF assms(4) assms(3)] step by argo
+  have \<open>\<exists>k::int. m1 - m2 = k\<^sub>\<rat>\<close>
+    using d_diff e_diff dyadic_and_integral_iff_int by blast
+  then obtain k where mk: \<open>m1 - m2 = k\<^sub>\<rat>\<close> by blast
+  have lb: \<open>m1 - m2 > - 1\<close> using lb1 ub1 lb2 ub2 by linarith
+  have ub: \<open>m1 - m2 < 1\<close> using lb1 ub1 lb2 ub2 by linarith
+  have \<open>k\<^sub>\<rat> > - 1\<close> using mk lb by simp
+  hence k_lb: \<open>k > - 1\<close>
+    by (metis of_int_less_iff of_int_minus of_int_1)
+  have \<open>k\<^sub>\<rat> < 1\<close> using mk ub by simp
+  hence k_ub: \<open>k < 1\<close>
+    by (metis of_int_less_iff of_int_1)
+  have \<open>k = 0\<close> using k_lb k_ub by simp
+  hence \<open>m1 - m2 = 0\<close> using mk by simp
+  thus \<open>m1 = m2\<close> by simp
+qed
+
+text %internal \<open>Existence of the 2-adic decomposition for an arbitrary \<^term>\<open>q :: rat\<close>.
+Write \<^term>\<open>q = a\<^sub>\<rat> / b\<^sub>\<rat>\<close> with \<^term>\<open>b = 2^n * b'\<close>, \<open>b'\<close> odd. If \<^term>\<open>n = 0\<close>, \<^term>\<open>q\<close> is itself
+two-adic-integral and \<^term>\<open>m = 0\<close>. Otherwise, the candidate is
+\<open>m = ((a * b'\<^sup>-\<^sup>1) mod\<^sup>\<plusminus> 2\<^sup>n)\<^sub>\<rat> / (2\<^sup>n)\<^sub>\<rat>\<close>: it is dyadic, lies in \<open>[-\<onehalf>, \<onehalf>)\<close>,
+and \<^term>\<open>q - m\<close> simplifies to \<^term>\<open>s\<^sub>\<rat> / b'\<^sub>\<rat>\<close> for some integer \<^term>\<open>s\<close>, hence has odd
+denominator.\<close>
+
+lemma %internal split_two_pow:
+  assumes \<open>b > 0\<close>
+  obtains n :: nat and b' :: int where \<open>b = 2^n * b'\<close> and \<open>odd b'\<close> and \<open>b' > 0\<close>
+proof -
+  define n where \<open>n = multiplicity 2 b\<close>
+  define b' where \<open>b' = b div 2^n\<close>
+  have eq: \<open>b = 2^n * b'\<close>
+    unfolding b'_def n_def using multiplicity_dvd[of 2 b] by simp
+  have pos: \<open>b' > 0\<close> using assms eq by (simp add: zero_less_mult_iff)
+  have \<open>odd b'\<close>
+  proof
+    assume \<open>2 dvd b'\<close>
+    hence \<open>2 ^ Suc n dvd b\<close> using eq by auto
+    with multiplicity_geI[OF _ _ this] assms show False unfolding n_def by simp
+  qed
+  thus ?thesis using eq pos that by blast
+qed
+
+lemma %internal twoadic_decomposition_existence:
+  shows \<open>\<exists>m. m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  obtain a b where ab: \<open>quotient_of q = (a, b)\<close> by (cases \<open>quotient_of q\<close>) auto
+  obtain n b' where bn: \<open>b = 2^n * b'\<close> and b'_odd: \<open>odd b'\<close> and b'_pos: \<open>b' > 0\<close>
+    using split_two_pow[OF quotient_of_denom_pos[OF ab]] by blast
+  have q_eq: \<open>q = a /\<^sub>\<rat> b\<close> using ab Fract_quotient_of[of q] quotient_of_denom_pos[OF ab]
+    by (metis Fract_of_int_quotient fst_conv snd_conv)
+  define R T k m where defs: \<open>R = (2::int)^n\<close> \<open>T = b'\<^sup>-\<^sup>1 mod 2^n\<close>
+                              \<open>k = (a * T) mod\<^sup>\<plusminus> R\<close> \<open>m = k /\<^sub>\<rat> R\<close>
+  have R_pos: \<open>R > 0\<close> and R_pos_rat: \<open>R\<^sub>\<rat> > 0\<close> and b'_nz_rat: \<open>b'\<^sub>\<rat> \<noteq> 0\<close>
+    using b'_pos by (auto simp: defs)
+  have md: \<open>m \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  proof -
+    have \<open>R\<^sub>\<rat> * m \<in> \<int>\<close> using R_pos_rat by (simp add: defs)
+    thus ?thesis using dyadic_iff_pow_int defs(1) by (metis of_int_numeral of_int_power)
+  qed
+  have k_lb: \<open>-R \<le> 2 * k\<close> and k_ub: \<open>2 * k < R\<close>
+    using mod_signed_lower[OF R_pos, of \<open>a * T\<close>] mod_signed_upper[OF R_pos, of \<open>a * T\<close>] R_pos
+    by (auto simp: defs)
+  have \<open>- R\<^sub>\<rat> \<le> 2 * k\<^sub>\<rat>\<close> \<open>2 * k\<^sub>\<rat> < R\<^sub>\<rat>\<close> using k_lb k_ub
+    by (metis of_int_minus of_int_le_iff of_int_mult of_int_numeral,
+        metis of_int_less_iff of_int_mult of_int_numeral)
+  hence target_m: \<open>m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> unfolding two_adic_target_iff using md R_pos_rat
+    by (simp add: defs field_simps)
+  have R_dvd_bT: \<open>R dvd (b' * T - 1)\<close>
+  proof (cases \<open>n = 0\<close>)
+    case True thus ?thesis by (simp add: defs)
+  next
+    case False thus ?thesis unfolding defs(1) defs(2)
+      using mod_inverse_correct(3)[OF _ b'_odd, of n] by (metis mod_eq_dvd_iff neq0_conv)
+  qed
+  have R_dvd_aTk: \<open>R dvd (a * T - k)\<close> unfolding defs by (metis R_dvd_z_minus_smod)
+  have \<open>a - b' * k = b' * (a * T - k) - a * (b' * T - 1)\<close> by (simp add: algebra_simps)
+  hence \<open>R dvd (a - b' * k)\<close> using R_dvd_bT R_dvd_aTk by (simp add: dvd_diff)
+  then obtain s where a_minus: \<open>a - b' * k = R * s\<close> by (elim dvdE)
+  have eps_eq: \<open>q - m = s /\<^sub>\<rat> b'\<close>
+  proof -
+    have \<open>q - m = (a - b' * k) /\<^sub>\<rat> (b' * R)\<close>
+      using q_eq bn b'_nz_rat R_pos_rat by (simp add: defs of_int_mult field_simps)
+    also have \<open>\<dots> = (R * s) /\<^sub>\<rat> (b' * R)\<close> using a_minus by (metis of_int_diff of_int_mult)
+    also have \<open>\<dots> = s /\<^sub>\<rat> b'\<close> using b'_nz_rat R_pos_rat by (simp add: field_simps)
+    finally show ?thesis .
+  qed
+  have \<open>(q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close> using eps_eq two_adic_integral_div_odd[OF b'_pos b'_odd, of s] by simp
+  with target_m show ?thesis by blast
+qed
+
+text\<open>For every rational number, there exists a unique 2-adic decomposition:\<close>
+
+theorem twoadic_decomposition_unique:
+  shows \<open>\<exists>!m. m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  obtain m where ex: \<open>m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using twoadic_decomposition_existence by blast
+  show ?thesis
+  proof (rule ex1I[of _ m])
+    show \<open>m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close> using ex .
+  next
+    fix m'
+    assume H: \<open>m' \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m') \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    show \<open>m' = m\<close>
+      using twoadic_uniqueness[of m' m q] ex H by simp
+  qed
+qed
+
+text \<open>The 2-adic rounding \<open>\<lfloor>\<cdot>\<rceil>\<^sub>[\<^sub>2\<^sub>] : \<rat> \<rightarrow> \<rat>\<close> picks the unique decomposition
+\<^term>\<open>q = m + e\<close> with \<open>m \<in> \<int>[\<onehalf>] \<inter> [-\<onehalf>, \<onehalf>)\<close> and \<^term>\<open>e\<close> two-adic-integral.\<close>
+
+definition round_2 (\<open>\<lfloor>_\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>) where
+  \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>2\<^sub>] \<equiv> THE m. m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+
+text %internal \<open>On a dyadic \<open>q\<close> the 2-adic round is the Euclidean fractional part: the
+candidate \<open>q - \<lfloor>q\<rceil>\<^sub>\<rat>\<close> is dyadic, lies in \<open>[-\<onehalf>, \<onehalf>)\<close>, and has integer
+complement \<^term>\<open>\<lfloor>q\<rceil>\<^sub>\<rat>\<close>.\<close>
+
+lemma %internal round_2_dyadic_eq:
+  assumes \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  shows \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>2\<^sub>] = q - \<lfloor>q\<rceil>\<^sub>\<rat>\<close>
+proof -
+  let ?m = \<open>q - \<lfloor>q\<rceil>\<^sub>\<rat>\<close>
+  have m_dyadic: \<open>?m \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> using dyadic_minus_int[OF assms, of \<open>\<lfloor>q\<rceil>\<close>] .
+  have e1: \<open>- (1/2) \<le> ?m\<close> using round_error_window(1)[of q] by simp
+  have e2: \<open>?m < 1/2\<close> using round_error_window(2)[of q] by simp
+  have target_m: \<open>?m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+    unfolding two_adic_target_iff using m_dyadic e1 e2 by simp
+  have int_form: \<open>q - ?m = \<lfloor>q\<rceil>\<^sub>\<rat>\<close> by simp
+  have integral_eps: \<open>(q - ?m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close> unfolding int_form by simp
+  have spec: \<open>?m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - ?m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using target_m integral_eps by simp
+  have unique: \<open>\<And>m'. m' \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m') \<in> \<int>\<^sub>[\<^sub>2\<^sub>] \<Longrightarrow> m' = ?m\<close>
+    using twoadic_decomposition_unique[of q] spec by metis
+  show ?thesis
+    unfolding round_2_def using spec unique by (rule the_equality)
+qed
+
+text \<open>On a dyadic rational, the Euclidean and 2-adic roundings sum to the
+identity. This, while trivial, is a core step in the transition from Barrett
+arithmetic (Euclidean domain) to Montgomery arithmetic (2-adic domain).\<close>
+
+theorem complementarity:
+  assumes \<open>q \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  shows \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>] + \<lfloor>q\<rceil>\<^sub>[\<^sub>2\<^sub>] = q\<close>
+proof -
+  have e: \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>] = \<lfloor>q\<rceil>\<^sub>\<rat>\<close> by (rule round_E_eq_round)
+  have t: \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>2\<^sub>] = q - \<lfloor>q\<rceil>\<^sub>\<rat>\<close> using round_2_dyadic_eq[OF assms] .
+  show ?thesis using e t by simp
+qed
+
+text %internal \<open>The bridge proof needs one more property of 2-adic rounding:
+it factors through \<open>\<rat> / (\<int>\<^sub>(\<^sub>2\<^sub>) \<inter> \<rat>)\<close>. Two rationals that differ by a
+two-adic-integral round to the same value.\<close>
+
+lemma %internal round_2_invariance:
+  assumes \<open>(q - q') \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  shows \<open>\<lfloor>q\<rceil>\<^sub>[\<^sub>2\<^sub>] = \<lfloor>q'\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  define m where \<open>m = \<lfloor>q\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>
+  have ex: \<open>m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  proof -
+    have unique: \<open>\<exists>!m. m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+      by (rule twoadic_decomposition_unique)
+    show ?thesis
+      using theI'[OF unique] m_def round_2_def by metis
+  qed
+  hence tgt_m: \<open>m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> and int_qm: \<open>(q - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close> by auto
+  have step_diff: \<open>q' - m = (q - m) - (q - q')\<close> by (simp add: algebra_simps)
+  have int_q'm: \<open>(q' - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using two_adic_integral_diff[OF int_qm assms] step_diff by argo
+  have spec: \<open>m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q' - m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using tgt_m int_q'm by simp
+  have unique': \<open>\<And>m'. m' \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (q' - m') \<in> \<int>\<^sub>[\<^sub>2\<^sub>] \<Longrightarrow> m' = m\<close>
+    using twoadic_decomposition_unique[of q'] spec by metis
+  show ?thesis
+    unfolding round_2_def using spec unique'
+    by (metis (no_types, lifting) m_def round_2_def the_equality)
+qed
+
+text \<open>Next, we gather a few basic arithmetic properties of 2-adic rounding.
+First, the 2-adic round of an integer divided by \<^term>\<open>2^n :: int\<close> is its
+signed remainder modulo \<^term>\<open>2^n :: int\<close>, scaled. The candidate is dyadic and lies in \<open>[-\<onehalf>, \<onehalf>)\<close>;
+the integer remainder \<^term>\<open>(x - x mod\<^sup>\<plusminus> 2^n) div 2^n\<close> is trivially in \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close>.\<close>
+
+lemma round_2_int_div_pow2:
+  assumes npos: \<open>n > 0\<close>
+  shows \<open>\<lfloor>x /\<^sub>\<rat> 2^n\<rceil>\<^sub>[\<^sub>2\<^sub>] = (x mod\<^sup>\<plusminus> 2^n /\<^sub>\<rat> 2^n)\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>x mod\<^sup>\<plusminus> ?R\<close>
+  let ?m = \<open>?k /\<^sub>\<rat> ?R\<close>  let ?q = \<open>x /\<^sub>\<rat> ?R\<close>
+  have R_eq: \<open>?R = 2 * (?R div 2)\<close> using npos by (induction n) auto
+  have target_m: \<open>?m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close>
+  proof -
+    have d: \<open>?m \<in> \<int>\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>]\<close> using int_div_pow2_dyadic[of ?k n] by simp
+    have lo: \<open>2 * ?k \<ge> -?R\<close> using mod_signed_lower[of ?R x] R_eq by simp
+    have hi: \<open>2 * ?k < ?R\<close> using mod_signed_upper[of ?R x] R_eq by simp
+    have lor: \<open>2 * ?k\<^sub>\<rat> \<ge> - ?R\<^sub>\<rat>\<close> using lo
+      by (metis of_int_minus of_int_le_iff of_int_mult of_int_numeral)
+    have hir: \<open>2 * ?k\<^sub>\<rat> < ?R\<^sub>\<rat>\<close> using hi
+      by (metis of_int_less_iff of_int_mult of_int_numeral)
+    show ?thesis unfolding two_adic_target_iff using d lor hir by (simp add: field_simps)
+  qed
+  obtain s where s_def: \<open>x - ?k = ?R * s\<close>
+    using R_dvd_z_minus_smod[of ?R x] by (elim dvdE)
+  have integral_diff: \<open>(?q - ?m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+  proof -
+    have \<open>x\<^sub>\<rat> - ?k\<^sub>\<rat> = ?R\<^sub>\<rat> * s\<^sub>\<rat>\<close>
+      using s_def by (metis of_int_diff of_int_mult)
+    hence \<open>?q - ?m = s\<^sub>\<rat>\<close> by (simp add: field_simps)
+    thus ?thesis by simp
+  qed
+  have spec: \<open>?m \<in> [-\<onehalf>, \<onehalf>)\<^sub>[\<^sub>1\<^sub>/\<^sub>2\<^sub>] \<and> (?q - ?m) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using target_m integral_diff by simp
+  show ?thesis unfolding round_2_def using spec
+    by (rule the_equality) (metis spec twoadic_decomposition_unique[of ?q])
+qed
+
+text \<open>Next, \<^term>\<open>1 /\<^sub>\<rat> N\<close> is 2-adically congruent to
+\<^term>\<open>(N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>\<close> modulo \<^term>\<open>R\<close>. While this looks trivial, it should be noted that the
+left hand side computes \<^term>\<open>1 /\<^sub>\<rat> N\<close> as a \<^emph>\<open>rational\<close> quotient, while the right hand side
+computes \<^term>\<open>N\<^sup>-\<^sup>1 mod R\<close> as a quotient in \<open>\<int>/R \<int>\<close> and then re-embeds it into \<^term>\<open>\<rat>\<close> via
+the composition of the unsigned embedding \<open>\<int>/R\<int> \<hookrightarrow> \<int>\<close> and the standard embedding \<open>\<int>\<hookrightarrow>\<rat>\<close>.
+The point is that \<^term>\<open>\<int>\<^sub>[\<^sub>2\<^sub>]\<close> is a domain that can hoist both while also keeping \<^term>\<open>R\<close>
+non-invertible, and hence allowing arithmetic modulo \<^term>\<open>R\<close> in it.\<close>
+
+lemma (in BarrettContext) mod_inverse_cong:
+  shows \<open>[1 /\<^sub>\<rat> N = (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+    and \<open>[z\<^sub>\<rat> * (1 /\<^sub>\<rat> N) = z\<^sub>\<rat> * (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+proof -
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod R)) mod R = 1 mod R\<close>
+    using mod_inverse_correct(3) .
+  have \<open>R dvd (N * (N\<^sup>-\<^sup>1 mod R) - 1)\<close>
+    using inv by (metis mod_eq_dvd_iff)
+  then obtain j where j_eq: \<open>N * (N\<^sup>-\<^sup>1 mod R) - 1 = R * j\<close>
+    by (elim dvdE)
+  have \<open>1 /\<^sub>\<rat> N - (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat> = (1 - N * (N\<^sup>-\<^sup>1 mod R)) /\<^sub>\<rat> N\<close>
+    by (simp add: field_simps)
+  also have \<open>\<dots> = (- (R * j)) /\<^sub>\<rat> N\<close>
+    using j_eq by (metis minus_diff_eq)
+  also have \<open>\<dots> = R\<^sub>\<rat> * ((- j) /\<^sub>\<rat> N)\<close>
+    by (simp add: field_simps)
+  finally have decomp: \<open>1 /\<^sub>\<rat> N - (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat> = R\<^sub>\<rat> * ((- j) /\<^sub>\<rat> N)\<close> .
+  have \<open>(1 /\<^sub>\<rat> N - (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>) / R\<^sub>\<rat> = (- j) /\<^sub>\<rat> N\<close>
+    unfolding decomp by (simp add: field_simps)
+  thus base2: \<open>[1 /\<^sub>\<rat> N = (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+    using two_adic_integral_div_odd[OF Npos Nodd, of \<open>- j\<close>] by simp
+  show \<open>[z\<^sub>\<rat> * (1 /\<^sub>\<rat> N) = z\<^sub>\<rat> * (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+    by (rule cong_R_two_adic_scale[OF base2])
+qed
+
+text \<open>Taking both together gives the following concrete formula for the 
+2-adic round of \<^term>\<open>z\<^sub>\<rat> / (N\<^sub>\<rat>*R\<^sub>\<rat>)\<close>. The reader will already notice the similarity
+of the right hand side with the definition of Montgomery reduction of \<^term>\<open>z\<close>.\<close>
+
+lemma (in BarrettContext) round_2_div_NR:
+  shows \<open>\<lfloor>z /\<^sub>\<rat> (N * R)\<rceil>\<^sub>[\<^sub>2\<^sub>] = ((z * (N\<^sup>-\<^sup>1 mod R)) mod\<^sup>\<plusminus> R) /\<^sub>\<rat> R\<close>
+proof -
+  have eq: \<open>(z\<^sub>\<rat> * (1 /\<^sub>\<rat> N) - z\<^sub>\<rat> * (N\<^sup>-\<^sup>1 mod R)\<^sub>\<rat>) / R\<^sub>\<rat>
+            = z /\<^sub>\<rat> (N * R) - (z * (N\<^sup>-\<^sup>1 mod R)) /\<^sub>\<rat> R\<close>
+    by (simp add: field_simps of_int_mult)
+  have inv_int: \<open>(z /\<^sub>\<rat> (N * R) - (z * (N\<^sup>-\<^sup>1 mod R)) /\<^sub>\<rat> R) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using mod_inverse_cong(2)[of z] unfolding eq[symmetric] by simp
+  have eq1: \<open>z\<^sub>\<rat> / (N\<^sub>\<rat> * R\<^sub>\<rat>) = z /\<^sub>\<rat> (N * R)\<close> by (simp add: of_int_mult)
+  have inv_step: \<open>\<lfloor>z /\<^sub>\<rat> (N * R)\<rceil>\<^sub>[\<^sub>2\<^sub>] = \<lfloor>(z * (N\<^sup>-\<^sup>1 mod R)) /\<^sub>\<rat> R\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using round_2_invariance[OF inv_int] eq1 by simp
+  show ?thesis
+    using inv_step round_2_int_div_pow2[OF npos, of \<open>z * (N\<^sup>-\<^sup>1 mod R)\<close>] by simp
+qed
+
+text\<open>Finally, this establishes the description of Montgomery reduction
+through 2-adic rounding:\<close>
+
+theorem (in BarrettContext) mont_sub_signed_as_round_2:
+  shows \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat> = z /\<^sub>\<rat> R - N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> (N * R)\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  define k :: int where \<open>k = (z * (N\<^sup>-\<^sup>1 mod R)) mod\<^sup>\<plusminus> R\<close>
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod R)) mod R = 1 mod R\<close>
+    using mod_inverse_correct(3) by simp
+  from mont_sub_signed_divisible[OF inv, of z] obtain s where
+    s_eq: \<open>z - k * N = R * s\<close> unfolding k_def by (auto simp: mult.commute elim: dvdE)
+  have unfold_eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = s\<close>
+    using mont_sub_signed_unfold[OF inv, of z] s_eq unfolding k_def by simp
+  have rat_eq: \<open>s\<^sub>\<rat> = z /\<^sub>\<rat> R - N\<^sub>\<rat> * (k /\<^sub>\<rat> R)\<close>
+    using s_eq by (simp add: field_simps)
+  show ?thesis
+    using unfold_eq rat_eq round_2_div_NR[of z]
+    unfolding k_def by simp
+qed
+
+text %internal \<open>The additive variant has the same form, with the \emph{argument} of the
+2-adic round negated --- a uniform formulation requiring no case split, since
+negating the argument absorbs the \<open>mont\<^sub>s\<^sub>u\<^sub>b\<close>/\<open>mont\<^sub>a\<^sub>d\<^sub>d\<close> distinction.\<close>
+
+theorem %internal (in BarrettContext) mont_add_signed_as_round_2:
+  shows \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat> = z /\<^sub>\<rat> R + N\<^sub>\<rat> * \<lfloor>- z /\<^sub>\<rat> (N * R)\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>
+proof -
+  define T :: int where \<open>T = - (N\<^sup>-\<^sup>1 mod R)\<close>
+  define k :: int where \<open>k = (z * (- (N\<^sup>-\<^sup>1 mod R))) mod\<^sup>\<plusminus> R\<close>
+  note T_def [simp] k_def [simp]
+
+  have inv: \<open>(N * T) mod R = (- 1) mod R\<close>
+    using mod_inverse_correct(3) by (simp, metis mod_minus_eq mult_minus_right)
+  have k_eq: \<open>k = ((- z) * (N\<^sup>-\<^sup>1 mod R)) mod\<^sup>\<plusminus> R\<close> by (simp add: algebra_simps)
+  have unfold_eq: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + k * N) div R\<close>
+    using mont_add_signed_unfold[OF inv[unfolded T_def], of z] by simp
+  have R_dvd: \<open>R dvd (z + k * N)\<close>
+    using mont_sub_signed_divisible[OF mod_inverse_correct(3), of \<open>- z\<close>]
+          k_eq dvd_minus_iff[of R "z + k * N"]
+    by (simp add: mult.commute)
+  obtain s where s_eq: \<open>z + k * N = R * s\<close> using R_dvd by (elim dvdE) simp
+  have d1: \<open>(z + k * N) div R = s\<close> using s_eq by simp
+  have d2: \<open>(z\<^sub>\<rat> + k\<^sub>\<rat> * N\<^sub>\<rat>) = R\<^sub>\<rat> * s\<^sub>\<rat>\<close> using s_eq by (metis of_int_add of_int_mult)
+  have div_to_rat: \<open>((z + k * N) div R)\<^sub>\<rat> = (z + k * N) /\<^sub>\<rat> R\<close> using d1 d2 by (simp add: field_simps)
+  have round2_eq: \<open>\<lfloor>- z /\<^sub>\<rat> (N * R)\<rceil>\<^sub>[\<^sub>2\<^sub>] = k /\<^sub>\<rat> R\<close>
+    using round_2_div_NR[of \<open>- z\<close>] k_eq by (simp add: field_simps)
+  show ?thesis using unfold_eq div_to_rat round2_eq by (simp add: field_simps)
+qed
+
+section \<open>The Barrett--Montgomery bridge\<close>
+
+text\<open>To derive the connection between Montgomery and Barrett arithmetic, the last remaining
+piece is the following identity relating \<^term>\<open>1/N\<close> and \<open>\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<close> modulo \<^term>\<open>R\<close>:\<close>
+
+lemma (in BarrettContext) magic_const_cong:
+  shows \<open>[\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat> = - (R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+    and \<open>[z\<^sub>\<rat> * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat> = z\<^sub>\<rat> * (- (R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N)] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+proof -
+  have eq: \<open>\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat> - (- (R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N) = R /\<^sub>\<rat> N\<close>
+    using magic_const_rat[OF f_approx, of N R] Npos by (simp add: field_simps)
+  have \<open>(\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat> - (- (R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N)) / R\<^sub>\<rat> = 1 /\<^sub>\<rat> N\<close>
+    using eq by (simp add: of_int_mult field_simps)
+  thus base': \<open>[\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat> = - (R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+    using two_adic_integral_div_odd[OF Npos Nodd, of 1] by simp
+  show \<open>[z\<^sub>\<rat> * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat> = z\<^sub>\<rat> * (- (R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N)] (mod R \<int>\<^sub>[\<^sub>2\<^sub>])\<close>
+    by (rule cong_R_two_adic_scale[OF base'])
+qed
+
+text \<open>The signed Barrett--Montgomery bridge is now a simple chain of equalities putting
+together the facts established above:\<close>
+
+text %proofnote \<open>\noindent\textit{Note.} Proof bodies are normally elided in
+this PDF; we exceptionally retain this one because of its brevity and
+centrality. See \autoref{ch:methodology} for the editorial policy.\<close>
+
+theorem (in BarrettContext) bridge_signed_conceptual:
+  shows \<open>bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N))\<close>
+proof %visible -
+  have cong: \<open>(z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R - (- ((z * (R mod\<lbrakk>f\<rbrakk> N)) /\<^sub>\<rat> (N * R)))) \<in> \<int>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using magic_const_cong(2)[of z] by %invisible (simp add: field_simps of_int_mult)
+  have key: \<open>N\<^sub>\<rat> * (z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R) + (z * (R mod\<lbrakk>f\<rbrakk> N)) /\<^sub>\<rat> R = z\<^sub>\<rat>\<close>
+    unfolding mod_approx_def by %invisible (simp add: field_simps)
+  have \<open>(bar\<^sup>\<plusminus>\<lbrakk>N, n, f\<rbrakk> z)\<^sub>\<rat> = z\<^sub>\<rat> - N\<^sub>\<rat> * \<lfloor>z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R\<rceil>\<^sub>[\<^sub>\<infinity>\<^sub>]\<close>
+    by %invisible (rule bar_signed_as_round_E)
+  also have \<open>\<dots> = z\<^sub>\<rat> - N\<^sub>\<rat> * (z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R - \<lfloor>z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R\<rceil>\<^sub>[\<^sub>2\<^sub>])\<close>
+    using complementarity[OF int_div_pow2_dyadic[of \<open>z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<close> n]] by %invisible simp
+  also have \<open>\<dots> = z\<^sub>\<rat> - N\<^sub>\<rat> * (z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R)
+                  + N\<^sub>\<rat> * \<lfloor>- ((z * (R mod\<lbrakk>f\<rbrakk> N)) /\<^sub>\<rat> (N * R))\<rceil>\<^sub>[\<^sub>2\<^sub>]\<close>
+    using round_2_invariance[OF cong] by %invisible (simp add: algebra_simps)
+  also have \<open>\<dots> = z\<^sub>\<rat> - N\<^sub>\<rat> * (z * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk> /\<^sub>\<rat> R)
+                  + ((mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N)))\<^sub>\<rat>
+                     - (z * (R mod\<lbrakk>f\<rbrakk> N)) /\<^sub>\<rat> R)\<close>
+    using mont_add_signed_as_round_2[of \<open>z * (R mod\<lbrakk>f\<rbrakk> N)\<close>] by %invisible simp
+  also have \<open>\<dots> = (mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (z * (R mod\<lbrakk>f\<rbrakk> N)))\<^sub>\<rat>\<close>
+    using key by %invisible (simp add: algebra_simps)
+  finally show ?thesis by %invisible (metis of_int_eq_iff)
+qed
+
+
+end
+

--- a/proofs/isabelle/neon_ntt/Conclusions.thy
+++ b/proofs/isabelle/neon_ntt/Conclusions.thy
@@ -1,0 +1,45 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Conclusions
+  imports Asm_Montgomery Asm_Barrett
+begin
+
+chapter \<open>Conclusions \label{ch:conclusions}\<close>
+
+text \<open>
+We have given a machine-checked Isabelle/HOL account of the
+modular-arithmetic core of~\cite{NeonNTT}: parametric Barrett and
+Montgomery reduction and multiplication uniform in modulus, word
+width, and integer approximation; the Barrett--Montgomery equivalence
+and its recasting through Euclidean--2-adic rounding duality; an
+empirical bound-quality study at the ML-KEM and ML-DSA moduli; and
+correctness theorems for the signed-word Neon kernels shipped by
+\texttt{mlkem-native} and \texttt{mldsa-native}. A small algorithmic
+improvement surfaced in the process: the parity hypothesis on
+\cite[Algorithm~8]{NeonNTT} is unnecessary, as independently
+discovered by the PPC64 contributors to \texttt{mlkem-native}.
+
+The development also functions as a demonstrator for human-directed,
+model-generated formalisation at the scale of a research paper. With a
+tight agent--prover feedback loop --- here, \texttt{AutoCorrode}'s I/Q
+and I/R interfaces --- the agent drafted definitions and proofs while
+the human author owned the architecture, the narrative, and the
+editorial choices. The result was both faster than writing the formal
+text by hand and arguably tighter: the discipline of mechanization
+sharpens definitions and surfaces silent assumptions, and cross-cutting
+refactors that a human author would otherwise defer become cheap
+enough to perform routinely. We expect this style of work to become
+common in cryptographic engineering research.
+
+Two pieces of infrastructure made this practical and warrant continued
+investment. Agent--prover interfaces such as those of
+\texttt{AutoCorrode}~\cite{AutoCorrode} give the agent direct access
+to prover state and a feedback channel without rebuilds. Isabelle's
+document preparation system keeps paper and proof in a single source:
+every chapter of this document is a theory file, and the
+synchronization overhead of maintaining separate paper and proof
+artifacts is removed by construction.
+\<close>
+
+end

--- a/proofs/isabelle/neon_ntt/Integer_Approximation.thy
+++ b/proofs/isabelle/neon_ntt/Integer_Approximation.thy
@@ -1,0 +1,1434 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Integer_Approximation
+  imports HOL.Rat HOL.NthRoot
+begin
+
+(*<*)
+text \<open>Suppress \<open>:: 'a\<close> in document antiquotations only. The IDE
+hover-types and outer \<open>term\<close> command are unaffected, since they don't go through
+\<^ML>\<open>Document_Output.antiquotation_pretty_source\<close>.\<close>
+
+setup \<open>
+  Document_Output.antiquotation_pretty_source_embedded \<^binding>\<open>term\<close>
+    (Term_Style.parse -- Args.term)
+    (fn ctxt => fn (style, t) =>
+      let
+        val ctxt' = ctxt
+          |> Config.put show_types false
+          |> Config.put show_sorts false
+          |> Config.put show_question_marks false
+          |> Config.put Printer.show_type_emphasis false
+      in Document_Output.pretty_term ctxt' (style t) end)
+\<close>
+(*>*)
+
+chapter \<open>Integer approximations and modular residues \label{ch:integer_approx}\<close>
+
+text \<open>
+Barrett and Montgomery reduction are usually presented with a fixed
+rounding mode, but multiple variants exist: the textbook bound proofs are
+stated for round-to-nearest, the unsigned variant uses flooring, and the
+\asminst{SQRDMULH}-based signed Barrett kernel produces an even-rounded result. To avoid replicating the
+same proof four times we work uniformly over an arbitrary \emph{integer approximation}
+\<open>\<lbrakk>_\<rbrakk> : \<rat> \<rightarrow> \<int>\<close>, prove the underlying arithmetic facts once, and specialise \<open>\<lbrakk>_\<rbrakk>\<close> at each use site.
+
+This chapter develops the predicate \<open>is_int_approx \<lbrakk>_\<rbrakk>\<close> defining what counts as an integer
+approximation, and the residue operator \<open>z mod\<lbrakk>f\<rbrakk> N\<close>, which generalises both the unsigned
+(\<open>mod\<^sup>+\<close>) and signed (\<open>mod\<^sup>\<plusminus>\<close>) representatives modulo \<open>N\<close>.
+We write \<open>_\<^sub>\<rat>\<close> for the embedding \<open>\<int> \<rightarrow> \<rat>\<close> and \<open>_/\<^sub>\<rat>_\<close> for the rational quotient of two integers.
+\<close>
+
+notation rat_of_int ("_\<^sub>\<rat>" [1000] 999)
+notation %invisible real_of_rat ("_\<^sub>\<real>" [1000] 999)
+abbreviation quot_of_int (infixl "'/\<^sub>\<rat>" 70) where "x /\<^sub>\<rat> y \<equiv> x\<^sub>\<rat> / y\<^sub>\<rat>"
+
+section \<open>Integer approximations\<close>
+
+text \<open>
+Following \cite[\S2.4]{NeonNTT}, \<open>is_int_approx \<lbrakk>_\<rbrakk>\<close> requires only that
+\<open>\<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> 1\<close> — not the stronger \<open>\<lbrakk>z\<rbrakk> = z\<close> on integer inputs, which the
+even-rounding function \<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close> fails.
+\<close>
+
+definition \<open>is_int_approx f \<longleftrightarrow> (\<forall>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> 1)\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+text \<open>
+Standard instances of integer approximations are round-to-nearest \<open>\<lfloor>\<cdot>\<rceil>\<close>,
+floor \<open>\<lfloor>\<cdot>\<rfloor>\<close>, and ceiling \<open>\<lceil>\<cdot>\<rceil>\<close>. Less canonically, the following is an
+integer approximation as well:
+\<close>
+
+notation %internal round (\<open>\<lfloor>_\<rceil>\<close>)
+definition round_even (\<open>\<lfloor>_\<rceil>\<^sub>2\<close>) where \<open>\<lfloor>z\<rceil>\<^sub>2 \<equiv> 2 * \<lfloor>z/2\<rceil>\<close>
+
+text %internal \<open>We also register notation for the unapplied forms of the approximation operators.
+Unfortunately we have to drop down to a print AST translation here: If we introduced the new syntax
+as an output notation, it would apply regardless of whether an argument is supplied or not, and lead
+to e.g. \<^verbatim>\<open>floor x\<close> being printed as \<^verbatim>\<open>\<lfloor>\<cdot>\<rfloor> x\<close> instead of the desired \<open>\<lfloor>z\<rfloor>\<close>. With a print-AST-translation,
+we can restrict the translation to unapplied occurrences.\<close>
+
+notation %internal (input) round      (\<open>\<lfloor>\<cdot>\<rceil>\<close>)
+notation %internal (input) round_even (\<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close>)
+notation %internal (input) floor      (\<open>\<lfloor>\<cdot>\<rfloor>\<close>)
+notation %internal (input) ceiling    (\<open>\<lceil>\<cdot>\<rceil>\<close>)
+
+syntax %internal "_round_even_dot" :: "'a" (\<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close>)
+syntax %internal "_round_dot"      :: "'a" (\<open>\<lfloor>\<cdot>\<rceil>\<close>)
+syntax %internal "_floor_dot"      :: "'a" (\<open>\<lfloor>\<cdot>\<rfloor>\<close>)
+syntax %internal "_ceiling_dot"    :: "'a" (\<open>\<lceil>\<cdot>\<rceil>\<close>)
+print_ast_translation %internal \<open>
+   let
+    fun unapplied c _ [] = Ast.Constant c
+      | unapplied _ _ _ = raise Match
+  in
+    [(\<^const_syntax>\<open>round\<close>,      unapplied \<^syntax_const>\<open>_round_dot\<close>),
+     (\<^const_syntax>\<open>round_even\<close>, unapplied \<^syntax_const>\<open>_round_even_dot\<close>),
+     (\<^const_syntax>\<open>floor\<close>,      unapplied \<^syntax_const>\<open>_floor_dot\<close>),
+     (\<^const_syntax>\<open>ceiling\<close>,    unapplied \<^syntax_const>\<open>_ceiling_dot\<close>)]
+  end
+\<close>                      
+
+text \<open>We confirm that indeed all of the above are integer approximations:\<close>
+
+theorem is_int_approx_instances:
+  shows is_int_approx_floor:      \<open>is_int_approx \<lfloor>\<cdot>\<rfloor>\<close>
+    and is_int_approx_ceiling:    \<open>is_int_approx \<lceil>\<cdot>\<rceil>\<close>
+    and is_int_approx_round:      \<open>is_int_approx \<lfloor>\<cdot>\<rceil>\<close>
+    and is_int_approx_round_even: \<open>is_int_approx \<lfloor>\<cdot>\<rceil>\<^sub>2\<close>
+  unfolding is_int_approx_def round_even_def round_def by (linarith+)
+
+
+section \<open>Approximation quality\<close>
+
+text \<open>
+The predicate \<open>is_int_approx \<lbrakk>_\<rbrakk>\<close> only requires the rounding error \<open>\<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar>\<close> to be
+bounded by \<^term>\<open>1\<close>. Different approximations enjoy tighter uniform bounds: \<open>\<lfloor>\<cdot>\<rceil>\<close> never
+errs by more than \<^term>\<open>1/2\<close>, while \<open>\<lfloor>\<cdot>\<rfloor>\<close>, \<open>\<lceil>\<cdot>\<rceil>\<close>, and \<open>\<lfloor>\<cdot>\<rceil>\<^sub>2\<close> can come
+arbitrarily close to \<^term>\<open>1\<close>. We capture this as the \emph{approximation quality}
+\<open>\<epsilon>(\<lbrakk>_\<rbrakk>)\<close>, the smallest rational bound on \<open>\<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar>\<close>.
+
+In general, the supremum of the rounding error need not be a rational number
+(see \S\ref{sec:golden} for a concrete example), so we characterise
+\<open>\<epsilon>(\<lbrakk>_\<rbrakk>)\<close> as the unique value (when one exists) that is both a uniform upper
+bound and least among all upper bounds; this is captured by the predicate
+\<open>is_int_approx_quality\<close>.
+\<close>
+
+definition int_approx_quality (\<open>\<epsilon> '(_')\<close>) where
+  \<open>\<epsilon>(f) \<equiv> SOME e. (\<forall>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> e) \<and>
+                    (\<forall>e'. (\<forall>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> e') \<longrightarrow> e \<le> e')\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+definition %internal is_int_approx_quality :: \<open>(rat \<Rightarrow> int) \<Rightarrow> rat \<Rightarrow> bool\<close> where
+  \<open>is_int_approx_quality f e \<longleftrightarrow> (\<forall>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> e) \<and>
+                                 (\<forall>e'. (\<forall>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> e') \<longrightarrow> e \<le> e')\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+text %internal \<open>
+Any two qualities for the same \<open>\<lbrakk>_\<rbrakk>\<close> agree, so \<open>is_int_approx_quality \<lbrakk>_\<rbrakk>\<close> is a singleton
+predicate; \<open>\<epsilon>(\<lbrakk>_\<rbrakk>)\<close> picks out its unique witness whenever one exists.
+\<close>
+
+lemma %internal is_int_approx_quality_unique:
+  assumes \<open>is_int_approx_quality f e1\<close> and \<open>is_int_approx_quality f e2\<close>
+  shows \<open>e1 = e2\<close>
+  using assms unfolding is_int_approx_quality_def by (meson order_antisym)
+
+lemma %internal int_approx_quality_eq:
+  assumes \<open>is_int_approx_quality f e\<close>
+  shows \<open>\<epsilon>(f) = e\<close>
+  unfolding int_approx_quality_def
+  by (rule someI2[where Q=\<open>\<lambda>x. x = e\<close>],
+      use assms in \<open>simp add: is_int_approx_quality_def\<close>,
+      use assms in \<open>simp add: is_int_approx_quality_unique[OF _ assms] is_int_approx_quality_def\<close>)
+
+lemma %internal quality_charI:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>) and e :: rat
+  assumes ub: \<open>\<And>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> e\<close>
+      and tight: \<open>\<And>e'. (\<And>z. \<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> e') \<Longrightarrow> e \<le> e'\<close>
+  shows \<open>is_int_approx_quality f e\<close>
+  using assms unfolding is_int_approx_quality_def by blast
+
+text %internal \<open>
+Whenever a quality witness exists, it provides the defining uniform bound and is itself
+bounded by \<open>1\<close> for any integer approximation.
+\<close>
+
+lemma %internal quality_bounds:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>is_int_approx_quality f e\<close>
+  shows \<open>\<bar>z - \<lbrakk>z\<rbrakk>\<^sub>\<rat>\<bar> \<le> \<epsilon>(f)\<close>
+  using assms int_approx_quality_eq[OF assms]
+  unfolding is_int_approx_quality_def by simp
+
+lemma %internal quality_le_one:
+  assumes \<open>is_int_approx f\<close> and \<open>is_int_approx_quality f e\<close>
+  shows \<open>\<epsilon>(f) \<le> 1\<close>
+proof -
+  have \<open>e \<le> 1\<close>
+    using assms unfolding is_int_approx_def is_int_approx_quality_def by blast
+  thus ?thesis using int_approx_quality_eq[OF assms(2)] by simp
+qed
+
+text \<open>The uniform quality \<open>\<epsilon>(f)\<close> dominates the actual rounding error
+\<open>|x - \<lbrakk>x\<rbrakk>\<^sub>\<rat>|\<close> at every input \<open>x\<close>. We name the latter \<open>\<epsilon>(f, x)\<close>;
+the relation \<open>\<epsilon>(f, x) \<le> \<epsilon>(f)\<close> is immediate.\<close>
+
+abbreviation int_approx_quality_at :: \<open>(rat \<Rightarrow> int) \<Rightarrow> rat \<Rightarrow> rat\<close> (\<open>\<epsilon> '(_, _')\<close>)
+  where \<open>\<epsilon>(f, x) \<equiv> \<bar>x - \<lbrakk>x\<rbrakk>\<^sub>\<rat>\<bar>\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+lemma %internal quality_at_le:
+  assumes \<open>is_int_approx_quality f e\<close>
+  shows \<open>\<epsilon>(f, x) \<le> \<epsilon>(f)\<close>
+  using quality_bounds[OF assms] .
+
+text \<open>
+The four standard approximations admit explicit quality witnesses. Round-to-nearest
+attains the ideal quality \<^term>\<open>1/2\<close>; the other three only come arbitrarily close to \<^term>\<open>1\<close>
+but no rational below \<^term>\<open>1\<close> is a uniform bound, so their quality is exactly \<^term>\<open>1\<close>.
+\<close>
+
+theorem %internal is_int_approx_quality_instances:
+  shows is_int_approx_quality_round:      \<open>is_int_approx_quality \<lfloor>\<cdot>\<rceil> (1/2)\<close>
+    and is_int_approx_quality_floor:      \<open>is_int_approx_quality \<lfloor>\<cdot>\<rfloor> 1\<close>
+    and is_int_approx_quality_ceiling:    \<open>is_int_approx_quality \<lceil>\<cdot>\<rceil> 1\<close>
+    and is_int_approx_quality_round_even: \<open>is_int_approx_quality \<lfloor>\<cdot>\<rceil>\<^sub>2 1\<close>
+proof -
+  show \<open>is_int_approx_quality \<lfloor>\<cdot>\<rceil> (1/2)\<close>
+  proof (rule quality_charI)
+    fix z :: rat show \<open>\<bar>z - (\<lfloor>\<cdot>\<rceil> z)\<^sub>\<rat>\<bar> \<le> 1/2\<close> unfolding round_def by linarith
+  next
+    fix e' :: rat
+    assume H: \<open>\<And>z. \<bar>z - (\<lfloor>\<cdot>\<rceil> z)\<^sub>\<rat>\<bar> \<le> e'\<close>
+    have \<open>\<lfloor>\<cdot>\<rceil> (1/2 :: rat) = 1\<close> unfolding round_def by simp
+    hence eq: \<open>\<bar>(1/2 :: rat) - (\<lfloor>\<cdot>\<rceil> (1/2 :: rat))\<^sub>\<rat>\<bar> = 1/2\<close> by simp
+    show \<open>1/2 \<le> e'\<close> using H[of \<open>1/2\<close>] eq by simp
+  qed
+next
+  show \<open>is_int_approx_quality \<lfloor>\<cdot>\<rfloor> 1\<close>
+  proof (rule quality_charI)
+    fix z :: rat show \<open>\<bar>z - (\<lfloor>\<cdot>\<rfloor> z)\<^sub>\<rat>\<bar> \<le> 1\<close> by linarith
+  next
+    fix e' :: rat
+    assume H: \<open>\<And>z. \<bar>z - (\<lfloor>\<cdot>\<rfloor> z)\<^sub>\<rat>\<bar> \<le> e'\<close>
+    have e'_nn: \<open>e' \<ge> 0\<close> using H[of 0] by simp
+    have key: \<open>\<forall>\<delta>::rat. 0 < \<delta> \<longrightarrow> \<delta> < 1 \<longrightarrow> 1 - \<delta> \<le> e'\<close>
+    proof (intro allI impI)
+      fix \<delta> :: rat assume \<delta>p: \<open>0 < \<delta>\<close> and \<delta>l: \<open>\<delta> < 1\<close>
+      have flr: \<open>\<lfloor>\<cdot>\<rfloor> (-\<delta>) = -1\<close> using \<delta>p \<delta>l by linarith
+      have \<open>\<bar>(-\<delta>) - (\<lfloor>\<cdot>\<rfloor> (-\<delta>))\<^sub>\<rat>\<bar> = 1 - \<delta>\<close> using \<delta>p \<delta>l flr by simp
+      thus \<open>1 - \<delta> \<le> e'\<close> using H[of \<open>-\<delta>\<close>] by simp
+    qed
+    show \<open>1 \<le> e'\<close>
+    proof (rule ccontr)
+      assume \<open>\<not> 1 \<le> e'\<close>
+      hence elt: \<open>e' < 1\<close> by simp
+      define \<delta> where \<delta>_def: \<open>\<delta> = (1 - e') / 2\<close>
+      have \<delta>p: \<open>0 < \<delta>\<close> unfolding \<delta>_def using elt by simp
+      have eq: \<open>2 * \<delta> = 1 - e'\<close> unfolding \<delta>_def by simp
+      hence \<delta>l: \<open>\<delta> < 1\<close> using elt e'_nn by linarith
+      from key[rule_format, OF \<delta>p \<delta>l] have h1: \<open>1 - \<delta> \<le> e'\<close> .
+      from eq have \<open>e' = 1 - 2*\<delta>\<close> by linarith
+      with h1 \<delta>p show False by linarith
+    qed
+  qed
+next
+  show \<open>is_int_approx_quality \<lceil>\<cdot>\<rceil> 1\<close>
+  proof (rule quality_charI)
+    fix z :: rat show \<open>\<bar>z - (\<lceil>\<cdot>\<rceil> z)\<^sub>\<rat>\<bar> \<le> 1\<close> by linarith
+  next
+    fix e' :: rat
+    assume H: \<open>\<And>z. \<bar>z - (\<lceil>\<cdot>\<rceil> z)\<^sub>\<rat>\<bar> \<le> e'\<close>
+    have e'_nn: \<open>e' \<ge> 0\<close> using H[of 0] by simp
+    have key: \<open>\<forall>\<delta>::rat. 0 < \<delta> \<longrightarrow> \<delta> < 1 \<longrightarrow> 1 - \<delta> \<le> e'\<close>
+    proof (intro allI impI)
+      fix \<delta> :: rat assume \<delta>p: \<open>0 < \<delta>\<close> and \<delta>l: \<open>\<delta> < 1\<close>
+      have ce: \<open>\<lceil>\<cdot>\<rceil> \<delta> = 1\<close> using \<delta>p \<delta>l by linarith
+      have \<open>\<bar>\<delta> - (\<lceil>\<cdot>\<rceil> \<delta>)\<^sub>\<rat>\<bar> = 1 - \<delta>\<close> using \<delta>p \<delta>l ce by simp
+      thus \<open>1 - \<delta> \<le> e'\<close> using H[of \<delta>] by simp
+    qed
+    show \<open>1 \<le> e'\<close>
+    proof (rule ccontr)
+      assume \<open>\<not> 1 \<le> e'\<close>
+      hence elt: \<open>e' < 1\<close> by simp
+      define \<delta> where \<delta>_def: \<open>\<delta> = (1 - e') / 2\<close>
+      have \<delta>p: \<open>0 < \<delta>\<close> unfolding \<delta>_def using elt by simp
+      have eq: \<open>2 * \<delta> = 1 - e'\<close> unfolding \<delta>_def by simp
+      hence \<delta>l: \<open>\<delta> < 1\<close> using elt e'_nn by linarith
+      from key[rule_format, OF \<delta>p \<delta>l] have h1: \<open>1 - \<delta> \<le> e'\<close> .
+      from eq have \<open>e' = 1 - 2*\<delta>\<close> by linarith
+      with h1 \<delta>p show False by linarith
+    qed
+  qed
+next
+  show \<open>is_int_approx_quality \<lfloor>\<cdot>\<rceil>\<^sub>2 1\<close>
+  proof (rule quality_charI)
+    fix z :: rat show \<open>\<bar>z - (\<lfloor>\<cdot>\<rceil>\<^sub>2 z)\<^sub>\<rat>\<bar> \<le> 1\<close>
+      unfolding round_even_def round_def by linarith
+  next
+    fix e' :: rat
+    assume H: \<open>\<And>z. \<bar>z - (\<lfloor>\<cdot>\<rceil>\<^sub>2 z)\<^sub>\<rat>\<bar> \<le> e'\<close>
+    have e'_nn: \<open>e' \<ge> 0\<close> using H[of 0] by simp
+    have key: \<open>\<forall>\<delta>::rat. 0 < \<delta> \<longrightarrow> \<delta> < 1 \<longrightarrow> 1 - \<delta> \<le> e'\<close>
+    proof (intro allI impI)
+      fix \<delta> :: rat assume \<delta>p: \<open>0 < \<delta>\<close> and \<delta>l: \<open>\<delta> < 1\<close>
+      let ?z = \<open>1 - \<delta> :: rat\<close>
+      have aux: \<open>?z / 2 + 1/2 = 1 - \<delta>/2\<close> by (simp add: field_simps)
+      have rng_lo: \<open>(0::rat) \<le> 1 - \<delta>/2\<close> using \<delta>l by simp
+      have rng_hi: \<open>(1 - \<delta>/2 :: rat) < 1\<close> using \<delta>p by simp
+      have flr0: \<open>\<lfloor>1 - \<delta>/2 :: rat\<rfloor> = 0\<close>
+        using rng_lo rng_hi floor_unique[of 0 \<open>1 - \<delta>/2\<close>] by simp
+      have \<open>\<lfloor>?z / 2 + 1/2\<rfloor> = 0\<close> using aux flr0 by simp
+      hence \<open>\<lfloor>\<cdot>\<rceil> (?z / 2) = 0\<close> unfolding round_def by simp
+      hence re: \<open>\<lfloor>\<cdot>\<rceil>\<^sub>2 ?z = 0\<close> unfolding round_even_def by simp
+      have \<open>\<bar>?z - (\<lfloor>\<cdot>\<rceil>\<^sub>2 ?z)\<^sub>\<rat>\<bar> = 1 - \<delta>\<close> using \<delta>p \<delta>l re by simp
+      thus \<open>1 - \<delta> \<le> e'\<close> using H[of ?z] by simp
+    qed
+    show \<open>1 \<le> e'\<close>
+    proof (rule ccontr)
+      assume \<open>\<not> 1 \<le> e'\<close>
+      hence elt: \<open>e' < 1\<close> by simp
+      define \<delta> where \<delta>_def: \<open>\<delta> = (1 - e') / 2\<close>
+      have \<delta>p: \<open>0 < \<delta>\<close> unfolding \<delta>_def using elt by simp
+      have eq: \<open>2 * \<delta> = 1 - e'\<close> unfolding \<delta>_def by simp
+      hence \<delta>l: \<open>\<delta> < 1\<close> using elt e'_nn by linarith
+      from key[rule_format, OF \<delta>p \<delta>l] have h1: \<open>1 - \<delta> \<le> e'\<close> .
+      from eq have \<open>e' = 1 - 2*\<delta>\<close> by linarith
+      with h1 \<delta>p show False by linarith
+    qed
+  qed
+qed
+
+corollary int_approx_quality_instances:
+  shows quality_round:      \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>) = 1/2\<close>
+    and quality_floor:      \<open>\<epsilon>(\<lfloor>\<cdot>\<rfloor>) = 1\<close>
+    and quality_ceiling:    \<open>\<epsilon>(\<lceil>\<cdot>\<rceil>) = 1\<close>
+    and quality_round_even: \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2) = 1\<close>
+  using int_approx_quality_eq[OF is_int_approx_quality_instances(1)]
+        int_approx_quality_eq[OF is_int_approx_quality_instances(2)]
+        int_approx_quality_eq[OF is_int_approx_quality_instances(3)]
+        int_approx_quality_eq[OF is_int_approx_quality_instances(4)]
+  by simp_all
+
+text \<open>For each of the four standard approximations, the worst-case error
+\<^term>\<open>\<epsilon>(f)\<close> is attained only at the supremum locus: for \<^term>\<open>round\<close> at
+half-integers, and approached but never attained for \<^term>\<open>floor\<close>,
+\<^term>\<open>ceiling\<close>, \<^term>\<open>round_even\<close> at integers. Outside these loci the
+pointwise error is strictly smaller. Note: for \<^term>\<open>floor\<close> and
+\<^term>\<open>ceiling\<close> the strict inequality holds unconditionally — the residue
+\<open>x - of_int (floor x)\<close> always lies in \<open>[0, 1)\<close>, so no precondition is
+needed.\<close>
+
+lemma quality_at_strict:
+  shows quality_at_strict_round:      \<open>2 * x \<notin> \<int> \<Longrightarrow> \<epsilon>(\<lfloor>\<cdot>\<rceil>, x) < \<epsilon>(\<lfloor>\<cdot>\<rceil>)\<close>
+    and quality_at_strict_round_even: \<open>x \<notin> \<int> \<Longrightarrow> \<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2, x) < \<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2)\<close>
+    and quality_at_strict_floor:      \<open>\<epsilon>(\<lfloor>\<cdot>\<rfloor>, x) < \<epsilon>(\<lfloor>\<cdot>\<rfloor>)\<close>
+    and quality_at_strict_ceiling:    \<open>\<epsilon>(\<lceil>\<cdot>\<rceil>, x) < \<epsilon>(\<lceil>\<cdot>\<rceil>)\<close>
+proof -
+  show \<open>2 * x \<notin> \<int> \<Longrightarrow> \<epsilon>(\<lfloor>\<cdot>\<rceil>, x) < \<epsilon>(\<lfloor>\<cdot>\<rceil>)\<close>
+  proof -
+    assume A: \<open>2 * x \<notin> \<int>\<close>
+    have abs_le: \<open>\<bar>x - of_int (\<lfloor>\<cdot>\<rceil> x)\<bar> \<le> 1/2\<close>
+      using of_int_round_abs_le by (simp add: abs_minus_commute)
+    have \<open>\<bar>x - of_int (\<lfloor>\<cdot>\<rceil> x)\<bar> < 1/2\<close>
+    proof (rule ccontr)
+      assume \<open>\<not> \<bar>x - of_int (\<lfloor>\<cdot>\<rceil> x)\<bar> < 1/2\<close>
+      hence eq: \<open>\<bar>x - of_int (\<lfloor>\<cdot>\<rceil> x)\<bar> = 1/2\<close> using abs_le by simp
+      hence \<open>x - of_int (\<lfloor>\<cdot>\<rceil> x) = 1/2 \<or> x - of_int (\<lfloor>\<cdot>\<rceil> x) = -(1/2)\<close>
+        by linarith
+      hence \<open>2 * x = of_int (2 * \<lfloor>\<cdot>\<rceil> x + 1) \<or> 2 * x = of_int (2 * \<lfloor>\<cdot>\<rceil> x - 1)\<close>
+        by (auto simp: algebra_simps)
+      hence \<open>2 * x \<in> \<int>\<close> using Ints_of_int by metis
+      thus False using A by simp
+    qed
+    thus \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>, x) < \<epsilon>(\<lfloor>\<cdot>\<rceil>)\<close> using quality_round by simp
+  qed
+next
+  show \<open>x \<notin> \<int> \<Longrightarrow> \<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2, x) < \<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2)\<close>
+  proof -
+    assume A: \<open>x \<notin> \<int>\<close>
+    have re_expand: \<open>\<bar>x - of_int (\<lfloor>\<cdot>\<rceil>\<^sub>2 x)\<bar> = 2 * \<bar>x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2))\<bar>\<close>
+    proof -
+      have re_eq: \<open>of_int (\<lfloor>\<cdot>\<rceil>\<^sub>2 x) = (2::rat) * of_int (\<lfloor>\<cdot>\<rceil> (x/2))\<close>
+        unfolding round_even_def by simp
+      have \<open>x - of_int (\<lfloor>\<cdot>\<rceil>\<^sub>2 x) = 2 * (x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2)))\<close>
+        using re_eq by (simp add: algebra_simps)
+      thus ?thesis by (metis abs_mult abs_numeral)
+    qed
+    have half_strict: \<open>\<bar>x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2))\<bar> < 1/2\<close>
+    proof (rule ccontr)
+      assume \<open>\<not> \<bar>x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2))\<bar> < 1/2\<close>
+      moreover have \<open>\<bar>x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2))\<bar> \<le> 1/2\<close>
+        using of_int_round_abs_le by (simp add: abs_minus_commute)
+      ultimately have eq: \<open>\<bar>x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2))\<bar> = 1/2\<close> by simp
+      hence \<open>x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2)) = 1/2 \<or> x/2 - of_int (\<lfloor>\<cdot>\<rceil> (x/2)) = -(1/2)\<close>
+        by linarith
+      hence \<open>x = of_int (2 * \<lfloor>\<cdot>\<rceil> (x/2) + 1) \<or> x = of_int (2 * \<lfloor>\<cdot>\<rceil> (x/2) - 1)\<close>
+        by (auto simp: algebra_simps)
+      hence \<open>x \<in> \<int>\<close> using Ints_of_int by metis
+      thus False using A by simp
+    qed
+    have \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2, x) < 1\<close>
+      using re_expand half_strict by simp
+    thus \<open>\<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2, x) < \<epsilon>(\<lfloor>\<cdot>\<rceil>\<^sub>2)\<close> using quality_round_even by simp
+  qed
+next
+  show \<open>\<epsilon>(\<lfloor>\<cdot>\<rfloor>, x) < \<epsilon>(\<lfloor>\<cdot>\<rfloor>)\<close>
+  proof -
+    have \<open>\<bar>x - of_int (\<lfloor>\<cdot>\<rfloor> x)\<bar> < 1\<close>
+      by linarith
+    thus ?thesis using quality_floor by simp
+  qed
+next
+  show \<open>\<epsilon>(\<lceil>\<cdot>\<rceil>, x) < \<epsilon>(\<lceil>\<cdot>\<rceil>)\<close>
+  proof -
+    have \<open>\<bar>x - of_int (\<lceil>\<cdot>\<rceil> x)\<bar> < 1\<close>
+      by linarith
+    thus ?thesis using quality_ceiling by simp
+  qed
+qed
+
+text \<open>
+Fun fact: For every \<open>\<delta> \<in> [0, 1/2]\<close>, the offset rounding \<open>z \<mapsto> round(z + \<delta>)\<close> is an
+integer approximation of quality \<^term>\<open>1/2 + \<delta>\<close>. Setting \<^term>\<open>\<delta> = 0\<close> recovers \<^term>\<open>round\<close>;
+\<^term>\<open>\<delta> = 1/2\<close> gives \<^term>\<open>floor\<close> (up to a half-integer shift). The map \<open>\<delta> \<mapsto> \<epsilon>(\<dots>)\<close>
+is therefore a bijection \<open>[0, 1/2] \<rightarrow> [1/2, 1]\<close>, witnessing that the
+quality range is fully achieved.
+\<close>
+
+lemma int_approx_quality_offset_round:
+  assumes \<open>0 \<le> \<delta>\<close> and \<open>\<delta> \<le> 1/2\<close>
+  shows \<open>is_int_approx (\<lambda>z. \<lfloor>\<cdot>\<rceil> (z + \<delta>))\<close>
+    and \<open>\<epsilon>(\<lambda>z. \<lfloor>\<cdot>\<rceil> (z + \<delta>)) = 1/2 + \<delta>\<close>
+proof -
+  have ub: \<open>\<And>z. \<bar>z - (\<lfloor>\<cdot>\<rceil> (z + \<delta>))\<^sub>\<rat>\<bar> \<le> 1/2 + \<delta>\<close>
+  proof -
+    fix z :: rat
+    have h1: \<open>\<bar>(z + \<delta>) - (\<lfloor>\<cdot>\<rceil> (z + \<delta>))\<^sub>\<rat>\<bar> \<le> 1/2\<close>
+      unfolding round_def by linarith
+    show \<open>\<bar>z - (\<lfloor>\<cdot>\<rceil> (z + \<delta>))\<^sub>\<rat>\<bar> \<le> 1/2 + \<delta>\<close>
+      using h1 assms(1) by linarith
+  qed
+  show \<open>is_int_approx (\<lambda>z. \<lfloor>\<cdot>\<rceil> (z + \<delta>))\<close>
+    unfolding is_int_approx_def
+  proof (intro allI)
+    fix z :: rat
+    show \<open>\<bar>z - \<lfloor>z + \<delta>\<rceil>\<^sub>\<rat>\<bar> \<le> 1\<close>
+      using ub[of z] assms(2) by linarith
+  qed
+  text \<open>Tightness witness: \<^term>\<open>z = -\<delta> - 1/2\<close>.\<close>
+  let ?z0 = \<open>- \<delta> - 1/2 :: rat\<close>
+  have wit_inner: \<open>?z0 + \<delta> = -1/2\<close> by simp
+  have round_neg_half: \<open>\<lfloor>\<cdot>\<rceil> (-1/2 :: rat) = 0\<close>
+    unfolding round_def by simp
+  have round_witness: \<open>\<lfloor>\<cdot>\<rceil> (?z0 + \<delta>) = 0\<close>
+    using wit_inner round_neg_half by simp
+  have err_witness: \<open>\<bar>?z0 - (\<lfloor>\<cdot>\<rceil> (?z0 + \<delta>))\<^sub>\<rat>\<bar> = 1/2 + \<delta>\<close>
+    using round_witness assms(1) by simp
+  have qual: \<open>is_int_approx_quality (\<lambda>z. \<lfloor>\<cdot>\<rceil> (z + \<delta>)) (1/2 + \<delta>)\<close>
+  proof (rule quality_charI)
+    fix z :: rat
+    show \<open>\<bar>z - (\<lfloor>\<cdot>\<rceil> (z + \<delta>))\<^sub>\<rat>\<bar> \<le> 1/2 + \<delta>\<close> using ub[of z] .
+  next
+    fix e' :: rat
+    assume H: \<open>\<And>z. \<bar>z - (\<lfloor>\<cdot>\<rceil> (z + \<delta>))\<^sub>\<rat>\<bar> \<le> e'\<close>
+    from H[of ?z0] err_witness show \<open>1/2 + \<delta> \<le> e'\<close> by simp
+  qed
+  show \<open>\<epsilon>(\<lambda>z. \<lfloor>\<cdot>\<rceil> (z + \<delta>)) = 1/2 + \<delta>\<close>
+    using int_approx_quality_eq[OF qual] .
+qed
+
+subsection \<open>A non-standard example: the golden-ratio approximation \label{sec:golden}\<close>
+
+text \<open>
+This subsection is for illustration and is not essential for the remainder of
+the development. We construct an integer approximation whose rounding threshold
+is the irrational number \<open>(\<surd>5 - 1)/2\<close> (the golden ratio minus one), proving that
+no rational quality witness exists.
+\<close>
+
+text %internal \<open>
+The following predicate uniquely determines an integer for every rational,
+yielding the golden-ratio approximation. The two disjuncts correspond to the
+cases where the integer lies below or above \<open>z\<close>.
+\<close>
+
+definition %internal golden_predicate :: "rat \<Rightarrow> int \<Rightarrow> bool" where
+  "golden_predicate z n \<equiv>
+     let r = z - of_int n in
+     (r \<ge> 0 \<and> r*r + r < 1) \<or> (-1 < r \<and> r < 0 \<and> (r+1)*(r+1) + (r+1) \<ge> 1)"
+
+lemma %internal golden_predicate_existence:
+  "\<exists>n::int. golden_predicate z n"
+proof -
+  let ?n = "\<lfloor>z\<rfloor>"
+  let ?r = "z - of_int ?n"
+  have r_nn: "?r \<ge> 0" by linarith
+  have r_lt1: "?r < 1" by linarith
+  show ?thesis
+  proof (cases "?r * ?r + ?r < 1")
+    case True
+    hence "golden_predicate z ?n"
+      unfolding golden_predicate_def Let_def using r_nn by simp
+    thus ?thesis by blast
+  next
+    case False
+    hence ge1: "?r * ?r + ?r \<ge> 1" by simp
+    let ?m = "\<lceil>z\<rceil>"
+    let ?s = "z - of_int ?m"
+    have s_le0: "?s \<le> 0" by linarith
+    show ?thesis
+    proof (cases "?s = 0")
+      case True
+      hence "z - of_int ?m = 0" by simp
+      hence "golden_predicate z ?m"
+        unfolding golden_predicate_def Let_def by simp
+      thus ?thesis by blast
+    next
+      case False
+      hence s_lt0: "?s < 0" using s_le0 by linarith
+      have s_gt_neg1: "?s > -1" by linarith
+      have m_eq: "?m = ?n + 1"
+        using False s_le0 by linarith
+      have ceq: "of_int (\<lceil>z\<rceil>) = of_int (\<lfloor>z\<rfloor>) + (1::rat)" using m_eq by simp
+      have sp1_eq: "z - of_int (\<lceil>z\<rceil>) + 1 = z - of_int (\<lfloor>z\<rfloor>)"
+        using ceq by linarith
+      have key: "(z - of_int (\<lceil>z\<rceil>) + 1) * (z - of_int (\<lceil>z\<rceil>) + 1) + (z - of_int (\<lceil>z\<rceil>) + 1) \<ge> 1"
+        using ge1 sp1_eq by metis
+      hence "golden_predicate z ?m"
+        unfolding golden_predicate_def Let_def using s_gt_neg1 s_lt0
+        by linarith
+      thus ?thesis by blast
+    qed
+  qed
+qed
+
+lemma %internal golden_predicate_uniqueness:
+  assumes "golden_predicate z n1" and "golden_predicate z n2"
+  shows "n1 = n2"
+proof -
+  define r1 where "r1 = z - of_int n1"
+  define r2 where "r2 = z - of_int n2"
+  have diff: "r1 - r2 = of_int (n2 - n1)" unfolding r1_def r2_def by simp
+  from assms(1) have P1: "(r1 \<ge> 0 \<and> r1*r1 + r1 < 1) \<or> (-1 < r1 \<and> r1 < 0 \<and> (r1+1)*(r1+1) + (r1+1) \<ge> 1)"
+    unfolding golden_predicate_def Let_def r1_def by simp
+  from assms(2) have P2: "(r2 \<ge> 0 \<and> r2*r2 + r2 < 1) \<or> (-1 < r2 \<and> r2 < 0 \<and> (r2+1)*(r2+1) + (r2+1) \<ge> 1)"
+    unfolding golden_predicate_def Let_def r2_def by simp
+  have aux: "\<And>r::rat. r \<ge> 0 \<Longrightarrow> r*r + r < 1 \<Longrightarrow> r < 1"
+  proof -
+    fix r :: rat assume rnn: "r \<ge> 0" and rsq: "r*r + r < 1"
+    have "r * (r + 1) < 1" using rsq by (simp add: algebra_simps)
+    moreover have "r + 1 > 0" using rnn by linarith
+    ultimately have "r < 1 / (r + 1)" using \<open>r + 1 > 0\<close>
+      by (simp add: field_simps)
+    also have "1 / (r + 1) \<le> 1" using rnn by (simp add: field_simps)
+    finally show "r < 1" .
+  qed
+  have goal: "n2 - n1 = 0"
+  proof (rule ccontr)
+    assume neq: "n2 - n1 \<noteq> 0"
+    show False
+    proof (cases "r1 \<ge> 0 \<and> r1*r1 + r1 < 1")
+      case True
+      hence r1_nn: "r1 \<ge> 0" and r1_sq: "r1*r1 + r1 < 1" by auto
+      have r1_lt1: "r1 < 1" using aux[OF r1_nn r1_sq] .
+      show False
+      proof (cases "r2 \<ge> 0 \<and> r2*r2 + r2 < 1")
+        case True
+        hence r2_nn: "r2 \<ge> 0" and r2_sq: "r2*r2 + r2 < 1" by auto
+        have r2_lt1: "r2 < 1" using aux[OF r2_nn r2_sq] .
+        have h: "\<bar>r1 - r2\<bar> < 1"
+          using r1_nn r1_lt1 r2_nn r2_lt1 by linarith
+        have "\<bar>of_int (n2 - n1) :: rat\<bar> < 1" using h diff by linarith
+        hence "\<bar>n2 - n1\<bar> < 1" by (metis of_int_abs of_int_less_1_iff)
+        thus False using neq by simp
+      next
+        case not_c2: False
+        show False
+        proof (cases "-1 < r2 \<and> r2 < 0 \<and> (r2+1)*(r2+1) + (r2+1) \<ge> 1")
+          case True
+          hence r2_neg: "r2 < 0" and r2_gt: "r2 > -1" and r2_ge: "(r2+1)*(r2+1) + (r2+1) \<ge> 1" by auto
+          have d_eq: "of_int (n2 - n1) = r1 - r2" using diff by linarith
+          have "r1 - r2 > 0" using r1_nn r2_neg by linarith
+          moreover have "r1 - r2 < 2" using r1_lt1 r2_gt by linarith
+          ultimately have "n2 - n1 = 1" using d_eq by linarith
+          hence "r2 = r1 - 1" using diff by linarith
+          hence eq: "r2 + 1 = r1" by simp
+          have "(r2+1)*(r2+1) + (r2+1) = r1*r1 + r1"
+            using eq by simp
+          hence "r1*r1 + r1 \<ge> 1" using r2_ge by simp
+          thus False using r1_sq by simp
+        next
+          case False
+          thus False using P2 not_c2 by auto
+        qed
+      qed
+    next
+      case not_c1: False
+      show False
+      proof (cases "-1 < r1 \<and> r1 < 0 \<and> (r1+1)*(r1+1) + (r1+1) \<ge> 1")
+        case True
+        hence r1_neg: "r1 < 0" and r1_gt: "r1 > -1" and r1_ge: "(r1+1)*(r1+1) + (r1+1) \<ge> 1" by auto
+        show False
+        proof (cases "r2 \<ge> 0 \<and> r2*r2 + r2 < 1")
+          case True
+          hence r2_nn: "r2 \<ge> 0" and r2_sq: "r2*r2 + r2 < 1" by auto
+          have r2_lt1: "r2 < 1" using aux[OF r2_nn r2_sq] .
+          have d_eq: "of_int (n2 - n1) = r1 - r2" using diff by linarith
+          have "r1 - r2 < 0" using r1_neg r2_nn by linarith
+          moreover have "r1 - r2 > -2" using r1_gt r2_lt1 by linarith
+          ultimately have "n2 - n1 = -1" using d_eq by linarith
+          hence "r1 = r2 - 1" using diff by linarith
+          hence eq: "r1 + 1 = r2" by simp
+          have "(r1+1)*(r1+1) + (r1+1) = r2*r2 + r2"
+            using eq by simp
+          hence "r2*r2 + r2 \<ge> 1" using r1_ge by simp
+          thus False using r2_sq by simp
+        next
+          case not_c2: False
+          show False
+          proof (cases "-1 < r2 \<and> r2 < 0 \<and> (r2+1)*(r2+1) + (r2+1) \<ge> 1")
+            case True
+            hence r2_neg: "r2 < 0" and r2_gt: "r2 > -1" by auto
+            have h: "\<bar>r1 - r2\<bar> < 1"
+              using r1_neg r1_gt r2_neg r2_gt by linarith
+            have "\<bar>of_int (n2 - n1) :: rat\<bar> < 1" using h diff by linarith
+            hence "\<bar>n2 - n1\<bar> < 1" by (metis of_int_abs of_int_less_1_iff)
+            thus False using neq by simp
+          next
+            case False
+            thus False using P2 not_c2 by auto
+          qed
+        qed
+      next
+        case False
+        thus False using P1 not_c1 by auto
+      qed
+    qed
+  qed
+  thus ?thesis by simp
+qed
+
+lemma %internal golden_predicate_approx:
+  assumes "golden_predicate z n"
+  shows "\<bar>z - of_int n\<bar> \<le> 1"
+proof -
+  define r where "r = z - of_int n"
+  from assms have P: "(r \<ge> 0 \<and> r*r + r < 1) \<or> (-1 < r \<and> r < 0 \<and> (r+1)*(r+1) + (r+1) \<ge> 1)"
+    unfolding golden_predicate_def Let_def r_def by simp
+  have "\<bar>r\<bar> \<le> 1"
+  proof (cases "r \<ge> 0 \<and> r*r + r < 1")
+    case True
+    hence "r \<ge> 0" and "r*r + r < 1" by auto
+    hence "r < 1"
+    proof -
+      have "r * (r + 1) < 1" using \<open>r*r + r < 1\<close> by (simp add: algebra_simps)
+      moreover have "r + 1 > 0" using \<open>r \<ge> 0\<close> by linarith
+      ultimately have "r < 1 / (r + 1)" by (simp add: field_simps)
+      also have "... \<le> 1" using \<open>r \<ge> 0\<close> by (simp add: field_simps)
+      finally show ?thesis .
+    qed
+    thus ?thesis using \<open>r \<ge> 0\<close> by linarith
+  next
+    case False
+    hence "-1 < r \<and> r < 0" using P by auto
+    thus ?thesis by linarith
+  qed
+  thus ?thesis unfolding r_def .
+qed
+
+text %internal \<open>
+The golden predicate uniquely determines an integer approximation whose worst-case
+rounding error is the irrational number \<open>(\<surd>5 - 1)/2\<close>. This makes it an example
+of an integer approximation that admits no rational quality witness.
+\<close>
+
+definition golden_approx (\<open>\<lfloor>_\<rceil>\<^sub>\<phi>\<close>) where
+  "\<lfloor>z\<rceil>\<^sub>\<phi> = (THE n. let r = z - n\<^sub>\<rat> in
+     (r \<ge> 0 \<and> r*r + r < 1) \<or> (-1 < r \<and> r < 0 \<and> (r+1)*(r+1) + (r+1) \<ge> 1))"
+
+notation %invisible golden_approx (\<open>\<lfloor>\<cdot>\<rceil>\<^sub>\<phi>\<close>)
+
+lemma %internal golden_approx_alt: "\<lfloor>z\<rceil>\<^sub>\<phi> = (THE n. golden_predicate z n)"
+  unfolding golden_approx_def golden_predicate_def ..
+
+lemma %internal golden_approx_predicate: "golden_predicate z \<lfloor>z\<rceil>\<^sub>\<phi>"
+proof -
+  have ex1: "\<exists>!n. golden_predicate z n"
+    using golden_predicate_existence golden_predicate_uniqueness by blast
+  show ?thesis unfolding golden_approx_alt[of z] using theI'[OF ex1] .
+qed
+
+text \<open>The golden approximation is indeed an integer approximation:\<close>
+
+theorem is_int_approx_golden: "is_int_approx \<lfloor>\<cdot>\<rceil>\<^sub>\<phi>"
+  unfolding is_int_approx_def
+  using golden_predicate_approx[OF golden_approx_predicate] by simp
+
+paragraph %internal \<open>Real quality\<close>
+
+text %internal \<open>We introduce a real-valued analogue of the approximation quality:\<close>
+
+definition %internal real_quality_pred where \<open>real_quality_pred f q \<equiv>
+  (\<forall>z. \<bar>z\<^sub>\<real> - real_of_int (f z)\<bar> \<le> q) \<and>
+  (\<forall>q'. (\<forall>z. \<bar>z\<^sub>\<real> - real_of_int (f z)\<bar> \<le> q') \<longrightarrow> q \<le> q')\<close>
+
+definition %internal real_quality (\<open>\<epsilon>\<^sub>\<real> '(_')\<close>) where \<open>\<epsilon>\<^sub>\<real>(f) \<equiv>
+  SOME q. real_quality_pred f q\<close>
+
+lemma %internal real_quality_pred_unique:
+  assumes \<open>real_quality_pred f q1\<close> and \<open>real_quality_pred f q2\<close>
+  shows \<open>q1 = q2\<close>
+  using assms unfolding real_quality_pred_def by (meson order_antisym)
+
+lemma %internal real_quality_eq:
+  assumes \<open>real_quality_pred f q\<close>
+  shows \<open>\<epsilon>\<^sub>\<real>(f) = q\<close>
+  unfolding real_quality_def
+  by (rule someI2[of _ q])
+     (use assms real_quality_pred_unique in auto)
+
+notation %invisible sqrt ("\<surd>")
+
+text %internal \<open>Auxiliary facts about \<open>\<surd>5\<close>.\<close>
+
+lemma %internal sqrt5_gt_2: "sqrt 5 > (2::real)"
+proof -
+  have "(2::real)^2 = 4" by simp
+  also have "(4::real) < 5" by simp
+  finally have "(2::real)^2 < 5" .
+  moreover have "(0::real) \<le> 2" by simp
+  ultimately show ?thesis using real_less_rsqrt by blast
+qed
+
+lemma %internal sqrt5_pos: "sqrt 5 > (0::real)"
+  using sqrt5_gt_2 by linarith
+
+lemma %internal sqrt5_squared: "(sqrt 5)^2 = (5::real)"
+  by simp
+
+lemma %internal sqrt5_lt_3: "sqrt 5 < (3::real)"
+proof -
+  have "sqrt 5 \<le> sqrt 9" by (intro real_sqrt_le_mono) simp
+  have sqrt9: "sqrt 9 = (3::real)" by (rule real_sqrt_unique) auto
+  have "sqrt 5 \<noteq> 3"
+  proof
+    assume "sqrt 5 = 3"
+    hence "(sqrt 5)^2 = 9" by simp
+    hence "(5::real) = 9" using sqrt5_squared by simp
+    thus False by simp
+  qed
+  show ?thesis using \<open>sqrt 5 \<le> sqrt 9\<close> sqrt9 \<open>sqrt 5 \<noteq> 3\<close> by linarith
+qed
+
+lemma %internal phi_pos: "(sqrt 5 - 1) / 2 > (0::real)"
+  using sqrt5_gt_2 by simp
+
+lemma %internal phi_lt_1: "(sqrt 5 - 1) / 2 < (1::real)"
+  using sqrt5_lt_3 by simp
+
+lemma %internal phi_quadratic: "((sqrt 5 - 1)/2) * ((sqrt 5 - 1)/2) + (sqrt 5 - 1)/2 = (1::real)"
+proof -
+  have "((sqrt 5 - 1)/2) * ((sqrt 5 - 1)/2) = ((sqrt 5)^2 - 2*sqrt 5 + 1) / 4"
+    by (simp add: power2_eq_square algebra_simps)
+  also have "\<dots> = (6 - 2*sqrt 5) / 4" using sqrt5_squared by simp
+  finally show ?thesis by (simp add: field_simps)
+qed
+
+text %internal \<open>
+The threshold \<open>r\<^sup>2 + r < 1\<close> for \<open>r \<ge> 0\<close> is equivalent to \<open>r < (\<surd>5 - 1)/2\<close>.
+\<close>
+
+lemma %internal golden_threshold:
+  fixes r :: real
+  assumes "r \<ge> 0" and "r*r + r < 1"
+  shows "r < (sqrt 5 - 1) / 2"
+proof (rule ccontr)
+  assume "\<not> r < (sqrt 5 - 1) / 2"
+  hence h: "r \<ge> (sqrt 5 - 1) / 2" by simp
+  have step: "r * r + r \<ge> ((sqrt 5 - 1) / 2) * ((sqrt 5 - 1) / 2) + (sqrt 5 - 1) / 2"
+    using h assms(1) by (intro add_mono mult_mono) auto
+  have "r * r + r \<ge> 1" using step phi_quadratic by simp
+  thus False using assms(2) by linarith
+qed
+
+lemma %internal golden_complement_bound: "(3 - sqrt 5) / 2 \<le> (sqrt 5 - 1) / (2::real)"
+proof -
+  have "3 - sqrt 5 \<le> sqrt 5 - 1" using sqrt5_gt_2 by linarith
+  thus ?thesis by (simp add: divide_right_mono)
+qed
+
+text %internal \<open>The error structure of @{const golden_approx} (i.e.\ @{term \<open>\<lfloor>\<cdot>\<rceil>\<^sub>\<phi>\<close>}).\<close>
+
+lemma %internal golden_error_bound_rat:
+  fixes z :: rat
+  defines "r \<equiv> z - of_int \<lfloor>z\<rceil>\<^sub>\<phi>"
+  shows "(r \<ge> 0 \<and> r*r + r < 1) \<or> (r < 0 \<and> r > -1 \<and> (r+1)*(r+1) + (r+1) \<ge> 1)"
+proof -
+  have gp: "golden_predicate z \<lfloor>z\<rceil>\<^sub>\<phi>" using golden_approx_predicate .
+  show ?thesis unfolding r_def
+    using gp unfolding golden_predicate_def Let_def by auto
+qed
+
+lemma %internal of_rat_abs_diff:
+  "\<bar>real_of_rat z - real_of_int (f z)\<bar> = real_of_rat \<bar>z - (f z)\<^sub>\<rat>\<bar>"
+proof -
+  have h1: "real_of_rat ((f z)\<^sub>\<rat>) = real_of_int (f z)"
+    by (simp add: of_rat_of_int_eq)
+  have h2: "real_of_rat z - real_of_int (f z) = real_of_rat (z - (f z)\<^sub>\<rat>)"
+    using h1 by (simp add: of_rat_diff)
+  show ?thesis using h2 abs_of_rat[of "z - (f z)\<^sub>\<rat>"] by simp
+qed
+
+theorem %internal golden_upper_bound:
+  "\<bar>real_of_rat z - real_of_int \<lfloor>z\<rceil>\<^sub>\<phi>\<bar> \<le> (sqrt 5 - 1) / 2"
+proof -
+  define r where "r = z - of_int \<lfloor>z\<rceil>\<^sub>\<phi>"
+  define R where "R = real_of_rat r"
+  have R_eq: "R = real_of_rat z - real_of_int \<lfloor>z\<rceil>\<^sub>\<phi>"
+    unfolding R_def r_def by (simp add: of_rat_diff of_rat_of_int_eq)
+  have cases: "(r \<ge> 0 \<and> r*r + r < 1) \<or> (r < 0 \<and> r > -1 \<and> (r+1)*(r+1) + (r+1) \<ge> 1)"
+    using golden_error_bound_rat[of z, folded r_def] .
+  show ?thesis
+  proof (cases "r \<ge> 0 \<and> r*r + r < 1")
+    case True
+    hence rnn: "r \<ge> 0" and rsq: "r*r + r < 1" by auto
+    have Rnn: "R \<ge> 0" unfolding R_def using rnn of_rat_less_eq[of 0 r] by simp
+    have "R*R + R < 1"
+    proof -
+      have "real_of_rat (r*r + r) < real_of_rat 1" using rsq of_rat_less[of "r*r+r" 1] by simp
+      thus ?thesis unfolding R_def by (simp add: of_rat_mult of_rat_add)
+    qed
+    hence "R < (sqrt 5 - 1) / 2" using golden_threshold[OF Rnn] by simp
+    moreover have "\<bar>R\<bar> = R" using Rnn by simp
+    ultimately show ?thesis using R_eq by simp
+  next
+    case False
+    hence neg_case: "r < 0 \<and> r > -1 \<and> (r+1)*(r+1) + (r+1) \<ge> 1" using cases by auto
+    hence rneg: "r < 0" and rgt: "r > -1" and rge: "(r+1)*(r+1) + (r+1) \<ge> 1" by auto
+    have Rneg: "R < 0" unfolding R_def using rneg of_rat_less[of r 0] by simp
+    have Rgt: "R > -1" unfolding R_def using rgt of_rat_less[of "-1" r] by simp
+    have abs_eq: "\<bar>R\<bar> = -R" using Rneg by simp
+    have Rge: "(R+1)*(R+1) + (R+1) \<ge> 1"
+    proof -
+      have "real_of_rat ((r+1)*(r+1) + (r+1)) \<ge> real_of_rat 1"
+        using rge of_rat_less_eq[of 1 "(r+1)*(r+1) + (r+1)"] by simp
+      thus ?thesis unfolding R_def by (simp add: of_rat_mult of_rat_add)
+    qed
+    have Rp1_nn: "R+1 \<ge> 0" using Rgt by linarith
+    have negR_bound: "-R \<le> (sqrt 5 - 1) / 2"
+    proof -
+      have "(R+1) \<ge> (sqrt 5 - 1) / 2"
+      proof (rule ccontr)
+        assume "\<not> (R+1) \<ge> (sqrt 5 - 1) / 2"
+        hence lt: "(R+1) < (sqrt 5 - 1) / 2" by simp
+        have step: "(R+1)*(R+1) + (R+1) < ((sqrt 5 - 1)/2) * ((sqrt 5 - 1)/2) + (sqrt 5 - 1)/2"
+          using Rp1_nn lt phi_pos by (intro add_less_le_mono mult_strict_mono') auto
+        have "(R+1)*(R+1) + (R+1) < 1" using step phi_quadratic by simp
+        thus False using Rge by linarith
+      qed
+      hence hR: "-R \<le> 1 - (sqrt 5 - 1) / 2" by linarith
+      have "(sqrt 5 - 1) / 2 \<ge> 1 - (sqrt 5 - 1) / 2"
+      proof -
+        have "sqrt 5 - 1 \<ge> 1" using sqrt5_gt_2 by linarith
+        thus ?thesis by (simp add: field_simps)
+      qed
+      thus ?thesis using hR by linarith
+    qed
+    show ?thesis using abs_eq negR_bound R_eq by simp
+  qed
+qed
+
+theorem %internal golden_tightness:
+  fixes q' :: real
+  assumes ub: "\<forall>z. \<bar>real_of_rat z - real_of_int \<lfloor>z\<rceil>\<^sub>\<phi>\<bar> \<le> q'"
+  shows "(sqrt 5 - 1) / 2 \<le> q'"
+proof (rule ccontr)
+  assume "\<not> (sqrt 5 - 1) / 2 \<le> q'"
+  hence q'_lt: "q' < (sqrt 5 - 1) / 2" by simp
+  have q'_nn: "q' \<ge> 0" using ub[rule_format, of 0] by simp
+  obtain z :: rat where z_gt: "real_of_rat z > q'" and z_lt: "real_of_rat z < (sqrt 5 - 1) / 2"
+    using of_rat_dense[OF q'_lt] by blast
+  have z_pos: "z > 0"
+  proof -
+    have "real_of_rat z > 0" using z_gt q'_nn by linarith
+    thus ?thesis using of_rat_less[of 0 z] by simp
+  qed
+  have z_lt1: "z < 1"
+  proof -
+    have "real_of_rat z < 1" using z_lt phi_lt_1 by linarith
+    thus ?thesis using of_rat_less[of z 1] by simp
+  qed
+  have z_nn: "z \<ge> 0" using z_pos by linarith
+  have zsq_lt: "z * z + z < 1"
+  proof -
+    define Z where "Z = real_of_rat z"
+    have Znn: "Z \<ge> 0" unfolding Z_def using z_nn of_rat_less_eq[of 0 z] by simp
+    have Zlt: "Z < (sqrt 5 - 1) / 2" using z_lt unfolding Z_def .
+    have step: "Z * Z + Z < ((sqrt 5 - 1)/2)*((sqrt 5 - 1)/2) + (sqrt 5 - 1)/2"
+      using Znn Zlt phi_pos by (intro add_less_le_mono mult_strict_mono') auto
+    have "Z * Z + Z < 1" using step phi_quadratic by simp
+    hence "real_of_rat (z * z + z) < real_of_rat 1"
+      unfolding Z_def by (simp add: of_rat_mult of_rat_add)
+    thus ?thesis using of_rat_less[of "z*z+z" 1] by simp
+  qed
+  have gp0: "golden_predicate z 0"
+    unfolding golden_predicate_def Let_def using z_nn zsq_lt by simp
+  have ga_eq: "\<lfloor>z\<rceil>\<^sub>\<phi> = 0"
+    using golden_predicate_uniqueness[OF golden_approx_predicate gp0] by simp
+  have err_eq: "\<bar>real_of_rat z - real_of_int \<lfloor>z\<rceil>\<^sub>\<phi>\<bar> = real_of_rat z"
+  proof -
+    have "real_of_rat z > 0" using z_gt q'_nn by linarith
+    thus ?thesis using ga_eq by simp
+  qed
+  show False using ub[rule_format, of z] err_eq z_gt by linarith
+qed
+
+text \<open>Its real quality is the golden ratio minus one, where the real quality
+\<open>\<epsilon>\<^sub>\<real>(f)\<close> is defined analogously to the rational quality \<open>\<epsilon>(f)\<close>.\<close>
+
+theorem real_quality_golden: \<open>\<epsilon>\<^sub>\<real>(\<lfloor>\<cdot>\<rceil>\<^sub>\<phi>) = (\<surd>5 - 1) / 2\<close>
+  by (rule real_quality_eq)
+     (unfold real_quality_pred_def,
+      use golden_upper_bound golden_tightness in blast)
+
+paragraph %internal \<open>Irrationality and no rational quality\<close>
+
+lemma %internal five_dvd_square: "(5::int) dvd n * n \<Longrightarrow> 5 dvd n"
+proof -
+  assume h: "5 dvd n * n"
+  have "\<not> 5 dvd n \<Longrightarrow> False"
+  proof -
+    assume nd: "\<not> 5 dvd n"
+    have "n mod 5 \<in> {1, 2, 3, 4}"
+    proof -
+      have "n mod 5 \<in> {0, 1, 2, 3, 4}" by auto
+      moreover have "n mod 5 \<noteq> 0" using nd by auto
+      ultimately show ?thesis by auto
+    qed
+    hence "(n mod 5) * (n mod 5) mod 5 \<in> {1, 4}"
+      by auto
+    hence "(n * n) mod 5 \<noteq> 0"
+      by (metis mod_mult_eq insert_iff singletonD
+          zero_neq_numeral numeral_eq_one_iff)
+    thus False using h by auto
+  qed
+  thus "5 dvd n" by blast
+qed
+
+lemma %internal sqrt5_step1:
+  assumes "q > (0::int)" "sqrt 5 = of_int p / of_int q"
+  shows "5 * q\<^sup>2 = p\<^sup>2"
+proof -
+  have q_nz: "of_int q \<noteq> (0::real)" using assms(1) by simp
+  have "sqrt 5 * of_int q = (of_int p :: real)"
+    using assms(2) q_nz by (simp add: field_simps)
+  hence "(sqrt 5)^2 * (of_int q)^2 = (of_int p :: real)^2"
+    by (metis power_mult_distrib)
+  hence "5 * (of_int q :: real)^2 = (of_int p :: real)^2"
+    using sqrt5_squared by simp
+  hence "(of_int (5 * q\<^sup>2) :: real) = of_int (p\<^sup>2)"
+    by (simp add: of_int_power of_int_mult)
+  thus "5 * q\<^sup>2 = p\<^sup>2" using of_int_eq_iff by blast
+qed
+
+lemma %internal sqrt5_step2:
+  assumes "5 * q\<^sup>2 = p\<^sup>2"
+  shows "(5::int) dvd p"
+proof -
+  from assms have pp: "p * p = 5 * (q * q)" by (simp add: power2_eq_square)
+  hence dvd_pp: "(5::int) dvd (p * p)" by simp
+  from five_dvd_square[OF dvd_pp] show "5 dvd p" .
+qed
+
+lemma %internal sqrt5_step3:
+  assumes eq2: "5 * q\<^sup>2 = p\<^sup>2" and p_eq: "p = 5 * k"
+  shows "(5::int) dvd q"
+proof -
+  from eq2 p_eq have "5 * q\<^sup>2 = (5 * k)\<^sup>2" by simp
+  hence "5 * (q * q) = 25 * (k * k)" by (simp add: power2_eq_square)
+  hence qq: "q * q = 5 * (k * k)" by linarith
+  hence dvd_qq: "(5::int) dvd (q * q)" by simp
+  from five_dvd_square[OF dvd_qq] show "5 dvd q" .
+qed
+
+lemma %internal sqrt5_not_rat: "sqrt 5 \<notin> \<rat>"
+proof
+  assume "sqrt 5 \<in> \<rat>"
+  then obtain p q :: int where q_pos: "q > 0" and eq: "sqrt 5 = of_int p / of_int q"
+    and coprime: "coprime p q"
+    using Rats_cases' by blast
+  have eq2: "5 * q\<^sup>2 = p\<^sup>2" using sqrt5_step1[OF q_pos eq] .
+  have p5: "5 dvd p" using sqrt5_step2[OF eq2] .
+  then obtain k where p_eq: "p = 5 * k" by auto
+  have q5: "5 dvd q" using sqrt5_step3[OF eq2 p_eq] .
+  from p5 q5 have "5 dvd gcd p q" by simp
+  with coprime show False by simp
+qed
+
+lemma %internal phi_not_rat: "(sqrt 5 - 1) / 2 \<notin> \<rat>"
+proof
+  assume h: "(sqrt 5 - 1) / 2 \<in> \<rat>"
+  have "sqrt 5 \<in> \<rat>"
+  proof -
+    from h obtain r :: rat where r_eq: "(sqrt 5 - 1) / 2 = real_of_rat r"
+      using Rats_cases by blast
+    hence "sqrt 5 = real_of_rat (2 * r + 1)"
+      by (simp add: of_rat_mult of_rat_add field_simps)
+    hence "sqrt 5 \<in> \<rat>" using Rats_of_rat by metis
+    thus ?thesis .
+  qed
+  with sqrt5_not_rat show False by simp
+qed
+
+text %internal \<open>A rational quality is also a real quality:\<close>
+
+lemma %internal rational_quality_is_real_quality:
+  assumes \<open>is_int_approx_quality f e\<close>
+  shows \<open>\<epsilon>\<^sub>\<real>(f) = e\<^sub>\<real>\<close>
+proof (rule real_quality_eq, unfold real_quality_pred_def, intro conjI allI impI)
+  fix z show "\<bar>real_of_rat z - real_of_int (f z)\<bar> \<le> real_of_rat e"
+  proof -
+    from assms have "\<bar>z - (f z)\<^sub>\<rat>\<bar> \<le> e"
+      unfolding is_int_approx_quality_def by blast
+    hence "real_of_rat \<bar>z - (f z)\<^sub>\<rat>\<bar> \<le> real_of_rat e"
+      using of_rat_less_eq by blast
+    thus ?thesis using of_rat_abs_diff[of z f] by simp
+  qed
+next
+  fix q' :: real assume ub: "\<forall>z. \<bar>real_of_rat z - real_of_int (f z)\<bar> \<le> q'"
+  show "real_of_rat e \<le> q'"
+  proof (rule ccontr)
+    assume "\<not> real_of_rat e \<le> q'"
+    hence q'_lt: "q' < real_of_rat e" by simp
+    obtain r :: rat where r_gt: "real_of_rat r > q'" and r_lt: "real_of_rat r < real_of_rat e"
+      using of_rat_dense[OF q'_lt] by blast
+    hence r_lt_e: "r < e" using of_rat_less by blast
+    from assms have nub: "\<not> (\<forall>z. \<bar>z - (f z)\<^sub>\<rat>\<bar> \<le> r)"
+      unfolding is_int_approx_quality_def using r_lt_e by force
+    then obtain z0 where z0: "\<not> \<bar>z0 - (f z0)\<^sub>\<rat>\<bar> \<le> r" by blast
+    hence z0_gt: "\<bar>z0 - (f z0)\<^sub>\<rat>\<bar> > r" by simp
+    hence "real_of_rat \<bar>z0 - (f z0)\<^sub>\<rat>\<bar> > real_of_rat r"
+      by (simp add: of_rat_less)
+    hence gt: "\<bar>real_of_rat z0 - real_of_int (f z0)\<bar> > real_of_rat r"
+      using of_rat_abs_diff[of z0 f] by simp
+    have "\<bar>real_of_rat z0 - real_of_int (f z0)\<bar> > q'"
+      using gt r_gt by linarith
+    thus False using ub[rule_format, of z0] by linarith
+  qed
+qed
+
+text \<open>Since the golden ratio is irrational, no rational quality exists:\<close>
+
+theorem \<open>\<not> is_int_approx_quality \<lfloor>\<cdot>\<rceil>\<^sub>\<phi> e\<close>
+proof
+  assume h: \<open>is_int_approx_quality \<lfloor>\<cdot>\<rceil>\<^sub>\<phi> e\<close>
+  from rational_quality_is_real_quality[OF h]
+  have \<open>\<epsilon>\<^sub>\<real>(\<lfloor>\<cdot>\<rceil>\<^sub>\<phi>) = e\<^sub>\<real>\<close> .
+  moreover from real_quality_golden
+  have \<open>\<epsilon>\<^sub>\<real>(\<lfloor>\<cdot>\<rceil>\<^sub>\<phi>) = (\<surd>5 - 1) / 2\<close> .
+  ultimately have \<open>e\<^sub>\<real> = (\<surd>5 - 1) / 2\<close> by simp
+  hence \<open>(\<surd>5 - 1) / 2 \<in> \<rat>\<close> using Rats_of_rat by metis
+  with phi_not_rat show False by simp
+qed
+
+section \<open>Modular residues\<close>
+
+text \<open>
+Each approximation \<open>\<lbrakk>_\<rbrakk>\<close> induces a residue \<open>z mod\<lbrakk>f\<rbrakk> N := z - N \<sqdot> \<lbrakk>z /\<^sub>\<rat> N\<rbrakk>\<close>. Setting
+\<open>\<lbrakk>_\<rbrakk> = \<lfloor>\<cdot>\<rfloor>\<close> recovers the unsigned representative \<open>z mod\<^sup>+ N\<close> in \<open>{0, \<dots>, N-1}\<close>;
+\<open>\<lbrakk>_\<rbrakk> = \<lfloor>\<cdot>\<rceil>\<close> the signed representative \<open>z mod\<^sup>\<plusminus> N\<close> in
+\<open>{-\<lfloor>N/2\<rfloor>, \<dots>, \<lfloor>(N-1)/2\<rfloor>}\<close>.
+\<close>
+
+definition \<open>mod_approx f z N \<equiv> z - N * \<lbrakk>z /\<^sub>\<rat> N\<rbrakk>\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+abbreviation mod_approx_paper (\<open>(_) mod \<lbrakk>_\<rbrakk> (_)\<close> [70, 0, 71] 70) where
+  \<open>z mod\<lbrakk>f\<rbrakk> N \<equiv> mod_approx f z N\<close>
+
+abbreviation mod_unsigned (infixl \<open>mod\<^sup>+\<close> 70) where
+  \<open>z mod\<^sup>+ N \<equiv> mod_approx \<lfloor>\<cdot>\<rfloor> z N\<close>
+
+abbreviation mod_signed (infixl \<open>mod\<^sup>\<plusminus>\<close> 70) where
+  \<open>z mod\<^sup>\<plusminus> N \<equiv> mod_approx \<lfloor>\<cdot>\<rceil> z N\<close>
+
+text \<open>
+A sanity check: the \<^term>\<open>floor\<close>-induced residue coincides with the standard unsigned
+reduction, justifying \<open>mod\<^sup>+\<close> as the unsigned representative throughout.
+\<close>
+
+lemma mod_unsigned_eq_mod:
+  assumes \<open>N > 0\<close>
+  shows \<open>z mod\<^sup>+ N = z mod N\<close>
+  unfolding mod_approx_def using assms
+  by (simp add: floor_divide_of_int_eq, simp add: minus_mult_div_eq_mod)
+
+text \<open>
+\noindent A general absolute bound \<^term>\<open>\<bar>z mod\<lbrakk>f\<rbrakk> N\<bar> \<le> N\<close> holds for every integer approximation.
+\<close>
+
+lemma mod_approx_bound:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>is_int_approx f\<close> and \<open>N > 0\<close>
+  shows \<open>\<bar>z mod\<lbrakk>f\<rbrakk> N\<bar> \<le> N\<close>
+proof -
+  have h: \<open>\<bar>z /\<^sub>\<rat> N - \<lbrakk>z /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat>\<bar> \<le> 1\<close>
+    using assms(1) unfolding is_int_approx_def by simp
+  have \<open>\<bar>(mod_approx f z N)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat>\<close>
+    unfolding mod_approx_def
+    using h assms(2) by (simp add: field_simps abs_mult_pos)
+  thus ?thesis by (metis of_int_abs of_int_le_iff)
+qed
+
+text \<open>The following is merely a reformulation of the definition, but useful:\<close>
+
+lemma magic_const_rat:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> ("\<lbrakk>_\<rbrakk>") and N R :: int
+  assumes \<open>is_int_approx f\<close> and \<open>N \<noteq> 0\<close>
+  shows \<open>(\<lbrakk>R /\<^sub>\<rat> N\<rbrakk>)\<^sub>\<rat> = (R - R mod\<lbrakk>f\<rbrakk> N) /\<^sub>\<rat> N\<close>
+proof -
+  have \<open>R mod\<lbrakk>f\<rbrakk> N = R - N * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk>\<close>
+    unfolding mod_approx_def by simp
+  hence \<open>(R - R mod\<lbrakk>f\<rbrakk> N)\<^sub>\<rat> = (N * \<lbrakk>R /\<^sub>\<rat> N\<rbrakk>)\<^sub>\<rat>\<close> by simp
+  thus ?thesis using assms(2) by (simp add: of_int_mult field_simps)
+qed
+text \<open>If a quality witness exists for \<open>\<lbrakk>_\<rbrakk>\<close>, the residue is bounded by \<^term>\<open>\<epsilon>(f) * N\<close>:
+the slope shrinks by exactly the approximation quality.\<close>
+
+lemma mod_approx_bound_eps_at:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>N > 0\<close>
+  shows \<open>\<bar>(z mod\<lbrakk>f\<rbrakk> N)\<^sub>\<rat>\<bar> = N\<^sub>\<rat> * \<epsilon>(f, z /\<^sub>\<rat> N)\<close>
+proof -
+  have iN_pos: \<open>N\<^sub>\<rat> > 0\<close> using assms by simp
+  have eq: \<open>(z mod\<lbrakk>f\<rbrakk> N)\<^sub>\<rat> = N\<^sub>\<rat> * (z /\<^sub>\<rat> N - \<lbrakk>z /\<^sub>\<rat> N\<rbrakk>\<^sub>\<rat>)\<close>
+    unfolding mod_approx_def using iN_pos by (simp add: field_simps)
+  show ?thesis unfolding eq using iN_pos by (simp add: abs_mult)
+qed
+
+lemma mod_approx_bound_eps:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>is_int_approx_quality f e\<close> and \<open>N > 0\<close>
+  shows \<open>\<bar>(z mod\<lbrakk>f\<rbrakk> N)\<^sub>\<rat>\<bar> \<le> N\<^sub>\<rat> * \<epsilon>(f)\<close>
+  using mod_approx_bound_eps_at[OF assms(2), of f z]
+        quality_at_le[OF assms(1), of \<open>z /\<^sub>\<rat> N\<close>]
+        assms(2)
+  by (simp add: mult_left_mono)
+
+text \<open>
+For the signed and unsigned residues, both pinned to canonical intervals,
+the bound \<^term>\<open>\<epsilon>(f) * N\<close> from @{thm [source] mod_approx_bound_eps} specialises to the integer-form
+inequalities below: the signed residue lies in
+\<^latex>\<open>$\{-\lfloor N/2\rfloor, \dots, \lfloor (N-1)/2 \rfloor\}$\<close> (matching
+\<^term>\<open>\<epsilon>(round) = 1/2\<close>), and the unsigned residue in \<open>\<lbrace>0, \<dots>, N - 1\<rbrace>\<close>
+(matching \<^term>\<open>\<epsilon>(floor) = 1\<close>).
+\<close>
+
+lemma mod_canonical_bounds:
+  assumes \<open>N > 0\<close>
+  shows mod_signed_lower:   \<open>- (N div 2) \<le> z mod\<^sup>\<plusminus> N\<close>
+    and mod_signed_upper:   \<open>z mod\<^sup>\<plusminus> N \<le> (N - 1) div 2\<close>
+    and mod_unsigned_lower: \<open>0 \<le> z mod\<^sup>+ N\<close>
+    and mod_unsigned_upper: \<open>z mod\<^sup>+ N < N\<close>
+proof -
+  have h1: \<open>(z mod\<^sup>\<plusminus> N)\<^sub>\<rat> = z\<^sub>\<rat> - N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat>\<close>
+    unfolding mod_approx_def by simp
+  have h3: \<open>N\<^sub>\<rat> > 0\<close> using assms by simp
+  have h2_lo: \<open>\<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> \<le> z /\<^sub>\<rat> N + 1/2\<close>
+    unfolding round_def by linarith
+  have \<open>N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> \<le> N\<^sub>\<rat> * (z /\<^sub>\<rat> N + 1/2)\<close>
+    using h2_lo h3 by (simp add: mult_left_mono)
+  also have \<open>\<dots> = z\<^sub>\<rat> + N\<^sub>\<rat> / 2\<close>
+    using h3 by (simp add: field_simps)
+  finally have \<open>z\<^sub>\<rat> - N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> \<ge> - (N\<^sub>\<rat> / 2)\<close>
+    by linarith
+  hence \<open>(z mod\<^sup>\<plusminus> N)\<^sub>\<rat> \<ge> - (N\<^sub>\<rat> / 2)\<close>
+    using h1 by simp
+  hence \<open>(2 * (z mod\<^sup>\<plusminus> N))\<^sub>\<rat> \<ge> - N\<^sub>\<rat>\<close>
+    by (simp add: field_simps)
+  hence \<open>2 * (z mod\<^sup>\<plusminus> N) \<ge> - N\<close>
+    by (metis of_int_le_iff of_int_minus of_int_mult of_int_numeral)
+  thus \<open>- (N div 2) \<le> z mod\<^sup>\<plusminus> N\<close> using assms by linarith
+next
+  have h1: \<open>(z mod\<^sup>\<plusminus> N)\<^sub>\<rat> = z\<^sub>\<rat> - N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat>\<close>
+    unfolding mod_approx_def by simp
+  have h3: \<open>N\<^sub>\<rat> > 0\<close> using assms by simp
+  have h2_hi: \<open>\<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> > z /\<^sub>\<rat> N - 1/2\<close>
+    unfolding round_def by linarith
+  have \<open>N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> > N\<^sub>\<rat> * (z /\<^sub>\<rat> N - 1/2)\<close>
+    using h2_hi h3 by (simp add: mult_strict_left_mono)
+  also have \<open>N\<^sub>\<rat> * (z /\<^sub>\<rat> N - 1/2) = z\<^sub>\<rat> - N\<^sub>\<rat> / 2\<close>
+    using h3 by (simp add: field_simps)
+  finally have \<open>z\<^sub>\<rat> - N\<^sub>\<rat> * \<lfloor>z /\<^sub>\<rat> N\<rceil>\<^sub>\<rat> < N\<^sub>\<rat> / 2\<close>
+    by linarith
+  hence \<open>(z mod\<^sup>\<plusminus> N)\<^sub>\<rat> < N\<^sub>\<rat> / 2\<close>
+    using h1 by simp
+  hence \<open>(2 * (z mod\<^sup>\<plusminus> N))\<^sub>\<rat> < N\<^sub>\<rat>\<close>
+    by (simp add: field_simps)
+  hence \<open>2 * (z mod\<^sup>\<plusminus> N) < N\<close>
+    by (metis of_int_less_iff of_int_mult of_int_numeral)
+  thus \<open>z mod\<^sup>\<plusminus> N \<le> (N - 1) div 2\<close> using assms by linarith
+next
+  show \<open>0 \<le> z mod\<^sup>+ N\<close> using mod_unsigned_eq_mod[OF assms] assms by simp
+next
+  show \<open>z mod\<^sup>+ N < N\<close> using mod_unsigned_eq_mod[OF assms] assms by simp
+qed
+
+paragraph %internal \<open>Fact 1: negation on the canonical signed range.\<close>
+
+text %internal \<open>
+\cite[Fact~1, \S3.1.1]{NeonNTT} describes how the signed residue
+interacts with negation on the canonical signed range. With \<^term>\<open>R = 2^n\<close>, signed reduction
+commutes with negation — \<^term>\<open>(-x) mod\<^sup>\<plusminus> R = -(x mod\<^sup>\<plusminus> R)\<close> — for almost every \<open>x \<in> \<int>\<^sub>R\<close>
+(\<open>mod_signed_negate_generic\<close>). The single exception is the boundary point \<^term>\<open>x = 2^(n-1)\<close>,
+whose negation crosses the asymmetric edge of the signed interval, producing an extra
+\<^term>\<open>-R\<close> correction (\<open>mod_signed_negate_exceptional\<close>).
+\<close>
+
+lemma %internal mod_signed_negate_generic:
+  assumes \<open>n \<ge> 1\<close>
+  defines \<open>R \<equiv> 2^n\<close>
+  assumes \<open>x mod R \<noteq> 2^(n-1)\<close>
+  shows \<open>(-x) mod\<^sup>\<plusminus> R = -(x mod\<^sup>\<plusminus> R)\<close>
+proof -
+  have R_pos: \<open>R > 0\<close> using assms unfolding R_def by simp
+  have R_div2: \<open>R = 2 * 2^(n-1)\<close>
+    using assms(1) unfolding R_def by (cases n, simp, simp)
+  let ?q = \<open>x div R\<close>
+  let ?r = \<open>x mod R\<close>
+  let ?s = \<open>?r /\<^sub>\<rat> R\<close>
+  have iR_pos: \<open>R\<^sub>\<rat> > 0\<close> using R_pos by simp
+  have iR_nz: \<open>R\<^sub>\<rat> \<noteq> 0\<close> using R_pos by simp
+  have x_decomp_int: \<open>x = R * ?q + ?r\<close> by simp
+  have x_decomp: \<open>x\<^sub>\<rat> = R\<^sub>\<rat> * ?q\<^sub>\<rat> + ?r\<^sub>\<rat>\<close>
+    using x_decomp_int by (metis of_int_add of_int_mult)
+  have r_bounds: \<open>0 \<le> ?r \<and> ?r < R\<close> using R_pos by simp
+  have key1: \<open>x /\<^sub>\<rat> R = ?q\<^sub>\<rat> + ?s\<close>
+    using x_decomp iR_nz by (simp add: add_divide_distrib)
+  have key2: \<open>(-x) /\<^sub>\<rat> R = -?q\<^sub>\<rat> - ?s\<close>
+    using x_decomp iR_nz by (simp add: add_divide_distrib field_simps)
+  have r_neq: \<open>?s \<noteq> 1/2\<close>
+  proof
+    assume \<open>?s = 1/2\<close>
+    hence \<open>?r\<^sub>\<rat> = R\<^sub>\<rat> / 2\<close> using iR_nz by (simp add: field_simps)
+    hence \<open>2 * ?r\<^sub>\<rat> = R\<^sub>\<rat>\<close> by simp
+    hence \<open>(2 * ?r)\<^sub>\<rat> = R\<^sub>\<rat>\<close> by simp
+    hence \<open>2 * ?r = R\<close> by (metis of_int_eq_iff of_int_mult of_int_numeral)
+    hence \<open>?r = R div 2\<close> by simp
+    also have \<open>R div 2 = 2^(n-1)\<close> using R_div2 by simp
+    finally show False using assms(3) by simp
+  qed
+  have rR_nn: \<open>0 \<le> ?s\<close> using r_bounds iR_pos by simp
+  have rR_lt1: \<open>?s < 1\<close> using r_bounds iR_pos by (simp add: divide_less_eq)
+  have round_x: \<open>\<lfloor>x /\<^sub>\<rat> R\<rceil> = ?q + (if ?s < 1/2 then 0 else 1)\<close>
+  proof (cases \<open>?s < 1/2\<close>)
+    case True
+    have \<open>\<lfloor>x /\<^sub>\<rat> R + 1/2\<rfloor> = \<lfloor>(?s + 1/2) + ?q\<^sub>\<rat>\<rfloor>\<close> using key1 by (simp add: algebra_simps)
+    also have \<open>\<dots> = \<lfloor>?s + 1/2\<rfloor> + ?q\<close> by (rule floor_add_int[symmetric])
+    also have \<open>\<lfloor>?s + 1/2\<rfloor> = 0\<close> using True rR_nn by linarith
+    finally show ?thesis using True unfolding round_def by simp
+  next
+    case False
+    hence sgt: \<open>?s > 1/2\<close> using r_neq by linarith
+    have \<open>\<lfloor>x /\<^sub>\<rat> R + 1/2\<rfloor> = \<lfloor>(?s + 1/2) + ?q\<^sub>\<rat>\<rfloor>\<close> using key1 by (simp add: algebra_simps)
+    also have \<open>\<dots> = \<lfloor>?s + 1/2\<rfloor> + ?q\<close> by (rule floor_add_int[symmetric])
+    also have \<open>\<lfloor>?s + 1/2\<rfloor> = 1\<close> using sgt rR_lt1 by linarith
+    finally show ?thesis using False unfolding round_def by simp
+  qed
+  have round_negx: \<open>\<lfloor>(-x) /\<^sub>\<rat> R\<rceil> = -?q - (if ?s < 1/2 then 0 else 1)\<close>
+  proof (cases \<open>?s < 1/2\<close>)
+    case True
+    have \<open>\<lfloor>(-x) /\<^sub>\<rat> R + 1/2\<rfloor> = \<lfloor>(1/2 - ?s) + (-?q)\<^sub>\<rat>\<rfloor>\<close> using key2 by (simp add: algebra_simps)
+    also have \<open>\<dots> = \<lfloor>1/2 - ?s\<rfloor> + (-?q)\<close> by (rule floor_add_int[symmetric])
+    also have \<open>\<lfloor>1/2 - ?s\<rfloor> = 0\<close> using True rR_nn r_neq by (cases \<open>?s = 1/2\<close>) (linarith+)
+    finally show ?thesis using True unfolding round_def by simp
+  next
+    case False
+    hence sgt: \<open>?s > 1/2\<close> using r_neq by linarith
+    have \<open>\<lfloor>(-x) /\<^sub>\<rat> R + 1/2\<rfloor> = \<lfloor>(1/2 - ?s) + (-?q)\<^sub>\<rat>\<rfloor>\<close> using key2 by (simp add: algebra_simps)
+    also have \<open>\<dots> = \<lfloor>1/2 - ?s\<rfloor> + (-?q)\<close> by (rule floor_add_int[symmetric])
+    also have \<open>\<lfloor>1/2 - ?s\<rfloor> = -1\<close> using sgt rR_lt1 by linarith
+    finally show ?thesis using False unfolding round_def by simp
+  qed
+  have round_eq: \<open>\<lfloor>(-x) /\<^sub>\<rat> R\<rceil> = - \<lfloor>x /\<^sub>\<rat> R\<rceil>\<close>
+    using round_x round_negx by simp
+  show ?thesis
+    unfolding mod_approx_def
+    using round_eq by (simp add: algebra_simps)
+qed
+
+text %internal \<open>The exceptional case \<^term>\<open>x mod R = 2^(n-1)\<close> is exactly the boundary that the
+preceding proof excluded, and produces the \<^term>\<open>-R\<close>-correction.\<close>
+
+lemma %internal mod_signed_negate_exceptional:
+  assumes \<open>n \<ge> 1\<close>
+  defines \<open>R \<equiv> 2^n\<close>
+  assumes \<open>x mod R = 2^(n-1)\<close>
+  shows \<open>(-x) mod\<^sup>\<plusminus> R = -(x mod\<^sup>\<plusminus> R) - R\<close>
+proof -
+  have R_pos: \<open>R > 0\<close> using assms unfolding R_def by simp
+  have R_div2: \<open>R = 2 * 2^(n-1)\<close>
+    using assms(1) unfolding R_def by (cases n, simp, simp)
+  let ?q = \<open>x div R\<close>
+  let ?r = \<open>x mod R\<close>
+  have iR_pos: \<open>R\<^sub>\<rat> > 0\<close> using R_pos by simp
+  have iR_nz: \<open>R\<^sub>\<rat> \<noteq> 0\<close> using R_pos by simp
+  have x_decomp_int: \<open>x = R * ?q + ?r\<close> by simp
+  have x_decomp: \<open>x\<^sub>\<rat> = R\<^sub>\<rat> * ?q\<^sub>\<rat> + ?r\<^sub>\<rat>\<close>
+    using x_decomp_int by (metis of_int_add of_int_mult)
+  have r_eq: \<open>?r = 2^(n-1)\<close> using assms(3) by simp
+  have key1: \<open>x /\<^sub>\<rat> R = ?q\<^sub>\<rat> + ?r /\<^sub>\<rat> R\<close>
+    using x_decomp iR_nz by (simp add: add_divide_distrib)
+  have key2: \<open>?r /\<^sub>\<rat> R = 1/2\<close>
+    using r_eq R_div2 R_pos by simp
+  have key: \<open>x /\<^sub>\<rat> R + 1/2 = (?q + 1)\<^sub>\<rat>\<close>
+    using key1 key2 by simp
+  have round_x: \<open>\<lfloor>x /\<^sub>\<rat> R\<rceil> = ?q + 1\<close>
+    unfolding round_def using key by (simp add: floor_of_int)
+  have neg_eq: \<open>(-x) /\<^sub>\<rat> R + 1/2 = -((?q + 1)\<^sub>\<rat>) + 1\<close>
+    using key by (simp add: field_simps)
+  have round_neg: \<open>\<lfloor>(-x) /\<^sub>\<rat> R\<rceil> = - ?q\<close>
+    unfolding round_def using neg_eq by (simp add: floor_of_int)
+  show ?thesis
+    unfolding mod_approx_def
+    using round_x round_neg by (simp add: algebra_simps)
+qed
+
+paragraph %internal \<open>Shift compatibility.\<close>
+
+text %internal \<open>
+An integer approximation \<open>\<lbrakk>_\<rbrakk>\<close> is \emph{shift-compatible} if it commutes with \<^term>\<open>(+) (1 :: rat)\<close>:
+\<close>
+
+definition %internal \<open>shift_compat f \<longleftrightarrow> (\<forall>z. \<lbrakk>z + 1\<rbrakk> = \<lbrakk>z\<rbrakk> + 1)\<close> for f ("\<lbrakk>_\<rbrakk>")
+
+text %internal \<open>
+Floor, ceiling, and round-to-nearest are shift-compatible. Even-rounding \<^term>\<open>round_even\<close>, however, is not. 
+Interestingly, shift-compatibility plays no role in the abstract Barrett-Montgomery development of 
+the following chapters, including the bridge of \autoref{ch:barrett_montgomery}: those proofs only invoke shift-compatibility 
+of the fixed outer rounding (\<^term>\<open>round\<close> or \<^term>\<open>floor\<close>) used to define the canonical residue, never of the 
+parameter \<open>\<lbrakk>_\<rbrakk>\<close>. Shift-compatibility therefore only constrains intermediate technical lemmas; the
+headline statements remain generic in \<open>\<lbrakk>_\<rbrakk>\<close>.
+\<close>
+
+lemma %internal shift_compat_standard:
+  shows shift_compat_floor: \<open>shift_compat \<lfloor>\<cdot>\<rfloor>\<close>
+    and shift_compat_ceiling: \<open>shift_compat \<lceil>\<cdot>\<rceil>\<close>
+    and shift_compat_round: \<open>shift_compat \<lfloor>\<cdot>\<rceil>\<close>
+proof -
+  show \<open>shift_compat \<lfloor>\<cdot>\<rfloor>\<close> unfolding shift_compat_def by simp
+  show \<open>shift_compat \<lceil>\<cdot>\<rceil>\<close> unfolding shift_compat_def by simp
+  show \<open>shift_compat \<lfloor>\<cdot>\<rceil>\<close>
+    unfolding shift_compat_def round_def by (simp add: int_add_floor add.commute)
+qed
+
+lemma %internal shift_compat_iter_pos:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>shift_compat f\<close>
+  shows \<open>\<lbrakk>z + (int k)\<^sub>\<rat>\<rbrakk> = \<lbrakk>z\<rbrakk> + int k\<close>
+proof (induction k arbitrary: z)
+  case 0
+  show ?case by simp
+next
+  case (Suc m)
+  have \<open>\<lbrakk>z + (int (Suc m))\<^sub>\<rat>\<rbrakk> = \<lbrakk>(z + (int m)\<^sub>\<rat>) + 1\<rbrakk>\<close>
+    by (simp add: algebra_simps)
+  also have \<open>\<dots> = \<lbrakk>z + (int m)\<^sub>\<rat>\<rbrakk> + 1\<close>
+    using assms unfolding shift_compat_def by simp
+  also have \<open>\<dots> = \<lbrakk>z\<rbrakk> + int m + 1\<close> using Suc by simp
+  finally show ?case by simp
+qed
+
+lemma %internal shift_compat_iter_int:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>shift_compat f\<close>
+  shows \<open>\<lbrakk>z + k\<^sub>\<rat>\<rbrakk> = \<lbrakk>z\<rbrakk> + k\<close>
+proof (cases \<open>k \<ge> 0\<close>)
+  case True
+  then obtain m where m: \<open>k = int m\<close> using zero_le_imp_eq_int by blast
+  show ?thesis using shift_compat_iter_pos[OF assms, of z m] m by simp
+next
+  case False
+  hence \<open>- k \<ge> 0\<close> by simp
+  then obtain m where m: \<open>- k = int m\<close> using zero_le_imp_eq_int by blast
+  hence k_eq: \<open>k = - int m\<close> by simp
+  have step: \<open>\<lbrakk>(z + k\<^sub>\<rat>) + (int m)\<^sub>\<rat>\<rbrakk> = \<lbrakk>z + k\<^sub>\<rat>\<rbrakk> + int m\<close>
+    using shift_compat_iter_pos[OF assms, of \<open>z + k\<^sub>\<rat>\<close> m] by simp
+  have eq: \<open>(z + k\<^sub>\<rat>) + (int m)\<^sub>\<rat> = z\<close>
+    using k_eq by simp
+  from step have \<open>\<lbrakk>z\<rbrakk> = \<lbrakk>z + k\<^sub>\<rat>\<rbrakk> + int m\<close> using eq by argo
+  thus ?thesis using k_eq by simp
+qed
+
+lemma %internal mod_approx_shift:
+  fixes f :: \<open>rat \<Rightarrow> int\<close> (\<open>\<lbrakk>_\<rbrakk>\<close>)
+  assumes \<open>shift_compat f\<close> and \<open>N > 0\<close>
+  shows \<open>(x + N * k) mod\<lbrakk>f\<rbrakk> N = x mod\<lbrakk>f\<rbrakk> N\<close>
+proof -
+  have div_split: \<open>(x + N * k) /\<^sub>\<rat> N = x /\<^sub>\<rat> N + k\<^sub>\<rat>\<close>
+    using assms(2) by (simp add: field_simps)
+  have \<open>\<lbrakk>(x + N * k) /\<^sub>\<rat> N\<rbrakk> = \<lbrakk>x /\<^sub>\<rat> N + k\<^sub>\<rat>\<rbrakk>\<close>
+    using div_split by simp
+  also have \<open>\<dots> = \<lbrakk>x /\<^sub>\<rat> N\<rbrakk> + k\<close>
+    using shift_compat_iter_int[OF assms(1)] by simp
+  finally have shift_eq:
+    \<open>\<lbrakk>(x + N * k) /\<^sub>\<rat> N\<rbrakk> = \<lbrakk>x /\<^sub>\<rat> N\<rbrakk> + k\<close> .
+  have \<open>(x + N * k) mod\<lbrakk>f\<rbrakk> N = (x + N * k) - N * \<lbrakk>(x + N * k) /\<^sub>\<rat> N\<rbrakk>\<close>
+    unfolding mod_approx_def by simp
+  also have \<open>\<dots> = (x + N * k) - N * (\<lbrakk>x /\<^sub>\<rat> N\<rbrakk> + k)\<close>
+    using shift_eq by simp
+  also have \<open>\<dots> = x - N * \<lbrakk>x /\<^sub>\<rat> N\<rbrakk>\<close>
+    by (simp add: algebra_simps)
+  also have \<open>\<dots> = x mod\<lbrakk>f\<rbrakk> N\<close>
+    unfolding mod_approx_def by simp
+  finally show ?thesis .
+qed
+
+section \<open>Standard locales \label{sec:standard_locales}\<close>
+
+text \<open>
+The Barrett and Montgomery analyses repeatedly need the same side conditions on
+the modulus \<open>N\<close> and the bit-width \<open>n\<close>: \<open>N > 1\<close>, \<open>N\<close> odd, \<open>n > 0\<close>, and
+\<open>N < 2^n\<close>. The integer-approximation analyses likewise rely on
+\<open>is_int_approx f\<close>. We capture each context in an Isabelle \isakeywordONE{locale}
+--- \<open>StandardModulus\<close> for the modulus side conditions,
+\<open>IntegerApproximation\<close> for the rounding hypothesis, and \<open>BarrettContext\<close>
+combining the two (defined in \autoref{ch:barrett_red}). Lemmas that depend
+on these conditions are introduced with the locale annotation
+\<open>(in StandardModulus)\<close> or \<open>(in BarrettContext)\<close> and take no explicit
+\<open>assumes\<close>; the side conditions are inherited from the locale, and
+abbreviations like \<open>R \<equiv> 2^n\<close> become visible.
+\<close>
+
+locale StandardModulus =
+  fixes N :: int and n :: nat
+  assumes Ngt1: \<open>N > 1\<close> and Nodd: \<open>odd N\<close> and npos: \<open>n > 0\<close>
+      and N_lt_R: \<open>N < 2^n\<close>
+begin
+
+abbreviation R :: int where \<open>R \<equiv> 2^n\<close>
+
+lemma %internal Npos [simp]: \<open>N > 0\<close> using Ngt1 by linarith
+lemma %internal N_nn [simp]: \<open>N \<ge> 0\<close> using Npos by linarith
+lemma %internal R_pos [simp]: \<open>R > 0\<close> by simp
+lemma %internal R_nz_int [simp]: \<open>R \<noteq> 0\<close> by simp
+lemma %internal R_nz_rat [simp]: \<open>R\<^sub>\<rat> \<noteq> 0\<close> by simp
+lemma %internal N_nz_int [simp]: \<open>N \<noteq> 0\<close> using Ngt1 by simp
+lemma %internal N_nz_rat [simp]: \<open>N\<^sub>\<rat> \<noteq> 0\<close> using Npos by simp
+lemma %internal N_pos_rat [simp]: \<open>N\<^sub>\<rat> > 0\<close> using Npos by simp
+lemma %internal R_pos_rat [simp]: \<open>R\<^sub>\<rat> > 0\<close> by simp
+lemma %internal N_lt_R_rat [simp]: \<open>N\<^sub>\<rat> < R\<^sub>\<rat>\<close> using N_lt_R by simp
+lemma %internal R_eq: \<open>R = 2 * 2^(n-1)\<close> using npos by (cases n) auto
+lemma %internal R_hlv: \<open>2^(n-1) = R /\<^sub>\<rat> 2\<close> by (simp add: Suc_le_eq npos power_diff)
+
+end
+
+locale IntegerApproximation =
+  fixes f :: \<open>rat \<Rightarrow> int\<close>
+  assumes f_approx: \<open>is_int_approx f\<close>
+begin
+notation f (\<open>\<lbrakk>_\<rbrakk>\<close>)
+end
+
+
+end

--- a/proofs/isabelle/neon_ntt/Introduction.thy
+++ b/proofs/isabelle/neon_ntt/Introduction.thy
@@ -1,0 +1,279 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Introduction
+  imports Asm_Montgomery Asm_Barrett
+begin
+
+chapter \<open>Introduction\<close>
+
+text \<open>
+The Number Theoretic Transform (NTT) is a performance-critical component of
+lattice-based cryptography: ML-KEM and ML-DSA both spend the majority of their
+arithmetic time in NTTs and the modular arithmetic operations they are comprised
+of. Fast implementations of ML-KEM and ML-DSA --- including
+\texttt{mlkem-native}~\cite{mlkemnative} and
+\texttt{mldsa-native}~\cite{mldsanative} --- handle those modular
+arithmetic cores through bespoke assembly instruction kernels tailored to the
+target architecture.
+
+The Neon NTT paper~\cite{NeonNTT} introduced
+multiple novel such assembly kernels for the Armv8-A Neon vector instruction set,
+notably signed Barrett multiplication, and presented a bounds reasoning for
+Barrett arithmetic based on an equivalence between Barrett and Montgomery
+multiplication and reduction. The correctness arguments for the kernels and the
+Barrett--Montgomery equivalence are pen-and-paper, and errors at this level are
+easy to make and easy to miss: an off-by-one in an absolute bound, a mis-stated
+parity hypothesis, or a silently shared assumption between the Barrett and
+Montgomery analyses can compromise an otherwise-audited NTT.
+
+This document provides a machine-checked Isabelle/HOL formalisation of this
+modular-arithmetic core of~\cite{NeonNTT}. At the level of abstract
+algebraic operations: we develop parametric theories of Barrett and Montgomery
+reduction and multiplication, uniform in modulus, word width, and integer
+approximation, prove the identity linking Barrett and Montgomery arithmetic, and
+treat the doubling- and rounding-Montgomery variants. We also offer a conceptual
+recasting of the Barrett--Montgomery equivalence through the duality between
+Euclidean and 2-adic rounding. Second, at the level of concrete assembly kernels:
+we model the relevant Neon instructions --- \asminst{MUL}, \asminst{MULH}, \asminst{MLA}, \asminst{MLS}, \asminst{SQDMULH},
+\asminst{SQRDMULH}, and \asminst{SHSUB} --- as operations on machine words, and prove correctness
+and bounds theorems for the signed-word kernels shipped by \texttt{mlkem-native}
+and \texttt{mldsa-native}. The kernel-level theorems are stated against this
+abstract word model, assumed to match the corresponding Armv8-A ISA semantics;
+NTT- and butterfly-level correctness, and a decoder from the abstract model to
+concrete binaries, are out of scope.
+
+Beyond its technical content, the development serves as a case study in
+human-directed, model-generated formalisation. Claude Opus~4.7, connecting to
+Isabelle through the open-source \texttt{AutoCorrode}~\cite{AutoCorrode} toolkit,
+drafted the Isabelle source under the author's direction --- the author owned the
+architecture and proof strategy, while the model supplied the formal text and
+absorbed the bookkeeping of iteration and refactoring.
+\autoref{ch:methodology} describes the loop in more detail.
+
+Our formalisation uses the Isabelle/HOL interactive proof assistant.
+Isabelle/HOL is one of the most mature proof assistants available today,
+with a development history spanning over three decades. It has been used in
+large-scale verification efforts including the seL4
+microkernel~\cite{Klein2009seL4,Klein2014seL4}, the formal proof of the
+Kepler conjecture~\cite{Hales2017Kepler}, recent work on cryptographic
+library verification at Apple~\cite{AppleCorecrypto2025}, and the ongoing
+verification of the AWS Nitro Isolation
+Engine~\cite{AWSNitro2025}. The Archive of Formal
+Proofs~\cite{AFP}, a refereed collection of Isabelle developments, hosts
+close to a thousand entries at the time of writing. Beyond maturity, we
+chose Isabelle/HOL for its
+general ease of use; its structured proof language Isar, which reads close
+to natural mathematical exposition; its document preparation system, which
+makes it possible to share a single source between paper and formal proof;
+and the author's prior familiarity with the system.
+
+\medskip\noindent\textbf{Contributions.}
+\begin{enumerate}
+\item A machine-checked Isabelle/HOL formalisation of the arithmetic core
+  of~\cite{NeonNTT}.
+\item A demonstrator for human-directed, model-generated formalisation at the
+  scale of a research paper.
+\end{enumerate}
+We do not claim novelty on the formal verification of assembly-level
+modular arithmetic kernels --- several prior efforts have established
+such results (see next section).
+
+\medskip\noindent\textbf{Related work.}
+\cite{NeonNTT} is the reference for the algorithms and bounds formalised
+here; its Lemma~1, Propositions~1--4, Facts~1--3, Corollaries~1 and~2, and
+Algorithms~2, 5, 7, 8, 9, 10, 12, and~13 each have a named counterpart in this
+development. Algorithms~1, 3, 4, 6, and~11 are pseudocode renderings of the same
+operators, captured at the operator level rather than as separate formal artifacts.
+
+Multiple prior efforts have established formal correctness for assembly-level
+modular arithmetic kernels used in post-quantum cryptography. CryptoLine
+verifies NTT multiplications for Kyber, SABER, and NTRU at the instruction
+level for both AVX2 and Cortex-M4~\cite{CryptoLine2022,CryptoLine2025}.
+The Formosa Crypto project~\cite{FormosaCrypto} uses Jasmin and EasyCrypt to
+produce verified high-speed implementations with end-to-end guarantees from
+source to binary. Apple's recent verification of
+corecrypto~\cite{AppleCorecrypto2025} covers assembly-level modular arithmetic
+in a production cryptographic library. And \texttt{mlkem-native} and
+\texttt{mldsa-native} ship HOL Light + \texttt{s2n-bignum} proofs that work
+at the binary level against a model of the Armv8-A instruction decoder and
+semantics for the deployed kernels.
+Relative to these efforts, the present development does not target a specific
+deployed binary but isolates the algebraic content shared across kernels ---
+parametrically over modulus, word width, and rounding mode --- so that a new
+kernel or parameter set reuses the bounds rather than reproving them.
+
+\medskip\noindent\textbf{Source code.}
+The Isabelle sources for this document reside in the \texttt{mldsa-native}
+repository~\cite{mldsanative} under
+\url{https://github.com/pq-code-package/mldsa-native/tree/main/proofs/isabelle/neon_ntt}.
+\<close>
+
+chapter \<open>Methodology \label{ch:methodology}\<close>
+
+text \<open>
+\medskip\noindent\textbf{AutoCorrode.}
+Large language models are powerful across many domains, and their efficacy
+can often be amplified by providing direct interfaces to their target, such
+as CLIs or MCPs. In the context of interactive theorem proving, a tight
+feedback loop based on a direct and persistent connection between agent and
+proof kernel allows the agent to develop proofs faster and more effectively
+than a repeated edit-and-rebuild loop.
+
+The \texttt{AutoCorrode}~\cite{AutoCorrode} verification infrastructure
+includes two agent--prover interfaces for Isabelle. First, Isabelle/Q
+(``I/Q'') is an Isabelle/jEdit plugin exposing proof editing and exploration
+as an MCP server --- the agent edits theory files and observes prover
+feedback in the same way a human would, without triggering a rebuild after
+every change. However, it is not conducive to concurrent edits by both human
+and the agent. For that, Isabelle/REPL (``I/R'') lets the agent talk
+directly to the Isabelle/ML prover process in a REPL loop, bypassing jEdit
+and PIDE. I/R is integrated into I/Q: the agent can fork a REPL at an
+arbitrary point in a theory opened in Isabelle/jEdit (e.g.\ a
+\texttt{sorry}'ed proof) and start exploring alternative theory texts
+without yet making the edits in jEdit. I/R is ad-hoc and may be replaced by
+something more PIDE-native in the future, but it demonstrates what
+concurrent human/AI proof editing can look like: the agent works out
+multiple proofs while the human keeps editing the document elsewhere.
+\texttt{AutoCorrode} also includes Isabelle/Proxy (``I/P''), which offloads
+the Isabelle/ML prover process to a remote server while keeping
+Isabelle/jEdit and the JVM local --- a powerful capability for large-scale
+developments, though less relevant for the present example.
+
+\medskip\noindent\textbf{The human/AI loop.}
+The agent provided the initial auto-formalisation of
+\cite{NeonNTT} completely autonomously. It lacked clarity,
+brevity, and generally did not make for a paper-style artifact that a human
+would like to consume. It was the task of the human author to then
+gradually nudge the agent to adjust the narrative, compact proofs, tweak
+definitions, introduce suitable syntax, and decide on what to abridge and
+what to include. No proof was ultimately written by the human --- even under
+strong editorial direction, the formal text remained entirely
+model-generated. Despite this heavy involvement, the development was much
+faster than had the human formalised the material themselves. In addition to
+the time-saving of not having to write definitions and proofs manually, the
+agent was hugely effective at making cross-cutting changes such as syntax
+adjustments, propagating signature changes through many call sites, and
+relocating code across theories.
+
+It was noteworthy that the agent had often disregarded existing proofs and
+even proof strategies from \cite{NeonNTT}, and come up with its
+own approaches --- for better or for worse. Two examples stand out. First,
+instead of relying on the Barrett--Montgomery equivalence to establish
+bounds for Barrett arithmetic, the agent proved those bounds directly. This
+is interesting per se, but directly opposed to the approach of
+\cite{NeonNTT}, which demonstrates how the obvious Montgomery
+bound can be carried over to Barrett using the equivalence. Second,
+\cite[Algorithm~8]{NeonNTT} states the correctness of Montgomery
+multiplication with rounding under a parity hypothesis (\<open>a\<close> odd or \<open>b\<close>
+odd). The agent correctly noted that this assumption is unnecessary and
+proved the algorithm unconditionally correct --- a genuine improvement over
+\cite{NeonNTT} surfaced by the
+formalisation.\footnote{Interestingly, a recent contribution
+(\url{https://github.com/pq-code-package/mlkem-native/pull/1184}) to
+\texttt{mlkem-native} had independently used this algorithm: the PPC64
+compiler developers had discovered and implemented it without the parity
+assumption
+(\url{https://github.com/pq-code-package/mlkem-native/pull/1184\#issuecomment-4485661049}).}
+
+\medskip\noindent\textbf{Unifying paper and proof.}
+When paper and formal development live in separate artifacts, time and care
+is needed to ensure that they stay in sync as changes are made on either
+side. To avoid this overhead and soundness risk, we use Isabelle's document
+preparation system to auto-generate all documentation from the formal
+sources. Every chapter of this document is an Isabelle theory file.
+Refactoring a lemma moves the surrounding prose with it; adding a new
+abbreviation propagates to every displayed term downstream. Isabelle's
+mixfix syntax keeps the formal text close to the notation a reader would
+expect from a paper. The present version is heavily abridged --- most
+auxiliary lemmas and almost all proofs are elided for the sake of
+highlighting the main arguments. The full theory contents can be included
+by rebuilding with different tags.
+\<close>
+
+chapter \<open>Roadmap\<close>
+
+text \<open>
+We provide a brief summary of each chapter:
+
+\begin{description}
+\item[\autoref{ch:integer_approx} (\<open>Integer_Approximation\<close>)]
+  develops the parametric notion of integer approximation
+  \<open>\<lbrakk>_\<rbrakk> : \<rat> \<rightarrow> \<int>\<close> and the residue operator
+  \<^term>\<open>z mod\<lbrakk>f\<rbrakk> N\<close>. Both round-to-nearest and floor are special cases.
+
+\item[\autoref{ch:montgomery_red} (\<open>Montgomery_Reduction\<close>)] develops
+  abstract Montgomery reduction and multiplication along two
+  independent axes --- additive vs.\ subtractive correction, and signed
+  vs.\ unsigned twist --- with divisibility, correctness, and absolute
+  bounds for each variant, plus Fact~3 of
+  \cite[\S2.4.2]{NeonNTT} relating the subtractive and
+  additive forms.
+
+\item[\autoref{ch:barrett_red} (\<open>Barrett_Reduction\<close>)] develops
+  signed and unsigned Barrett reduction operations
+  @{term "barrett_red_signed N n f"} and
+  @{term "barrett_red_unsigned N n f"}, as well as Barrett
+  multiplication operations @{term "barrett_mul_signed N n f a b"} and
+  @{term "barrett_mul_unsigned N n f a b"}, all parametric in an
+  integer approximation \<open>\<lbrakk>_\<rbrakk>\<close>. We also introduce a refined Barrett
+  reduction at an inflated effective radix \<open>2\<^sup>n\<^sup>+\<^sup>\<alpha>\<^sup>-\<^sup>1\<close>, used by the
+  \asminst{SQDMULH}/\asminst{SRSHR}-based kernel in
+  \autoref{ch:asm_barrett}. Output absolute bounds for Barrett are
+  deferred to \autoref{ch:barrett_montgomery}, where they fall out of
+  the Barrett--Montgomery equivalence.
+
+\item[\autoref{ch:barrett_montgomery} (\<open>Barrett_Montgomery\<close>)] proves
+  the Barrett--Montgomery equivalence: Barrett reduction of \<^term>\<open>z\<close> equals
+  Montgomery reduction of \<open>z \<cdot> (R mod\<lbrakk>f\<rbrakk> N)\<close>, with the corresponding
+  statement for multiplication, in both signed and unsigned forms
+  \cite[\S3.1.1, Propositions~1 and~2]{NeonNTT}. This
+  collapses the bounds proofs of the two families
+  \cite[Corollaries~1 and~2]{NeonNTT} into a single
+  argument, and the chapter hosts all Barrett output absolute bounds.
+
+\item[\autoref{ch:barrett_bound_quality}
+  (\<open>Barrett_Bound_Quality\<close>)] checks the quality of the abstract
+  Barrett bounds against empirical maxima at three concrete moduli:
+  a small illustrative prime ($N = 97$), the ML-KEM modulus
+  ($N = 3329$), and the ML-DSA modulus ($N = 8380417$). The
+  evaluation uses Isabelle's code extractor and the code-equation
+  mechanism to register efficiently computable alternative definitions,
+  making exhaustive sweeps over large input ranges feasible within
+  the prover.
+
+\item[\autoref{ch:montgomery_doubling} (\<open>Montgomery_Doubling\<close>)]
+  formalises the doubling- and rounding-Montgomery variants
+  \cite[Algorithms~7 and~8]{NeonNTT}.
+
+\item[\autoref{ch:bridge_conceptual} (\<open>Bridge_Conceptual\<close>)] revisits
+  the Barrett--Montgomery equivalence from a higher vantage point,
+  casting it as a consequence of the duality between Euclidean and
+  2-adic rounding of a rational number.
+
+\item[\autoref{ch:word_ops} (\<open>Word_Ops\<close>)] models the relevant Neon
+  instructions --- low-half \asminst{MUL}, \asminst{MLA}, \asminst{MLS};
+  high-half \asminst{MULH}, \asminst{UMULH}; the doubling high-half
+  \asminst{SQDMULH} and \asminst{SQRDMULH} (saturating); the
+  multiply-accumulate \asminst{SQRDMLAH}; the halving subtract
+  \asminst{SHSUB}; and the rounding right shift \asminst{SRSHR} --- as
+  parametric operations on \<open>'a::len\<close>-bit lanes, with each \<^term>\<open>sint\<close> (or
+  \<^term>\<open>uint\<close>) of the word operation tied back to an integer-level
+  specification. Working at this width-parametric level lets every kernel
+  correctness theorem be stated once.
+
+\item[\autoref{ch:asm_barrett} (\<open>Asm_Barrett\<close>)] proves correctness of
+  the Neon-style Barrett kernels of \cite[\S3.2.1, \S3.2.2]{NeonNTT} ---
+  Barrett multiplication, plain Barrett reduction, and the refined
+  Barrett reduction at an inflated radix \<open>2\<^sup>n\<^sup>+\<^sup>\<alpha>\<^sup>-\<^sup>1\<close> --- against the models of
+  \autoref{ch:word_ops}.
+
+\item[\autoref{ch:asm_montgomery} (\<open>Asm_Montgomery\<close>)] proves
+  correctness of the Neon-style Montgomery kernel of
+  \cite[\S3.2.3]{NeonNTT}, including the doubling- and
+  rounding-based variants.
+
+\end{description}
+\<close>
+
+end

--- a/proofs/isabelle/neon_ntt/Makefile
+++ b/proofs/isabelle/neon_ntt/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+ISABELLE_VERSION ?= Isabelle2025-2
+ISABELLE_HOME ?= /Applications/$(ISABELLE_VERSION).app/bin
+ISABELLE_DIR  ?= /Applications/$(ISABELLE_VERSION).app
+
+PDF_NAME ?= neon_ntt_autoformalized.pdf
+
+# Number of random samples per non-8-bit op when running `make conformance`.
+CONFORMANCE_RUNS ?= 50000
+
+# Locate the Isabelle binary up-front: bail out with a clear message rather
+# than letting `make` die on an opaque "No such file or directory" when the
+# default macOS app path doesn't apply.
+define CHECK_ISABELLE
+	@if [ ! -x "$(ISABELLE_HOME)/isabelle" ]; then \
+	  echo "error: '$(ISABELLE_HOME)/isabelle' not found or not executable." >&2; \
+	  echo "Set ISABELLE_HOME to the directory containing the 'isabelle' binary, e.g.:" >&2; \
+	  echo "  make ISABELLE_HOME=/path/to/Isabelle/bin $@" >&2; \
+	  exit 1; \
+	fi
+endef
+
+all:
+	$(CHECK_ISABELLE)
+	$(ISABELLE_HOME)/isabelle build -D .
+	cp output/document.pdf $(PDF_NAME)
+
+clean:
+	$(CHECK_ISABELLE)
+	$(ISABELLE_HOME)/isabelle build -c -D .
+	rm -f $(PDF_NAME)
+	$(MAKE) -C model/hw clean
+	$(MAKE) -C model/sml clean
+
+jedit:
+	$(CHECK_ISABELLE)
+	$(ISABELLE_HOME)/isabelle jedit -D . Asm_Montgomery.thy
+
+# --- Conformance testing -------------------------------------------------
+# Build the AArch64 NEON reference (model/hw) and the Isabelle-exported SML
+# model (model/sml), then drive both side-by-side from model/conformance.
+
+model/hw/hw_exec:
+	$(MAKE) -C model/hw
+
+model/sml/model_exec:
+	$(MAKE) -C model/sml ISABELLE_DIR=$(ISABELLE_DIR)
+
+conformance: model/hw/hw_exec model/sml/model_exec
+	python3 model/conformance/run.py edge
+	python3 model/conformance/run.py random -n $(CONFORMANCE_RUNS)
+
+.PHONY: all clean jedit conformance

--- a/proofs/isabelle/neon_ntt/Montgomery_Doubling.thy
+++ b/proofs/isabelle/neon_ntt/Montgomery_Doubling.thy
@@ -1,0 +1,378 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Montgomery_Doubling
+  imports Montgomery_Reduction
+begin
+
+chapter \<open>Montgomery multiplication via doubling and rounding \label{ch:montgomery_doubling}\<close>
+
+text \<open>Not every architecture exposes a plain truncating high-half multiply
+\<open>MULH\<close> of the kind used in standard Montgomery multiplication. Fixed-point
+arithmetic ISAs commonly provide \emph{doubling} or \emph{rounding} high-half
+multiplies instead --- on AArch64, \<open>SQDMULH\<close> (returns \<^term>\<open>\<lfloor>2 * a * b /\<^sub>\<rat> R\<rfloor>\<close> for \<^term>\<open>a :: int\<close>, \<^term>\<open>b :: int\<close>, \<^term>\<open>R :: int\<close>) and
+\<open>SQRDMULH\<close> (returns \<^term>\<open>\<lfloor>2 * a * b /\<^sub>\<rat> R\<rceil>\<close> under the same typing). \cite[Algorithms~7 and~8, \S3.3]{NeonNTT} rebuild Montgomery multiplication around these
+two operations.
+
+\<close>
+
+section \<open>Montgomery Multiplication via Doubling\<close>
+
+text \<open>The idea behind Montgomery Multiplication with Doubling is simple:
+use doubling high-half multiplies, and compensate for the doubling through a
+halving subtract --- which too is common in fixed-point arithmetic ISAs:\<close>
+
+definition \<open>mont_mul_doubling N n T a b \<equiv>
+     (let R = (2::int)^n;
+          z = (2 * (a * b)) div R;
+          k = ((a * b * T) mod\<^sup>\<plusminus> R);
+          c = (2 * (k * N)) div R
+      in (z - c) div 2)\<close>
+
+text \<open>Algorithm~7 computes \<^term>\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close> for arbitrary \<^term>\<open>a\<close>, \<^term>\<open>b\<close>:\<close>
+
+theorem (in StandardModulus) mont_mul_doubling_eq:
+  assumes T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>mont_mul_doubling N n T a b = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>(a * b * T) mod\<^sup>\<plusminus> ?R\<close>
+  let ?u = \<open>a * b - ?k * N\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have R_dvd_u: \<open>?R dvd ?u\<close>
+    using mont_sub_signed_divisible[OF T_inv, of \<open>a * b\<close>] by simp
+  then obtain q where q: \<open>?u = ?R * q\<close> unfolding dvd_def by auto
+  have mont_eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b) = q\<close>
+    using mont_sub_signed_unfold[OF T_inv, of \<open>a * b\<close>]
+          q R_pos by simp
+  have ab_eq: \<open>2 * (a * b) = ?R * (2 * q) + 2 * (?k * N)\<close>
+    using q by (simp add: algebra_simps)
+  have z_eq: \<open>(2 * (a * b)) div ?R = 2 * q + (2 * (?k * N)) div ?R\<close>
+  proof -
+    have \<open>(2 * (a * b)) div ?R = (?R * (2 * q) + 2 * (?k * N)) div ?R\<close>
+      using ab_eq by simp
+    also have \<open>\<dots> = 2 * q + (2 * (?k * N)) div ?R\<close>
+      by simp
+    finally show ?thesis .
+  qed
+  have \<open>mont_mul_doubling N n T a b = ((2 * (a * b)) div ?R - (2 * (?k * N)) div ?R) div 2\<close>
+    unfolding mont_mul_doubling_def Let_def by simp
+  also have \<open>\<dots> = (2 * q) div 2\<close> using z_eq by simp
+  also have \<open>\<dots> = q\<close> by simp
+  finally show ?thesis using mont_eq by simp
+qed
+
+section \<open>Montgomery Multiplication via Rounding\<close>
+
+text \<open>The idea behind Montgomery Multiplication via Rounding is to express
+the carry from the low half of the standard Montgomery step as the joint
+\emph{rounding carry} of two \<open>SQRDMULH\<close> operations: each contributes a
+\<^term>\<open>(1/2 :: rat)\<close> on its own, and combining them recovers the missing high-bit. The
+construction is exact for all \<^term>\<open>a\<close>, \<^term>\<open>b\<close> except at one boundary case (low
+half exactly \<^term>\<open>2^(n-1)\<close>) where both \<open>SQRDMULH\<close>s round up; the trailing
+\<open>SHSUB\<close> halves the doubled output and absorbs the boundary error.
+
+Note: \cite{NeonNTT} did not recognise this corrective effect of \<open>SHSUB\<close>
+and unnecessarily assumed one operand to be odd; we drop that assumption.
+The boundary case becomes a genuine off-by-one in the doubled variant of
+the next section (no \<open>SHSUB\<close>), where assuming it away is the correct fix.\<close>
+
+definition \<open>mont_mul_rounding N n T a b \<equiv>
+     (let z = \<lfloor>(2 * (a * b)) /\<^sub>\<rat> 2^n\<rceil>;
+          k = ((a * b * T) mod\<^sup>\<plusminus> 2^n);
+          c = \<lfloor>(2 * (k * N)) /\<^sub>\<rat> 2^n\<rceil>
+      in (z + c) div 2)\<close>
+
+text %internal \<open>A parity fact: under \<^term>\<open>\<bar>a\<bar> < R/2 \<and> \<bar>b\<bar> < R/2\<close> and \<^term>\<open>odd a \<and> odd b\<close>, the product
+avoids the midpoint \<^term>\<open>2^(n-1)\<close> modulo \<^term>\<open>R\<close>. Used via
+\cite[Fact~1]{NeonNTT}; our equality proof below bypasses Fact~1
+and does not consume it.\<close>
+
+lemma %internal ab_mod_not_half:
+  fixes a b :: int and n :: nat
+  assumes \<open>n \<ge> 1\<close>
+      and \<open>2 * \<bar>a\<bar> < 2^n\<close> and \<open>2 * \<bar>b\<bar> < 2^n\<close>
+      and \<open>odd a \<and> odd b\<close>
+  shows \<open>(a * b) mod 2^n \<noteq> 2^(n-1)\<close>
+proof
+  let ?R = \<open>(2::int)^n\<close>
+  let ?H = \<open>(2::int)^(n-1)\<close>
+  assume eq: \<open>(a * b) mod ?R = ?H\<close>
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using assms(1) by (cases n) auto
+  have ab_odd: \<open>odd (a * b)\<close> using assms(4) by simp
+  have ab_par: \<open>(a * b) mod 2 \<noteq> 0\<close>
+    using ab_odd by presburger
+  have H_par: \<open>?H mod 2 = 0\<close> if \<open>n \<ge> 2\<close>
+    using that by (induct n) auto
+  consider (n_eq_1) \<open>n = 1\<close> | (n_ge_2) \<open>n \<ge> 2\<close> using assms(1) by linarith
+  thus False
+  proof cases
+    case n_eq_1
+    have \<open>a = 0\<close> using assms(2) n_eq_1 by simp
+    thus False using assms(4) by simp
+  next
+    case n_ge_2
+    have \<open>(a * b) mod 2 = ?H mod 2\<close>
+      using eq by (metis dvd_imp_mod_0 mod_mod_cancel R_eq dvd_triv_left)
+    also have \<open>\<dots> = 0\<close> using H_par[OF n_ge_2] .
+    finally have \<open>(a * b) mod 2 = 0\<close> .
+    thus False using ab_par by simp
+  qed
+qed
+
+
+text \<open>Under the standard Montgomery side-conditions, Algorithm~8 computes
+exactly \<^term>\<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close> for all \<^term>\<open>a\<close>, \<^term>\<open>b\<close>. The parity assumption of \cite[Algorithm~8]{NeonNTT}
+that either \<^term>\<open>a\<close> or \<^term>\<open>b\<close> be odd is unnecessary.\<close>
+
+theorem (in StandardModulus) mont_mul_rounding_eq:
+  assumes T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  shows \<open>mont_mul_rounding N n T a b = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>(a * b * T) mod\<^sup>\<plusminus> ?R\<close>
+  let ?u = \<open>a * b + ?k * N\<close>
+  let ?z = \<open>\<lfloor>(2 * (a * b)) /\<^sub>\<rat> ?R\<rceil>\<close>
+  let ?c = \<open>\<lfloor>(2 * (?k * N)) /\<^sub>\<rat> ?R\<rceil>\<close>
+  let ?s = \<open>(2 * (a * b)) /\<^sub>\<rat> ?R\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have R_dvd_u: \<open>?R dvd ?u\<close>
+    using mont_add_signed_divisible[OF T_inv, of \<open>a * b\<close>] by simp
+  then obtain q where q: \<open>?u = ?R * q\<close> unfolding dvd_def by auto
+  have mont_eq: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b) = q\<close>
+    using mont_add_signed_unfold[OF T_inv, of \<open>a * b\<close>]
+          q R_pos by simp
+  have R_rat_nz: \<open>?R\<^sub>\<rat> \<noteq> 0\<close> by simp
+  have aux_floor: \<open>\<lfloor>- (x::rat)\<rfloor> + \<lfloor>x\<rfloor> = (if x \<in> \<int> then 0 else -1)\<close> for x
+  proof (cases \<open>x \<in> \<int>\<close>)
+    case True
+    then obtain m :: int where \<open>x = m\<^sub>\<rat>\<close> using Ints_cases by blast
+    thus ?thesis by simp
+  next
+    case False
+    hence \<open>x \<noteq> \<lfloor>x\<rfloor>\<^sub>\<rat>\<close> by (metis Ints_of_int)
+    hence \<open>\<lceil>x\<rceil> = \<lfloor>x\<rfloor> + 1\<close> by (simp add: ceiling_altdef)
+    thus ?thesis using False by (simp add: floor_minus)
+  qed
+  have round_pair: \<open>\<lfloor>s\<rceil> + \<lfloor>-s\<rceil> \<in> {0, 1}\<close> for s :: rat
+  proof -
+    let ?h = \<open>s - 1/2\<close>
+    have shf: \<open>\<lfloor>?h + 1\<^sub>\<rat>\<rfloor> = \<lfloor>?h\<rfloor> + 1\<close>
+      using floor_add_int[of ?h 1] by simp
+    have \<open>\<lfloor>s\<rceil> = \<lfloor>s + 1/2\<rfloor>\<close> by (simp add: round_def add.commute)
+    also have \<open>s + 1/2 = ?h + 1\<^sub>\<rat>\<close> by simp
+    also have \<open>\<lfloor>?h + 1\<^sub>\<rat>\<rfloor> = \<lfloor>?h\<rfloor> + 1\<close> using shf .
+    finally have rs: \<open>\<lfloor>s\<rceil> = \<lfloor>?h\<rfloor> + 1\<close> .
+    have \<open>\<lfloor>-s\<rceil> = \<lfloor>-s + 1/2\<rfloor>\<close> by (simp add: round_def add.commute)
+    also have \<open>-s + 1/2 = - ?h\<close> by simp
+    finally have rsn: \<open>\<lfloor>-s\<rceil> = \<lfloor>- ?h\<rfloor>\<close> .
+    have sum_eq: \<open>\<lfloor>s\<rceil> + \<lfloor>-s\<rceil> = \<lfloor>?h\<rfloor> + \<lfloor>- ?h\<rfloor> + 1\<close>
+      using rs rsn by simp
+    show ?thesis using sum_eq aux_floor[of ?h] by (auto split: if_splits)
+  qed
+  have q_eq_int: \<open>2 * (?k * N) = 2 * ?R * q - 2 * (a * b)\<close>
+    using q by (simp add: algebra_simps)
+  have rat_q_split: \<open>(2 * (?k * N))\<^sub>\<rat> = (2 * ?R * q)\<^sub>\<rat> - (2 * (a * b))\<^sub>\<rat>\<close>
+    using q_eq_int by (metis of_int_diff)
+  have \<open>(2 * (?k * N)) /\<^sub>\<rat> ?R = ((2 * ?R * q)\<^sub>\<rat> - (2 * (a * b))\<^sub>\<rat>) / ?R\<^sub>\<rat>\<close>
+    using rat_q_split by simp
+  also have \<open>\<dots> = (2 * ?R * q) /\<^sub>\<rat> ?R - (2 * (a * b)) /\<^sub>\<rat> ?R\<close>
+    by (simp add: diff_divide_distrib)
+  also have \<open>(2 * ?R * q) /\<^sub>\<rat> ?R = (2 * q)\<^sub>\<rat>\<close>
+    using R_rat_nz by (simp add: field_simps)
+  finally have rat_q: \<open>(2 * (?k * N)) /\<^sub>\<rat> ?R = (2 * q)\<^sub>\<rat> - ?s\<close> .
+  have c_shift: \<open>\<lfloor>(2 * q)\<^sub>\<rat> - ?s\<rceil> = 2 * q + \<lfloor>- ?s\<rceil>\<close>
+  proof -
+    have \<open>\<lfloor>(2 * q)\<^sub>\<rat> - ?s\<rceil> = \<lfloor>(2 * q)\<^sub>\<rat> - ?s + 1/2\<rfloor>\<close>
+      by (simp add: round_def)
+    also have \<open>(2 * q)\<^sub>\<rat> - ?s + 1/2 = (- ?s + 1/2) + (2 * q)\<^sub>\<rat>\<close>
+      by simp
+    also have \<open>\<lfloor>(- ?s + 1/2) + (2 * q)\<^sub>\<rat>\<rfloor> = \<lfloor>- ?s + 1/2\<rfloor> + 2 * q\<close>
+      using floor_add_int[of \<open>- ?s + 1/2\<close> \<open>2 * q\<close>] by simp
+    also have \<open>\<lfloor>- ?s + 1/2\<rfloor> = \<lfloor>- ?s\<rceil>\<close> by (simp add: round_def add.commute)
+    finally show ?thesis by simp
+  qed
+  have c_eq2: \<open>?c = 2 * q + \<lfloor>- ?s\<rceil>\<close> using rat_q c_shift by simp
+  have z_plus_c: \<open>?z + ?c = 2 * q + (\<lfloor>?s\<rceil> + \<lfloor>- ?s\<rceil>)\<close>
+    using c_eq2 by simp
+  have div_q: \<open>(?z + ?c) div 2 = q\<close>
+  proof -
+    from round_pair[of ?s]
+    consider \<open>\<lfloor>?s\<rceil> + \<lfloor>- ?s\<rceil> = 0\<close> | \<open>\<lfloor>?s\<rceil> + \<lfloor>- ?s\<rceil> = 1\<close>
+      by auto
+    thus ?thesis
+    proof cases
+      case 1 hence \<open>?z + ?c = 2 * q\<close> using z_plus_c by simp
+      thus ?thesis by simp
+    next
+      case 2 hence \<open>?z + ?c = 2 * q + 1\<close> using z_plus_c by simp
+      thus ?thesis by simp
+    qed
+  qed
+  have \<open>mont_mul_rounding N n T a b = (?z + ?c) div 2\<close>
+    unfolding mont_mul_rounding_def Let_def by simp
+  also have \<open>\<dots> = q\<close> using div_q by simp
+  also have \<open>\<dots> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close> using mont_eq by simp
+  finally show ?thesis .
+qed
+
+section \<open>Montgomery Multiplication via Rounding, no halving\<close>
+
+text \<open>A variant of Algorithm~8 that drops the trailing \<open>SHSUB\<close> (the final
+\<open>div 2\<close>) and fuses the high-half product with the correction into a single
+rounding multiply-accumulate \<open>SQRDMLAH\<close>. Without the halving step there
+is no longer a \<^term>\<open>(1/2 :: rat)\<close> to absorb the \<^term>\<open>{0,1}\<close> ambiguity at the boundary
+\<^term>\<open>(2*a*b) mod 2^n = 2^(n-1)\<close>, so we exclude this case by hypothesis.
+Under that hypothesis the kernel computes exactly
+\<^term>\<open>2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>. In implementation contexts the
+hypothesis is discharged by \<^term>\<open>odd a \<and> odd b\<close> together with the standard
+input bound \<^term>\<open>\<bar>a\<bar> < R/2 \<and> \<bar>b\<bar> < R/2\<close>, recovering the ``one factor odd''
+assumption of \cite[Algorithm~8]{NeonNTT}.\<close>
+
+definition \<open>mont_mul_rounding_doubled_int N n T a b \<equiv>
+     (let z = \<lfloor>2 * a * b /\<^sub>\<rat> 2^n\<rceil>;
+          k = a * b * T mod\<^sup>\<plusminus> 2^n;
+          c = \<lfloor>2 * k * N /\<^sub>\<rat> 2^n\<rceil>
+      in z + c)\<close>
+
+lemma %internal rat_eq_half_imp_int_eq:
+  fixes c d :: int
+  assumes \<open>d > 0\<close>
+      and \<open>c /\<^sub>\<rat> d = m\<^sub>\<rat> + 1/2\<close>
+  shows \<open>2 * c = d * (2*m + 1)\<close>
+proof -
+  have d_nz: \<open>d\<^sub>\<rat> \<noteq> 0\<close> using assms(1) by simp
+  have \<open>c\<^sub>\<rat> = (m\<^sub>\<rat> + 1/2) * d\<^sub>\<rat>\<close>
+    using assms(2) d_nz by (simp add: field_simps)
+  hence \<open>2 * c\<^sub>\<rat> = (2 * m\<^sub>\<rat> + 1) * d\<^sub>\<rat>\<close>
+    by (simp add: algebra_simps)
+  hence \<open>(2 * c)\<^sub>\<rat> = ((2*m + 1) * d)\<^sub>\<rat>\<close>
+    by (simp add: of_int_mult)
+  thus ?thesis by (metis of_int_eq_iff mult.commute)
+qed
+
+lemma %internal s_minus_half_not_int:
+  fixes a b :: int and n :: nat
+  assumes \<open>n \<ge> 1\<close>
+      and parity: \<open>2 * a * b mod 2^n \<noteq> 2^(n-1)\<close>
+  shows \<open>2 * a * b /\<^sub>\<rat> 2^n - 1/2 \<notin> \<int>\<close>
+proof
+  let ?R = \<open>(2::int)^n\<close>
+  let ?H = \<open>(2::int)^(n-1)\<close>
+  let ?s = \<open>2 * a * b /\<^sub>\<rat> ?R\<close>
+  assume \<open>?s - 1/2 \<in> \<int>\<close>
+  then obtain m :: int where m: \<open>?s - 1/2 = m\<^sub>\<rat>\<close>
+    using Ints_cases by blast
+  hence \<open>?s = m\<^sub>\<rat> + 1/2\<close> by simp
+  hence eq: \<open>2 * (2 * a * b) = ?R * (2*m + 1)\<close>
+    using rat_eq_half_imp_int_eq[of ?R \<open>2 * a * b\<close> m] by simp
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using assms(1) by (cases n) auto
+  have \<open>4 * a * b = 2 * ?H * (2*m + 1)\<close> using eq R_eq by (simp add: algebra_simps)
+  hence \<open>2 * a * b = ?H * (2*m + 1)\<close> by (simp add: algebra_simps)
+  hence \<open>2 * a * b = ?H + ?H * (2*m)\<close> by (simp add: algebra_simps)
+  hence \<open>2 * a * b = ?H + ?R * m\<close> using R_eq by (simp add: algebra_simps)
+  hence \<open>2 * a * b mod ?R = (?H + ?R * m) mod ?R\<close> by simp
+  also have \<open>\<dots> = ?H mod ?R\<close> by simp
+  also have \<open>\<dots> = ?H\<close>
+  proof -
+    have \<open>?H \<ge> 0\<close> by simp
+    have \<open>?H < ?R\<close> using R_eq by simp
+    thus ?thesis by simp
+  qed
+  finally have \<open>2 * a * b mod ?R = ?H\<close> .
+  thus False using parity by simp
+qed
+
+text \<open>The doubled-rounding kernel computes exactly twice the additive
+signed Montgomery reduction. The hypothesis
+\<^term>\<open>(2*a*b) mod 2^n \<noteq> 2^(n-1)\<close> rules out the only configuration in which the
+two \<open>SQRDMULH\<close> roundings would together contribute \<^term>\<open>2\<close> rather than \<^term>\<open>1\<close>.\<close>
+
+theorem (in StandardModulus) mont_mul_rounding_doubled_eq:
+  assumes T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+      and parity: \<open>2 * a * b mod 2^n \<noteq> 2^(n-1)\<close>
+  shows \<open>mont_mul_rounding_doubled_int N n T a b = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>a * b * T mod\<^sup>\<plusminus> ?R\<close>
+  let ?u = \<open>a * b + ?k * N\<close>
+  let ?z = \<open>\<lfloor>2 * a * b /\<^sub>\<rat> ?R\<rceil>\<close>
+  let ?c = \<open>\<lfloor>2 * ?k * N /\<^sub>\<rat> ?R\<rceil>\<close>
+  let ?s = \<open>2 * a * b /\<^sub>\<rat> ?R\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have R_dvd_u: \<open>?R dvd ?u\<close>
+    using mont_add_signed_divisible[OF T_inv, of \<open>a * b\<close>] by simp
+  then obtain q where q: \<open>?u = ?R * q\<close> unfolding dvd_def by auto
+  have mont_eq: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b) = q\<close>
+    using mont_add_signed_unfold[OF T_inv, of \<open>a * b\<close>]
+          q R_pos by simp
+  have R_rat_nz: \<open>?R\<^sub>\<rat> \<noteq> 0\<close> by simp
+  have aux_floor: \<open>\<lfloor>- (x::rat)\<rfloor> + \<lfloor>x\<rfloor> = (if x \<in> \<int> then 0 else -1)\<close> for x
+  proof (cases \<open>x \<in> \<int>\<close>)
+    case True
+    then obtain m :: int where \<open>x = m\<^sub>\<rat>\<close> using Ints_cases by blast
+    thus ?thesis by simp
+  next
+    case False
+    hence \<open>x \<noteq> \<lfloor>x\<rfloor>\<^sub>\<rat>\<close> by (metis Ints_of_int)
+    hence \<open>\<lceil>x\<rceil> = \<lfloor>x\<rfloor> + 1\<close> by (simp add: ceiling_altdef)
+    thus ?thesis using False by (simp add: floor_minus)
+  qed
+  have round_pair_zero: \<open>\<lfloor>s\<rceil> + \<lfloor>-s\<rceil> = 0\<close> if H: \<open>s - 1/2 \<notin> \<int>\<close> for s :: rat
+  proof -
+    let ?h = \<open>s - 1/2\<close>
+    have shf: \<open>\<lfloor>?h + 1\<^sub>\<rat>\<rfloor> = \<lfloor>?h\<rfloor> + 1\<close>
+      using floor_add_int[of ?h 1] by simp
+    have \<open>\<lfloor>s\<rceil> = \<lfloor>s + 1/2\<rfloor>\<close> by (simp add: round_def add.commute)
+    also have \<open>s + 1/2 = ?h + 1\<^sub>\<rat>\<close> by simp
+    also have \<open>\<lfloor>?h + 1\<^sub>\<rat>\<rfloor> = \<lfloor>?h\<rfloor> + 1\<close> using shf .
+    finally have rs: \<open>\<lfloor>s\<rceil> = \<lfloor>?h\<rfloor> + 1\<close> .
+    have \<open>\<lfloor>-s\<rceil> = \<lfloor>-s + 1/2\<rfloor>\<close> by (simp add: round_def add.commute)
+    also have \<open>-s + 1/2 = - ?h\<close> by simp
+    finally have rsn: \<open>\<lfloor>-s\<rceil> = \<lfloor>- ?h\<rfloor>\<close> .
+    have sum_eq: \<open>\<lfloor>s\<rceil> + \<lfloor>-s\<rceil> = \<lfloor>?h\<rfloor> + \<lfloor>- ?h\<rfloor> + 1\<close>
+      using rs rsn by simp
+    show ?thesis using sum_eq aux_floor[of ?h] H by simp
+  qed
+  have q_eq_int: \<open>2 * ?k * N = 2 * ?R * q - 2 * a * b\<close>
+    using q by (simp add: algebra_simps)
+  have rat_q_split: \<open>(2 * ?k * N)\<^sub>\<rat> = (2 * ?R * q)\<^sub>\<rat> - (2 * a * b)\<^sub>\<rat>\<close>
+    using q_eq_int by (metis of_int_diff)
+  have \<open>2 * ?k * N /\<^sub>\<rat> ?R = ((2 * ?R * q)\<^sub>\<rat> - (2 * a * b)\<^sub>\<rat>) / ?R\<^sub>\<rat>\<close>
+    using rat_q_split by simp
+  also have \<open>\<dots> = 2 * ?R * q /\<^sub>\<rat> ?R - 2 * a * b /\<^sub>\<rat> ?R\<close>
+    by (simp add: diff_divide_distrib)
+  also have \<open>2 * ?R * q /\<^sub>\<rat> ?R = (2 * q)\<^sub>\<rat>\<close>
+    using R_rat_nz by (simp add: field_simps)
+  finally have rat_q: \<open>2 * ?k * N /\<^sub>\<rat> ?R = (2 * q)\<^sub>\<rat> - ?s\<close> .
+  have c_shift: \<open>\<lfloor>(2 * q)\<^sub>\<rat> - ?s\<rceil> = 2 * q + \<lfloor>- ?s\<rceil>\<close>
+  proof -
+    have \<open>\<lfloor>(2 * q)\<^sub>\<rat> - ?s\<rceil> = \<lfloor>(2 * q)\<^sub>\<rat> - ?s + 1/2\<rfloor>\<close>
+      by (simp add: round_def)
+    also have \<open>(2 * q)\<^sub>\<rat> - ?s + 1/2 = (- ?s + 1/2) + (2 * q)\<^sub>\<rat>\<close>
+      by simp
+    also have \<open>\<lfloor>(- ?s + 1/2) + (2 * q)\<^sub>\<rat>\<rfloor> = \<lfloor>- ?s + 1/2\<rfloor> + 2 * q\<close>
+      using floor_add_int[of \<open>- ?s + 1/2\<close> \<open>2 * q\<close>] by simp
+    also have \<open>\<lfloor>- ?s + 1/2\<rfloor> = \<lfloor>- ?s\<rceil>\<close> by (simp add: round_def add.commute)
+    finally show ?thesis by simp
+  qed
+  have c_eq2: \<open>?c = 2 * q + \<lfloor>- ?s\<rceil>\<close> using rat_q c_shift by simp
+  have z_plus_c: \<open>?z + ?c = 2 * q + (\<lfloor>?s\<rceil> + \<lfloor>- ?s\<rceil>)\<close>
+    using c_eq2 by simp
+  have n_ge_1: \<open>n \<ge> 1\<close> using npos by simp
+  have h_not_int: \<open>?s - 1/2 \<notin> \<int>\<close>
+    using s_minus_half_not_int[OF n_ge_1 parity] .
+  have round_zero: \<open>\<lfloor>?s\<rceil> + \<lfloor>- ?s\<rceil> = 0\<close>
+    using round_pair_zero[OF h_not_int] .
+  have main: \<open>?z + ?c = 2 * q\<close> using z_plus_c round_zero by simp
+  have \<open>mont_mul_rounding_doubled_int N n T a b = ?z + ?c\<close>
+    unfolding mont_mul_rounding_doubled_int_def Let_def by simp
+  also have \<open>\<dots> = 2 * q\<close> using main .
+  also have \<open>\<dots> = 2 * mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b)\<close> using mont_eq by simp
+  finally show ?thesis .
+qed
+
+end
+

--- a/proofs/isabelle/neon_ntt/Montgomery_Reduction.thy
+++ b/proofs/isabelle/neon_ntt/Montgomery_Reduction.thy
@@ -1,0 +1,1487 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Montgomery_Reduction
+  imports Integer_Approximation "HOL-Number_Theory.Cong"
+begin
+
+chapter \<open>Montgomery reduction and multiplication \label{ch:montgomery_red}\<close>
+
+text \<open>In this chapter, we discuss Montgomery reduction and Montgomery multiplication
+along the lines of \cite{NeonNTT} and establish their correctness
+and bounds. The idea of Montgomery reduction is to replace an expensive division
+by \<^term>\<open>N\<close> with a division by \<^term>\<open>R = 2^n\<close>, by efficiently adjusting a representative
+of \<^term>\<open>z mod N\<close> to become divisible by \<^term>\<open>2^n\<close>.\<close>
+
+section %internal \<open>Modular inverse\<close>
+
+text %internal \<open>We introduce \<open>N\<^sup>-\<^sup>1 mod 2^n\<close>, the canonical unsigned representative of
+\<open>N\<^sup>-\<^sup>1\<close> in \<open>[0, 2^n)\<close>, so abstract theorems depend only on \<open>(N, n)\<close>. The
+negated inverse \<open>-N\<^sup>-\<^sup>1\<close> for the additive variants is \<open>(- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>.\<close>
+
+definition %internal mod_inverse :: \<open>int \<Rightarrow> int \<Rightarrow> int\<close> ("_\<^sup>-\<^sup>1 mod _" [79, 79] 79) where
+  \<open>N\<^sup>-\<^sup>1 mod R \<equiv> THE T. 0 \<le> T \<and> T < R \<and> (N * T) mod R = 1 mod R\<close>
+
+lemma %internal mod_inverse_unique:
+  fixes N :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>odd N\<close>
+  shows \<open>\<exists>!T. 0 \<le> T \<and> T < 2^n \<and> (N * T) mod 2^n = 1 mod 2^n\<close>
+proof -
+  let ?m = \<open>(2::int)^n\<close>
+  have copr: \<open>coprime N ?m\<close>
+    using assms(2) by (simp add: coprime_power_right_iff)
+  obtain x where x: \<open>[N * x = 1] (mod ?m)\<close>
+    using cong_solve_coprime_int[OF copr] by blast
+  obtain T where T: \<open>0 \<le> T\<close> \<open>T < ?m\<close> \<open>[x = T] (mod ?m)\<close>
+    using cong_less_unique_int[of ?m x] by auto
+  have T_eq: \<open>(N * T) mod ?m = 1 mod ?m\<close>
+    using x T(3) unfolding cong_def by (metis mod_mult_right_eq)
+  show ?thesis
+  proof (rule ex1I[of _ T])
+    show \<open>0 \<le> T \<and> T < ?m \<and> (N * T) mod ?m = 1 mod ?m\<close> using T T_eq by simp
+  next
+    fix T'
+    assume H: \<open>0 \<le> T' \<and> T' < ?m \<and> (N * T') mod ?m = 1 mod ?m\<close>
+    have \<open>[N * T = N * T'] (mod ?m)\<close> using T_eq H unfolding cong_def by simp
+    hence \<open>[T = T'] (mod ?m)\<close> using cong_mult_lcancel[OF copr] by simp
+    thus \<open>T' = T\<close>
+      using cong_less_imp_eq_int[of T' ?m T] T H by (simp add: cong_sym)
+  qed
+qed
+
+text %internal \<open>Downstream arguments use \<open>mod_inverse_correct\<close> with the substitution lemmas
+below, which swap in any explicit \<open>T\<close> satisfying
+\<^latex>\<open>$N \cdot T \equiv \pm 1 \pmod{R}$\<close>.\<close>
+
+lemma %internal mod_inverse_correct:
+  fixes N :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>odd N\<close>
+  shows \<open>0 \<le> N\<^sup>-\<^sup>1 mod 2^n\<close>
+    and \<open>N\<^sup>-\<^sup>1 mod 2^n < 2^n\<close>
+    and \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+proof -
+  let ?P = \<open>\<lambda>T. 0 \<le> T \<and> T < 2^n \<and> (N * T) mod 2^n = 1 mod 2^n\<close>
+  have \<open>\<exists>!T. ?P T\<close> using mod_inverse_unique[OF assms] .
+  hence h: \<open>?P (N\<^sup>-\<^sup>1 mod 2^n)\<close>
+    unfolding mod_inverse_def using theI'[of ?P] by blast
+  show \<open>0 \<le> N\<^sup>-\<^sup>1 mod 2^n\<close> using h by simp
+  show \<open>(N\<^sup>-\<^sup>1 mod 2^n) < 2^n\<close> using h by simp
+  show \<open>(N * N\<^sup>-\<^sup>1 mod 2^n) mod 2^n = 1 mod 2^n\<close> using h by simp
+qed
+
+lemma %internal mod_inverse_idem [simp]:
+  assumes \<open>n > 0\<close> and \<open>odd N\<close>
+  shows \<open>(N\<^sup>-\<^sup>1 mod 2^n) mod 2^n = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  using mod_inverse_correct(1)[OF assms] mod_inverse_correct(2)[OF assms]
+  by simp
+
+lemma %internal mod_inverse_neg_idem [simp]:
+  assumes \<open>n > 0\<close> and \<open>odd N\<close>
+  shows \<open>((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n) mod 2^n = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  by (simp add: mod_mod_trivial)
+
+text %internal \<open>Both reductions are invariant under replacing \<^term>\<open>T\<close> by a congruent representative
+mod \<^term>\<open>2^n\<close>, since \<^term>\<open>round\<close> and \<^term>\<open>floor\<close> are shift-compatible (\autoref{ch:integer_approx}).\<close>
+
+lemma %internal mod_approx_smod_cong:
+  fixes z T1 T2 :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>T1 mod 2^n = T2 mod 2^n\<close>
+  shows \<open>(z * T1) mod\<^sup>\<plusminus> 2^n = (z * T2) mod\<^sup>\<plusminus> 2^n\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have eq: \<open>(z * T1) mod ?R = (z * T2) mod ?R\<close>
+    using assms(2) by (metis mod_mult_right_eq)
+  hence dvd: \<open>?R dvd (z * T1 - z * T2)\<close>
+    by (simp add: mod_eq_dvd_iff)
+  then obtain k where k_eq: \<open>z * T1 - z * T2 = ?R * k\<close>
+    using dvd_def by blast
+  hence k_eq': \<open>z * T1 = z * T2 + ?R * k\<close> by linarith
+  have \<open>(z * T1) mod\<^sup>\<plusminus> ?R = (z * T2 + ?R * k) mod\<^sup>\<plusminus> ?R\<close>
+    using k_eq' by simp
+  also have \<open>\<dots> = (z * T2) mod\<^sup>\<plusminus> ?R\<close>
+    using mod_approx_shift[OF shift_compat_round R_pos, of \<open>z*T2\<close> k] .
+  finally show ?thesis .
+qed
+
+lemma %internal mod_approx_umod_cong:
+  fixes z T1 T2 :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>T1 mod 2^n = T2 mod 2^n\<close>
+  shows \<open>(z * T1) mod\<^sup>+ 2^n = (z * T2) mod\<^sup>+ 2^n\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have eq: \<open>(z * T1) mod ?R = (z * T2) mod ?R\<close>
+    using assms(2) by (metis mod_mult_right_eq)
+  hence dvd: \<open>?R dvd (z * T1 - z * T2)\<close>
+    by (simp add: mod_eq_dvd_iff)
+  then obtain k where k_eq: \<open>z * T1 - z * T2 = ?R * k\<close>
+    using dvd_def by blast
+  hence k_eq': \<open>z * T1 = z * T2 + ?R * k\<close> by linarith
+  have \<open>(z * T1) mod\<^sup>+ ?R = (z * T2 + ?R * k) mod\<^sup>+ ?R\<close>
+    using k_eq' by simp
+  also have \<open>\<dots> = (z * T2) mod\<^sup>+ ?R\<close>
+    using mod_approx_shift[OF shift_compat_floor R_pos, of \<open>z*T2\<close> k] .
+  finally show ?thesis .
+qed
+
+lemma %internal mod_inverse_alt:
+  fixes N T :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>odd N\<close> and \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>T mod 2^n = N\<^sup>-\<^sup>1 mod 2^n\<close>
+proof -
+  have copr: \<open>coprime N ((2::int)^n)\<close>
+    using \<open>odd N\<close> by (simp add: coprime_power_right_iff)
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+    using mod_inverse_correct(3)[OF assms(1) assms(2)] .
+  have \<open>[N * T = N * (N\<^sup>-\<^sup>1 mod 2^n)] (mod 2^n)\<close>
+    using assms(3) inv unfolding cong_def by simp
+  hence \<open>[T = N\<^sup>-\<^sup>1 mod 2^n] (mod 2^n)\<close>
+    using cong_mult_lcancel[OF copr, of T \<open>N\<^sup>-\<^sup>1 mod 2^n\<close>] by simp
+  hence \<open>T mod 2^n = (N\<^sup>-\<^sup>1 mod 2^n) mod 2^n\<close>
+    unfolding cong_def .
+  also have \<open>(N\<^sup>-\<^sup>1 mod 2^n) mod 2^n = N\<^sup>-\<^sup>1 mod 2^n\<close>
+    using mod_inverse_correct(1)[OF assms(1) assms(2)]
+          mod_inverse_correct(2)[OF assms(1) assms(2)]
+    by simp
+  finally show ?thesis .
+qed
+
+lemma %internal mod_inverse_neg_alt:
+  fixes N T :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>odd N\<close> and \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  shows \<open>T mod 2^n = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+proof -
+  have copr: \<open>coprime N ((2::int)^n)\<close>
+    using \<open>odd N\<close> by (simp add: coprime_power_right_iff)
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+    using mod_inverse_correct(3)[OF assms(1) assms(2)] .
+  have ne: \<open>(N * (- (N\<^sup>-\<^sup>1 mod 2^n))) mod 2^n = (- 1) mod 2^n\<close>
+    using inv by (metis mod_minus_eq mult_minus_right)
+  have \<open>[N * T = N * (- (N\<^sup>-\<^sup>1 mod 2^n))] (mod 2^n)\<close>
+    using assms(3) ne unfolding cong_def by simp
+  hence \<open>[T = - (N\<^sup>-\<^sup>1 mod 2^n)] (mod 2^n)\<close>
+    using cong_mult_lcancel[OF copr, of T \<open>- (N\<^sup>-\<^sup>1 mod 2^n)\<close>] by simp
+  thus ?thesis unfolding cong_def by simp
+qed
+
+text \<open>Inside \<^locale>\<open>StandardModulus\<close>, the side conditions
+\<^term>\<open>n > 0\<close> and \<^term>\<open>odd N\<close> are inherited from the locale, and the
+modulus \<^term>\<open>2^n\<close> is exposed as the abbreviation \<^term>\<open>R\<close>.\<close>
+
+lemma %internal (in StandardModulus) mod_inverse_correct [simp]:
+  shows \<open>0 \<le> N\<^sup>-\<^sup>1 mod R\<close>
+    and \<open>N\<^sup>-\<^sup>1 mod R < R\<close>
+    and \<open>(N * (N\<^sup>-\<^sup>1 mod R)) mod R = 1 mod R\<close>
+  using mod_inverse_correct[OF npos Nodd] by simp_all
+
+lemma %internal (in StandardModulus) mod_inverse_neg_correct:
+  \<open>(N * ((- (N\<^sup>-\<^sup>1 mod R)) mod R)) mod R = (- 1) mod R\<close>
+  using mod_inverse_correct(3)
+  by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+
+section \<open>Montgomery reduction\<close>
+
+text \<open>Following \cite[\S2.4.2, Algorithm~2]{NeonNTT}, we formalise Montgomery
+reduction along two independent axes: \emph{additive} vs \emph{subtractive}
+(\<^term>\<open>T = N\<^sup>-\<^sup>1 mod R\<close> with \<^term>\<open>z - k*N\<close>, or \<^term>\<open>T = -N\<^sup>-\<^sup>1 mod R\<close> with \<^term>\<open>z + k*N\<close>), and
+\emph{signed} (\<open>\<^sup>\<plusminus>\<close>) vs \emph{unsigned} (\<open>\<^sup>+\<close>) twist for the inner residue
+\<^term>\<open>k = (z*T) mod R\<close>. Each reduction maps \<^term>\<open>z\<close> to a representative of \<open>z\<sqdot>R\<^sup>-\<^sup>1\<close> in \<open>\<int>\<^sub>N\<close>,
+where \<^term>\<open>R = 2^n\<close>; the canonical inverse \<open>\<plusminus>N\<^sup>-\<^sup>1\<close> is supplied via the notation \<^term>\<open>N\<^sup>-\<^sup>1 mod 2^n\<close>.\<close>
+
+definition mont_sub_signed (\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>_,_\<rbrakk>\<close>) where
+  \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z \<equiv> (z - ((z * (N\<^sup>-\<^sup>1 mod 2^n)) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+
+definition mont_add_signed (\<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>_,_\<rbrakk>\<close>) where
+  \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z \<equiv> (z + ((z * (- (N\<^sup>-\<^sup>1 mod 2^n) mod 2^n)) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+
+definition mont_add_unsigned (\<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>_,_\<rbrakk>\<close>) where
+  \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z \<equiv> (z + ((z * (- (N\<^sup>-\<^sup>1 mod 2^n) mod 2^n)) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+
+definition mont_sub_unsigned (\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+ \<lbrakk>_,_\<rbrakk>\<close>) where
+  \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z \<equiv> (z - ((z * (N\<^sup>-\<^sup>1 mod 2^n)) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+
+subsection %internal \<open>Computational expressions\<close>
+
+text %internal \<open>Each operator equals the same expression with any \<^latex>\<open>$T \equiv \pm N^{-1} \pmod{R}$\<close>
+substituted for the canonical \<^term>\<open>N\<^sup>-\<^sup>1 mod 2^n\<close>; downstream reasoning uses this
+user-supplied \<^term>\<open>T\<close>.\<close>
+
+lemma %internal (in StandardModulus) mont_unfold:
+  shows mont_sub_signed_unfold:
+    \<open>(N * T) mod 2^n = 1 mod 2^n
+       \<Longrightarrow> mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+  and mont_add_signed_unfold:
+    \<open>(N * T) mod 2^n = (- 1) mod 2^n
+       \<Longrightarrow> mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+  and mont_add_unsigned_unfold:
+    \<open>(N * T) mod 2^n = (- 1) mod 2^n
+       \<Longrightarrow> mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+  and mont_sub_unsigned_unfold:
+    \<open>(N * T) mod 2^n = 1 mod 2^n
+       \<Longrightarrow> mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+proof -
+  let ?Tpos = \<open>N\<^sup>-\<^sup>1 mod 2^n\<close>
+  let ?Tneg = \<open>(- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  show \<open>(N * T) mod 2^n = 1 mod 2^n
+          \<Longrightarrow> mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+  proof -
+    assume T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+    have \<open>T mod 2^n = ?Tpos mod 2^n\<close>
+      using mod_inverse_alt[OF npos Nodd T_inv]
+            mod_inverse_idem[OF npos Nodd] by simp
+    hence \<open>(z * T) mod\<^sup>\<plusminus> 2^n = (z * ?Tpos) mod\<^sup>\<plusminus> 2^n\<close>
+      using mod_approx_smod_cong[OF npos, of T ?Tpos z] by simp
+    thus ?thesis unfolding mont_sub_signed_def by simp
+  qed
+  show \<open>(N * T) mod 2^n = (- 1) mod 2^n
+          \<Longrightarrow> mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+  proof -
+    assume T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+    have \<open>T mod 2^n = ?Tneg mod 2^n\<close>
+      using mod_inverse_neg_alt[OF npos Nodd T_inv] by simp
+    hence \<open>(z * T) mod\<^sup>\<plusminus> 2^n = (z * ?Tneg) mod\<^sup>\<plusminus> 2^n\<close>
+      using mod_approx_smod_cong[OF npos, of T ?Tneg z] by simp
+    thus ?thesis unfolding mont_add_signed_def by simp
+  qed
+  show \<open>(N * T) mod 2^n = (- 1) mod 2^n
+          \<Longrightarrow> mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+  proof -
+    assume T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+    have \<open>T mod 2^n = ?Tneg mod 2^n\<close>
+      using mod_inverse_neg_alt[OF npos Nodd T_inv] by simp
+    hence \<open>(z * T) mod\<^sup>+ 2^n = (z * ?Tneg) mod\<^sup>+ 2^n\<close>
+      using mod_approx_umod_cong[OF npos, of T ?Tneg z] by simp
+    thus ?thesis unfolding mont_add_unsigned_def by simp
+  qed
+  show \<open>(N * T) mod 2^n = 1 mod 2^n
+          \<Longrightarrow> mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+  proof -
+    assume T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+    have \<open>T mod 2^n = ?Tpos mod 2^n\<close>
+      using mod_inverse_alt[OF npos Nodd T_inv]
+            mod_inverse_idem[OF npos Nodd] by simp
+    hence \<open>(z * T) mod\<^sup>+ 2^n = (z * ?Tpos) mod\<^sup>+ 2^n\<close>
+      using mod_approx_umod_cong[OF npos, of T ?Tpos z] by simp
+    thus ?thesis unfolding mont_sub_unsigned_def by simp
+  qed
+qed
+
+text \<open>The signed additive and subtractive Montgomery operators agree except
+at the boundary case \<^term>\<open>(z * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 2^(n-1)\<close>, where they
+differ by exactly \<^term>\<open>N\<close> \cite[\S2.4.2]{NeonNTT}.\<close>
+
+text %internal \<open>Auxiliary lemma: under \<^term>\<open>odd N\<close> and \<^term>\<open>n \<ge> 1\<close>, the boundary condition
+\<^term>\<open>(z * T) mod R = 2^(n-1)\<close> (where \<^term>\<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close> and \<^term>\<open>R = 2^n\<close>) is
+equivalent to the simpler condition \<^term>\<open>z mod R = 2^(n-1)\<close>. This holds because
+\<^term>\<open>T\<close> is odd (since \<^term>\<open>(N * T) mod R = 1 mod R\<close> with \<^term>\<open>R\<close> even forces \<^term>\<open>T\<close> odd) and
+\<^term>\<open>(2^(n-1) * m) mod 2^n = 2^(n-1)\<close> for any odd \<^term>\<open>m\<close>.\<close>
+
+lemma %internal (in StandardModulus) exceptional_iff:
+  shows \<open>((z * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 2^(n-1)) \<longleftrightarrow> (z mod 2^n = 2^(n-1))\<close>
+proof -
+  define T where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  have n_pos: \<open>n > 0\<close> using npos by simp
+  have R_ge_2: \<open>(2::int)^n \<ge> 2\<close> using n_pos by (simp add: self_le_power)
+  have NT': \<open>(N * T) mod 2^n = 1\<close> unfolding T_def using R_ge_2 n_pos Nodd by simp
+  have R_even: \<open>even ((2::int)^n)\<close> using n_pos by auto
+  have key: \<open>\<And>m::int. odd m \<Longrightarrow> (2^(n-1) * m) mod 2^n = 2^(n-1)\<close>
+  proof -
+    fix m::int assume \<open>odd m\<close>
+    then obtain k where k: \<open>m = 2*k + 1\<close> using oddE by blast
+    have R_half: \<open>(2::int)^(n-1) * 2 = 2^n\<close>
+      using n_pos by (metis One_nat_def Suc_pred power_Suc2)
+    have lt: \<open>(2::int)^(n-1) < 2^n\<close> using R_half by (smt (verit) zero_less_power)
+    have eq: \<open>2^(n-1) * m = 2^n * k + 2^(n-1)\<close>
+      using k R_half by (simp add: algebra_simps)
+    show \<open>2^(n-1) * m mod 2^n = 2^(n-1)\<close> using eq lt by simp
+  qed
+  have NTodd: \<open>odd (N * T)\<close>
+    using NT' R_even by (metis div_mult_mod_eq even_add even_mult_iff odd_one)
+  hence T_odd: \<open>odd T\<close> by simp
+  show ?thesis
+  proof
+    assume \<open>(z * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 2^(n-1)\<close>
+    hence H: \<open>(z * T) mod 2^n = 2^(n-1)\<close> unfolding T_def .
+    have \<open>z mod 2^n = (z * (N * T)) mod 2^n\<close>
+      using NT' by (metis mod_mult_right_eq mult.right_neutral)
+    also have \<open>\<dots> = (((z * T) mod 2^n) * N) mod 2^n\<close>
+      by (metis mod_mult_left_eq mult.assoc mult.commute)
+    also have \<open>\<dots> = (2^(n-1) * N) mod 2^n\<close> using H by simp
+    also have \<open>\<dots> = 2^(n-1)\<close> using key[OF Nodd] by simp
+    finally show \<open>z mod 2^n = 2^(n-1)\<close> .
+  next
+    assume \<open>z mod 2^n = 2^(n-1)\<close>
+    hence \<open>(z * T) mod 2^n = (2^(n-1) * T) mod 2^n\<close>
+      by (metis mod_mult_left_eq mult.commute)
+    also have \<open>\<dots> = 2^(n-1)\<close> using key[OF T_odd] .
+    finally show \<open>(z * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 2^(n-1)\<close> unfolding T_def .
+  qed
+qed
+
+lemma (in StandardModulus) mont_sub_eq_add_signed_generic:
+  assumes \<open>z mod 2^n \<noteq> 2^(n-1)\<close>
+  shows \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<close>
+proof -
+  define T_pos where \<open>T_pos = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  have n_ge_1: \<open>n \<ge> 1\<close> using npos by simp
+  have T_pos_inv: \<open>(N * T_pos) mod 2^n = 1 mod 2^n\<close>
+    unfolding T_pos_def using mod_inverse_correct(3) .
+  have T_neg_inv: \<open>(N * (- T_pos)) mod 2^n = (- 1) mod 2^n\<close>
+    using T_pos_inv by (metis mod_minus_eq mult_minus_right)
+  have z_T_ne: \<open>(z * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n \<noteq> 2^(n-1)\<close>
+    using exceptional_iff[of z] assms by blast
+  have neg: \<open>(z * (- T_pos)) mod\<^sup>\<plusminus> 2^n = - ((z * T_pos) mod\<^sup>\<plusminus> 2^n)\<close>
+    using mod_signed_negate_generic[OF n_ge_1] z_T_ne
+    unfolding T_pos_def
+    by (simp add: algebra_simps)
+  have lhs: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - ((z * T_pos) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+    using mont_sub_signed_unfold[OF T_pos_inv, of z] .
+  have rhs: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + ((z * (- T_pos)) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+    using mont_add_signed_unfold[OF T_neg_inv, of z] .
+  have \<open>(z + ((z * (- T_pos)) mod\<^sup>\<plusminus> 2^n) * N) div 2^n
+        = (z + (- ((z * T_pos) mod\<^sup>\<plusminus> 2^n)) * N) div 2^n\<close>
+    using neg by simp
+  also have \<open>\<dots> = (z - ((z * T_pos) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+    by (simp add: algebra_simps)
+  finally show ?thesis using lhs rhs by simp
+qed
+
+lemma (in StandardModulus) mont_sub_eq_add_signed_exceptional:
+  assumes \<open>z mod 2^n = 2^(n-1)\<close>
+  shows \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z - N\<close>
+proof -
+  define R where \<open>R = (2::int)^n\<close>
+  define T where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  have R_nz: \<open>R \<noteq> 0\<close> unfolding R_def by simp
+  have T_inv: \<open>(N * T) mod R = 1 mod R\<close>
+    unfolding T_def R_def using mod_inverse_correct(3) .
+  have T_neg: \<open>(N * (- T)) mod R = (- 1) mod R\<close>
+    using T_inv by (metis mod_minus_eq mult_minus_right)
+  have neg: \<open>(z * (- T)) mod\<^sup>\<plusminus> R = - ((z * T) mod\<^sup>\<plusminus> R) - R\<close>
+    using mod_signed_negate_exceptional[of n] exceptional_iff[of z] assms npos
+    unfolding R_def T_def by (simp add: algebra_simps)
+  have lhs: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>\<plusminus> R) * N) div R\<close>
+    using mont_sub_signed_unfold[OF T_inv[unfolded R_def], of z] unfolding R_def by simp
+  have rhs: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + ((z * (- T)) mod\<^sup>\<plusminus> R) * N) div R\<close>
+    using mont_add_signed_unfold[OF T_neg[unfolded R_def], of z] unfolding R_def by simp
+  have \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = ((z - ((z * T) mod\<^sup>\<plusminus> R) * N) + (- N) * R) div R\<close>
+    unfolding rhs neg by (simp add: algebra_simps)
+  also have \<open>\<dots> = (- N) + (z - ((z * T) mod\<^sup>\<plusminus> R) * N) div R\<close>
+    using R_nz by (rule div_mult_self1)
+  finally show ?thesis using lhs by simp
+qed
+
+subsection \<open>Correctness and Absolute Bounds\<close>
+
+text \<open>Each of the four Montgomery reduction variants is correct and bounded by
+\<^term>\<open>\<bar>z\<bar>/R + N/2\<close> (signed) or \<^term>\<open>\<bar>z\<bar>/R + N\<close> (unsigned).\<close>
+
+text %internal \<open>\textbf{Additive signed.} Twist \<^latex>\<open>$T \equiv -N^{-1} \pmod{R}$\<close>; we prove divisibility, then correctness.\<close>
+
+lemma %internal mont_add_signed_divisible:
+  assumes \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  shows \<open>2^n dvd (z + ((z * T) mod\<^sup>\<plusminus> 2^n) * N)\<close>
+proof -
+  have aux: \<open>(z * T - 2 ^ n * \<lfloor>(z*T) /\<^sub>\<rat> (2 ^ n)\<rceil>) mod 2 ^ n = (z * T) mod 2 ^ n\<close>
+  proof -
+    have \<open>2 ^ n * \<lfloor>(z*T) /\<^sub>\<rat> (2 ^ n)\<rceil> mod 2^n = 0\<close> by simp
+    thus ?thesis
+      using mod_diff_right_eq[of \<open>z*T\<close> \<open>2^n * \<lfloor>(z*T) /\<^sub>\<rat> (2 ^ n)\<rceil>\<close> \<open>2^n\<close>]
+      by simp
+  qed
+  have smod_mod: \<open>((z * T) mod\<^sup>\<plusminus> 2^n) mod 2^n = (z * T) mod 2^n\<close>
+    using aux unfolding mod_approx_def by simp
+  have \<open>(((z * T) mod\<^sup>\<plusminus> 2^n) * N) mod 2^n = (z * ((N * T) mod 2^n)) mod 2^n\<close>
+    using smod_mod
+    by (metis mod_mult_left_eq mod_mult_right_eq mult.commute mult.left_commute)
+  also have \<open>\<dots> = (z * ((-1) mod 2^n)) mod 2^n\<close> using assms by simp
+  also have \<open>\<dots> = (-z) mod 2^n\<close>
+    by (metis mod_mult_right_eq mult_minus1_right)
+  finally have chain: \<open>(((z*T) mod\<^sup>\<plusminus> 2^n) * N) mod 2^n = (-z) mod 2^n\<close> .
+  have \<open>(z + ((z*T) mod\<^sup>\<plusminus> 2^n) * N) mod 2^n = (z + (-z)) mod 2^n\<close>
+    using chain by (metis mod_add_right_eq)
+  thus ?thesis by (simp add: mod_eq_0_iff_dvd)
+qed
+
+text %internal \<open>\textbf{Subtractive signed.} Twist \<^latex>\<open>$T \equiv N^{-1} \pmod{R}$\<close>; the sign of the correction flips.\<close>
+
+lemma %internal mont_sub_signed_divisible:
+  assumes \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>2^n dvd (z - ((z * T) mod\<^sup>\<plusminus> 2^n) * N)\<close>
+proof -
+  have aux: \<open>(z * T - 2 ^ n * \<lfloor>(z*T) /\<^sub>\<rat> (2 ^ n)\<rceil>) mod 2 ^ n = (z * T) mod 2 ^ n\<close>
+  proof -
+    have \<open>2 ^ n * \<lfloor>(z*T) /\<^sub>\<rat> (2 ^ n)\<rceil> mod 2^n = 0\<close> by simp
+    thus ?thesis
+      using mod_diff_right_eq[of \<open>z*T\<close> \<open>2^n * \<lfloor>(z*T) /\<^sub>\<rat> (2 ^ n)\<rceil>\<close> \<open>2^n\<close>]
+      by simp
+  qed
+  have smod_mod: \<open>((z * T) mod\<^sup>\<plusminus> 2^n) mod 2^n = (z * T) mod 2^n\<close>
+    using aux unfolding mod_approx_def by simp
+  have \<open>(((z * T) mod\<^sup>\<plusminus> 2^n) * N) mod 2^n = (z * ((N * T) mod 2^n)) mod 2^n\<close>
+    using smod_mod
+    by (metis mod_mult_left_eq mod_mult_right_eq mult.commute mult.left_commute)
+  also have \<open>\<dots> = (z * (1 mod 2^n)) mod 2^n\<close> using assms by simp
+  also have \<open>\<dots> = z mod 2^n\<close>
+    by (metis mod_mult_right_eq mult.right_neutral)
+  finally have chain: \<open>(((z*T) mod\<^sup>\<plusminus> 2^n) * N) mod 2^n = z mod 2^n\<close> .
+  have \<open>(z - ((z*T) mod\<^sup>\<plusminus> 2^n) * N) mod 2^n = (z - z) mod 2^n\<close>
+    using chain by (metis mod_diff_right_eq)
+  thus ?thesis by (simp add: mod_eq_0_iff_dvd)
+qed
+
+text %internal \<open>\textbf{Additive unsigned.} Same shape as additive signed, with \<open>mod\<^sup>+\<close> for the inner residue.\<close>
+
+lemma %internal mont_add_unsigned_divisible:
+  assumes \<open>n > 0\<close> and \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  shows \<open>2^n dvd (z + ((z * T) mod\<^sup>+ 2^n) * N)\<close>
+proof -
+  have R_pos: \<open>((2::int)^n) > 0\<close> using assms(1) by simp
+  have umod_mod: \<open>((z * T) mod\<^sup>+ 2^n) mod 2^n = (z * T) mod 2^n\<close>
+    using mod_unsigned_eq_mod[OF R_pos] R_pos by simp
+  have \<open>(((z * T) mod\<^sup>+ 2^n) * N) mod 2^n = (z * ((N * T) mod 2^n)) mod 2^n\<close>
+    using umod_mod
+    by (metis mod_mult_left_eq mod_mult_right_eq mult.commute mult.left_commute)
+  also have \<open>\<dots> = (z * ((-1) mod 2^n)) mod 2^n\<close> using assms(2) by simp
+  also have \<open>\<dots> = (-z) mod 2^n\<close>
+    by (metis mod_mult_right_eq mult_minus1_right)
+  finally have chain: \<open>(((z*T) mod\<^sup>+ 2^n) * N) mod 2^n = (-z) mod 2^n\<close> .
+  have \<open>(z + ((z*T) mod\<^sup>+ 2^n) * N) mod 2^n = (z + (-z)) mod 2^n\<close>
+    using chain by (metis mod_add_right_eq)
+  thus ?thesis by (simp add: mod_eq_0_iff_dvd)
+qed
+
+text %internal \<open>\textbf{Subtractive unsigned.} Twist \<^latex>\<open>$T \equiv N^{-1} \pmod{R}$\<close> with \<open>mod\<^sup>+\<close> for the inner residue.\<close>
+
+lemma %internal mont_sub_unsigned_divisible:
+  assumes \<open>n > 0\<close> and \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>2^n dvd (z - ((z * T) mod\<^sup>+ 2^n) * N)\<close>
+proof -
+  have R_pos: \<open>((2::int)^n) > 0\<close> using assms(1) by simp
+  have umod_mod: \<open>((z * T) mod\<^sup>+ 2^n) mod 2^n = (z * T) mod 2^n\<close>
+    using mod_unsigned_eq_mod[OF R_pos] R_pos by simp
+  have \<open>(((z * T) mod\<^sup>+ 2^n) * N) mod 2^n = (z * ((N * T) mod 2^n)) mod 2^n\<close>
+    using umod_mod
+    by (metis mod_mult_left_eq mod_mult_right_eq mult.commute mult.left_commute)
+  also have \<open>\<dots> = (z * (1 mod 2^n)) mod 2^n\<close> using assms(2) by simp
+  also have \<open>\<dots> = z mod 2^n\<close>
+    by (metis mod_mult_right_eq mult.right_neutral)
+  finally have chain: \<open>(((z*T) mod\<^sup>+ 2^n) * N) mod 2^n = z mod 2^n\<close> .
+  have \<open>(z - ((z*T) mod\<^sup>+ 2^n) * N) mod 2^n = (z - z) mod 2^n\<close>
+    using chain by (metis mod_diff_right_eq)
+  thus ?thesis by (simp add: mod_eq_0_iff_dvd)
+qed
+
+theorem (in StandardModulus) mont_correct:
+  shows \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+    and \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+    and \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+    and \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+proof -
+  show \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+  proof -
+    define T where \<open>T = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+    have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+      using mod_inverse_correct(3) .
+    have T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+      unfolding T_def using inv
+      by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+    define k where \<open>k = (z * T) mod\<^sup>\<plusminus> 2^n\<close>
+    have div: \<open>2^n dvd (z + k * N)\<close>
+      unfolding k_def using T_inv
+      by (rule mont_add_signed_divisible)
+    have unfold: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + k * N) div 2^n\<close>
+      using mont_add_signed_unfold[OF T_inv, of z] k_def by simp
+    have \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n = z + k * N\<close>
+      using unfold div by simp
+    then have \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = (z + k * N) mod N\<close>
+      by simp
+    also have \<open>\<dots> = z mod N\<close> by simp
+    finally show ?thesis .
+  qed
+  show \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+  proof -
+    define T where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+    have T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+      unfolding T_def using mod_inverse_correct(3) .
+    define k where \<open>k = (z * T) mod\<^sup>\<plusminus> 2^n\<close>
+    have div: \<open>2^n dvd (z - k * N)\<close>
+      unfolding k_def using T_inv by (rule mont_sub_signed_divisible)
+    have unfold: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - k * N) div 2^n\<close>
+      using mont_sub_signed_unfold[OF T_inv, of z] k_def by simp
+    have eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z * 2^n = z - k * N\<close>
+      using unfold div by simp
+    have \<open>(z - k * N) mod N = z mod N\<close>
+      using mod_diff_eq[of z N \<open>k * N\<close>]
+      by simp
+    with eq show ?thesis by simp
+  qed
+  show \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+  proof -
+    define T where \<open>T = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+    have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+      using mod_inverse_correct(3) .
+    have T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+      unfolding T_def using inv
+      by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+    define k where \<open>k = (z * T) mod\<^sup>+ 2^n\<close>
+    have div: \<open>2^n dvd (z + k * N)\<close>
+      unfolding k_def using npos T_inv by (rule mont_add_unsigned_divisible)
+    have unfold: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z + k * N) div 2^n\<close>
+      using mont_add_unsigned_unfold[OF T_inv, of z] k_def by simp
+    have \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n = z + k * N\<close>
+      using unfold div by simp
+    then have \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = (z + k * N) mod N\<close>
+      by simp
+    also have \<open>\<dots> = z mod N\<close> by simp
+    finally show ?thesis .
+  qed
+  show \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n) mod N = z mod N\<close>
+  proof -
+    define T where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+    have T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+      unfolding T_def using mod_inverse_correct(3) .
+    define k where \<open>k = (z * T) mod\<^sup>+ 2^n\<close>
+    have div: \<open>2^n dvd (z - k * N)\<close>
+      unfolding k_def using npos T_inv by (rule mont_sub_unsigned_divisible)
+    have unfold: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z - k * N) div 2^n\<close>
+      using mont_sub_unsigned_unfold[OF T_inv, of z] k_def by simp
+    have eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z * 2^n = z - k * N\<close>
+      using unfold div by simp
+    have \<open>(z - k * N) mod N = z mod N\<close>
+      using mod_diff_eq[of z N \<open>k * N\<close>]
+      by simp
+    with eq show ?thesis by simp
+  qed
+qed
+
+lemmas %internal (in StandardModulus) mont_add_signed_correct   = mont_correct(1)
+lemmas %internal (in StandardModulus) mont_sub_signed_correct   = mont_correct(2)
+lemmas %internal (in StandardModulus) mont_add_unsigned_correct = mont_correct(3)
+lemmas %internal (in StandardModulus) mont_sub_unsigned_correct = mont_correct(4)
+
+text %internal \<open>The triangle inequality \<^term>\<open>\<bar>z + k*N\<bar> \<le> \<bar>z\<bar> + \<bar>k\<bar>*N\<close> makes the bound depend
+only on the range of \<^term>\<open>k\<close>:
+\[
+  \lvert \mathit{mont}^{\pm}(z) \rvert \;\le\; \lvert z \rvert / R + N/2,
+  \qquad
+  \lvert \mathit{mont}^{+}(z) \rvert \;\le\; \lvert z \rvert / R + N.
+\]
+We prove each bound on the unfolded expression with an arbitrary inverse \<^term>\<open>T\<close>;
+the operator form follows by substitution.\<close>
+
+lemma %internal mont_add_signed_bound_int_raw:
+  assumes \<open>N > 0\<close> and \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  shows \<open>2 * \<bar>(z + ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<bar> * 2^n
+           \<le> 2 * \<bar>z\<bar> + N * 2^n\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>(z * T) mod\<^sup>\<plusminus> ?R\<close>
+  let ?u = \<open>z + ?k * N\<close>
+  let ?m = \<open>?u div ?R\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have div: \<open>?R dvd ?u\<close>
+    using mont_add_signed_divisible[OF assms(2), of z] by simp
+  have eq: \<open>?m * ?R = ?u\<close> using div by (simp add: dvd_div_mult_self)
+  have k_lo: \<open>- (?R div 2) \<le> ?k\<close> using mod_signed_lower R_pos by blast
+  have k_hi: \<open>?k \<le> (?R - 1) div 2\<close> using mod_signed_upper R_pos by blast
+  have two_k_abs: \<open>2 * \<bar>?k\<bar> \<le> ?R\<close> using k_lo k_hi by linarith
+  have N_nn: \<open>N \<ge> 0\<close> using assms(1) by simp
+  have abs_kN: \<open>2 * \<bar>?k * N\<bar> \<le> ?R * N\<close>
+    using mult_right_mono[OF two_k_abs N_nn] N_nn by (simp add: abs_mult)
+  have abs_u: \<open>2 * \<bar>?u\<bar> \<le> 2 * \<bar>z\<bar> + ?R * N\<close>
+    using abs_triangle_ineq[of z \<open>?k * N\<close>] abs_kN by force
+  have abs_eq: \<open>\<bar>?m\<bar> * ?R = \<bar>?u\<bar>\<close>
+    using eq R_pos by (metis abs_mult abs_of_pos)
+  show ?thesis using abs_eq abs_u by (simp add: mult.assoc mult.commute)
+qed
+
+lemma %internal (in StandardModulus) mont_add_signed_bound_int:
+  shows \<open>2 * \<bar>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n \<le> 2 * \<bar>z\<bar> + N * 2^n\<close>
+proof -
+  define T where \<open>T = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+    using mod_inverse_correct(3) .
+  have T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+    unfolding T_def using inv
+    by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+  have eq: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+    using mont_add_signed_unfold[OF T_inv] .
+  show ?thesis
+    using mont_add_signed_bound_int_raw[OF Npos T_inv, of z] eq by simp
+qed
+
+lemma %internal mont_sub_signed_bound_int_raw:
+  assumes \<open>N > 0\<close> and \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>2 * \<bar>(z - ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<bar> * 2^n
+           \<le> 2 * \<bar>z\<bar> + N * 2^n\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close>
+  let ?k = \<open>(z * T) mod\<^sup>\<plusminus> ?R\<close>
+  let ?u = \<open>z - ?k * N\<close>
+  let ?m = \<open>?u div ?R\<close>
+  have R_pos: \<open>?R > 0\<close> by simp
+  have div: \<open>?R dvd ?u\<close>
+    using mont_sub_signed_divisible[OF assms(2), of z] by simp
+  have eq: \<open>?m * ?R = ?u\<close> using div by (simp add: dvd_div_mult_self)
+  have k_lo: \<open>- (?R div 2) \<le> ?k\<close> using mod_signed_lower R_pos by blast
+  have k_hi: \<open>?k \<le> (?R - 1) div 2\<close> using mod_signed_upper R_pos by blast
+  have two_k_abs: \<open>2 * \<bar>?k\<bar> \<le> ?R\<close> using k_lo k_hi by linarith
+  have N_nn: \<open>N \<ge> 0\<close> using assms(1) by simp
+  have step_c: \<open>2 * \<bar>?k * N\<bar> \<le> ?R * N\<close>
+    using two_k_abs N_nn mult_right_mono[of \<open>2 * \<bar>?k\<bar>\<close> ?R N]
+    by (simp add: abs_mult mult.assoc)
+  have abs_u: \<open>2 * \<bar>?u\<bar> \<le> 2 * \<bar>z\<bar> + ?R * N\<close>
+    using abs_triangle_ineq4[of z \<open>?k * N\<close>] step_c by arith
+  have abs_eq: \<open>\<bar>?m\<bar> * ?R = \<bar>?u\<bar>\<close>
+    using eq R_pos by (metis abs_mult abs_of_pos)
+  show ?thesis using abs_eq abs_u by (simp add: mult.assoc mult.commute)
+qed
+
+lemma %internal (in StandardModulus) mont_sub_signed_bound_int:
+  shows \<open>2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n \<le> 2 * \<bar>z\<bar> + N * 2^n\<close>
+proof -
+  define T where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  have T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+    unfolding T_def using mod_inverse_correct(3) .
+  have eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+    using mont_sub_signed_unfold[OF T_inv] .
+  show ?thesis
+    using mont_sub_signed_bound_int_raw[OF Npos T_inv, of z] eq by simp
+qed
+
+text %internal \<open>Unsigned twist: \<open>k \<in> [0, R)\<close>, so \<open>k \<le> R - 1\<close> and the bound is
+\<open>\<bar>mont(z)\<bar> \<le> \<bar>z\<bar>/R + N - N/R\<close>.\<close>
+
+lemma %internal mont_add_unsigned_bound_int_raw:
+  assumes \<open>N > 0\<close> and \<open>n > 0\<close> and \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  shows \<open>\<bar>(z + ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<bar> * 2^n \<le> \<bar>z\<bar> + N * 2^n - N\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close> let ?k = \<open>(z * T) mod\<^sup>+ ?R\<close> let ?u = \<open>z + ?k * N\<close>
+  have div: \<open>?R dvd ?u\<close>
+    using mont_add_unsigned_divisible[OF assms(2) assms(3), of z] by simp
+  have k: \<open>0 \<le> ?k\<close> \<open>?k \<le> ?R - 1\<close>
+    using mod_unsigned_lower[of ?R] mod_unsigned_upper[of ?R] by auto
+  have \<open>\<bar>?u div ?R\<bar> * ?R = \<bar>?u\<bar>\<close>
+    using dvd_div_mult_self[OF div] by (metis abs_mult abs_of_pos zero_less_power zero_less_numeral)
+  also have \<open>\<bar>?u\<bar> \<le> \<bar>z\<bar> + ?k * N\<close>
+    using k(1) assms(1) abs_triangle_ineq[of z \<open>?k * N\<close>] by (simp add: abs_mult)
+  also have \<open>\<dots> \<le> \<bar>z\<bar> + (?R - 1) * N\<close>
+    using k(2) assms(1) by (simp add: mult_right_mono)
+  finally show ?thesis by (simp add: algebra_simps)
+qed
+
+lemma %internal (in StandardModulus) mont_add_unsigned_bound_int:
+  shows \<open>\<bar>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n \<le> \<bar>z\<bar> + N * 2^n - N\<close>
+proof -
+  define T where \<open>T = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+    using mod_inverse_correct(3) .
+  have T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+    unfolding T_def using inv
+    by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+  have eq: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+    using mont_add_unsigned_unfold[OF T_inv] .
+  show ?thesis
+    using mont_add_unsigned_bound_int_raw[OF Npos npos T_inv, of z] eq by simp
+qed
+
+lemma %internal mont_sub_unsigned_bound_int_raw:
+  assumes \<open>N > 0\<close> and \<open>n > 0\<close> and \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  shows \<open>\<bar>(z - ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<bar> * 2^n \<le> \<bar>z\<bar> + N * 2^n - N\<close>
+proof -
+  let ?R = \<open>(2::int)^n\<close> let ?k = \<open>(z * T) mod\<^sup>+ ?R\<close> let ?u = \<open>z - ?k * N\<close>
+  have div: \<open>?R dvd ?u\<close>
+    using mont_sub_unsigned_divisible[OF assms(2) assms(3), of z] by simp
+  have k: \<open>0 \<le> ?k\<close> \<open>?k \<le> ?R - 1\<close>
+    using mod_unsigned_lower[of ?R] mod_unsigned_upper[of ?R] by auto
+  have \<open>\<bar>?u div ?R\<bar> * ?R = \<bar>?u\<bar>\<close>
+    using dvd_div_mult_self[OF div] by (metis abs_mult abs_of_pos zero_less_power zero_less_numeral)
+  also have \<open>\<bar>?u\<bar> \<le> \<bar>z\<bar> + ?k * N\<close>
+    using k(1) assms(1) abs_triangle_ineq4[of z \<open>?k * N\<close>] by (simp add: abs_mult)
+  also have \<open>\<dots> \<le> \<bar>z\<bar> + (?R - 1) * N\<close>
+    using k(2) assms(1) by (simp add: mult_right_mono)
+  finally show ?thesis by (simp add: algebra_simps)
+qed
+
+lemma %internal (in StandardModulus) mont_sub_unsigned_bound_int:
+  shows \<open>\<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n \<le> \<bar>z\<bar> + N * 2^n - N\<close>
+proof -
+  define T where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  have T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+    unfolding T_def using mod_inverse_correct(3) .
+  have eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+    using mont_sub_unsigned_unfold[OF T_inv] .
+  show ?thesis
+    using mont_sub_unsigned_bound_int_raw[OF Npos npos T_inv, of z] eq by simp
+qed
+
+text \<open>The headline output bound: every Montgomery variant of \<^term>\<open>z\<close>
+is bounded in absolute value by \<open>|z|/R + N/2\<close> in the signed forms, and
+by \<open>|z|/R + N - N/R\<close> in the unsigned forms. Both are sharp; they say
+that Montgomery reduction shrinks any input to \<^emph>\<open>roughly\<close> the canonical
+range, with a residual error tied to \<^term>\<open>N\<close>.\<close>
+
+theorem (in StandardModulus) mont_bound:
+  shows \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+    and \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+    and \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+    and \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+proof -
+  have iR_pos: \<open>(2^n)\<^sub>\<rat> > 0\<close> by simp
+  show \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+  proof -
+    have \<open>(2 * \<bar>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n)\<^sub>\<rat> \<le> (2 * \<bar>z\<bar> + N * 2^n)\<^sub>\<rat>\<close>
+      using mont_add_signed_bound_int by (simp only: of_int_le_iff)
+    hence \<open>2 * \<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> * (2^n)\<^sub>\<rat> \<le> 2 * \<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat>\<close>
+      by (simp add: of_int_mult of_int_add)
+    thus ?thesis using iR_pos by (simp add: field_simps)
+  qed
+  show \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+  proof -
+    have \<open>(2 * \<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n)\<^sub>\<rat> \<le> (2 * \<bar>z\<bar> + N * 2^n)\<^sub>\<rat>\<close>
+      using mont_sub_signed_bound_int by (simp only: of_int_le_iff)
+    hence \<open>2 * \<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> * (2^n)\<^sub>\<rat> \<le> 2 * \<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat>\<close>
+      by (simp add: of_int_mult of_int_add)
+    thus ?thesis using iR_pos by (simp add: field_simps)
+  qed
+  show \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+  proof -
+    have \<open>(\<bar>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n)\<^sub>\<rat> \<le> (\<bar>z\<bar> + N * 2^n - N)\<^sub>\<rat>\<close>
+      using mont_add_unsigned_bound_int by (simp only: of_int_le_iff)
+    hence h: \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> * (2^n)\<^sub>\<rat> \<le> \<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat> - N\<^sub>\<rat>\<close>
+      by (simp add: of_int_mult of_int_add of_int_diff)
+    from h iR_pos have \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> (\<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat> - N\<^sub>\<rat>) / (2^n)\<^sub>\<rat>\<close>
+      by (simp add: pos_le_divide_eq mult.commute)
+    moreover have \<open>(\<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat> - N\<^sub>\<rat>) / (2^n)\<^sub>\<rat> = \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+      using iR_pos by (simp add: diff_divide_distrib add_divide_distrib)
+    ultimately show ?thesis by simp
+  qed
+  show \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+  proof -
+    have \<open>(\<bar>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z\<bar> * 2^n)\<^sub>\<rat> \<le> (\<bar>z\<bar> + N * 2^n - N)\<^sub>\<rat>\<close>
+      using mont_sub_unsigned_bound_int by (simp only: of_int_le_iff)
+    hence h: \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> * (2^n)\<^sub>\<rat> \<le> \<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat> - N\<^sub>\<rat>\<close>
+      by (simp add: of_int_mult of_int_add of_int_diff)
+    from h iR_pos have \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>+\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> \<le> (\<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat> - N\<^sub>\<rat>) / (2^n)\<^sub>\<rat>\<close>
+      by (simp add: pos_le_divide_eq mult.commute)
+    moreover have \<open>(\<bar>z\<bar>\<^sub>\<rat> + N\<^sub>\<rat> * (2^n)\<^sub>\<rat> - N\<^sub>\<rat>) / (2^n)\<^sub>\<rat> = \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+      using iR_pos by (simp add: diff_divide_distrib add_divide_distrib)
+    ultimately show ?thesis by simp
+  qed
+qed
+
+lemmas %internal (in StandardModulus) mont_add_signed_bound   = mont_bound(1)
+lemmas %internal (in StandardModulus) mont_sub_signed_bound   = mont_bound(2)
+lemmas %internal (in StandardModulus) mont_add_unsigned_bound = mont_bound(3)
+lemmas %internal (in StandardModulus) mont_sub_unsigned_bound = mont_bound(4)
+
+text \<open>The signed bounds are tight: there exist inputs at which the
+inequality is an equality. As an example, we pick \<open>n = 3\<close>, \<open>N = 3\<close>, 
+so \<open>R = 8\<close>: then \<^term>\<open>N\<^sup>-\<^sup>1 mod R = 3\<close>, \<open>k = -4\<close> at \<open>z = -4\<close> (additive) or
+\<open>z = 4\<close> (subtractive), with \<open>\<bar>m\<bar> = 2\<close> matching\<^term>\<open>\<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2\<close>.\<close>
+
+lemma mont_add_signed_bound_tight:
+  shows \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>3, 3\<rbrakk> (-4))\<^sub>\<rat>\<bar> = \<bar>-4\<bar> /\<^sub>\<rat> 2^3 + 3 /\<^sub>\<rat> 2\<close>
+proof -
+  interpret SM: StandardModulus 3 3 by unfold_locales auto
+  have inv: \<open>(3 * (5::int)) mod 2^3 = (- 1) mod 2^3\<close> by simp
+  have h: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>3, 3\<rbrakk> (-4) = ((-4) + ((-4 * 5) mod\<^sup>\<plusminus> 2^3) * 3) div 2^3\<close>
+    using SM.mont_add_signed_unfold[OF inv, of \<open>-4\<close>] by simp
+  have k: \<open>((-4 * 5)::int) mod\<^sup>\<plusminus> 2^3 = -4\<close>
+    unfolding mod_approx_def by code_simp
+  have v: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>3, 3\<rbrakk> (-4) = -2\<close> using h k by simp
+  show ?thesis unfolding v by simp
+qed
+
+lemma mont_sub_signed_bound_tight:
+  shows \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>3, 3\<rbrakk> 4)\<^sub>\<rat>\<bar> = \<bar>4\<bar> /\<^sub>\<rat> 2^3 + 3 /\<^sub>\<rat> 2\<close>
+proof -
+  interpret SM: StandardModulus 3 3 by unfold_locales auto
+  have inv: \<open>(3 * (3::int)) mod 2^3 = 1 mod 2^3\<close> by simp
+  have h: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>3, 3\<rbrakk> 4 = (4 - ((4 * 3) mod\<^sup>\<plusminus> 2^3) * 3) div 2^3\<close>
+    using SM.mont_sub_signed_unfold[OF inv, of 4] by simp
+  have k: \<open>((4 * 3)::int) mod\<^sup>\<plusminus> 2^3 = -4\<close>
+    unfolding mod_approx_def by code_simp
+  have v: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>3, 3\<rbrakk> 4 = 2\<close> using h k by simp
+  show ?thesis unfolding v by simp
+qed
+
+text \<open>The unsigned bounds are also tight in the sharper form
+\<^term>\<open>\<bar>m\<bar>\<^sub>\<rat> \<le> \<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R\<close>. As an example, we pick \<open>n = 3\<close>, \<open>N = 3\<close>, 
+so \<open>R = 8\<close>, with twist \<^term>\<open>-N\<^sup>-\<^sup>1 mod R = 5\<close>. At \<open>z = 3\<close> we get \<open>k = 7\<close>
+and \<open>m = 3\<close>, matching \<^term>\<open>\<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> - N /\<^sub>\<rat> R = 3\<close>.\<close>
+
+lemma mont_add_unsigned_bound_tight:
+  shows \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>3, 3\<rbrakk> 3)\<^sub>\<rat>\<bar> = \<bar>3\<bar> /\<^sub>\<rat> 2^3 + 3 - 3 /\<^sub>\<rat> 2^3\<close>
+proof -
+  interpret SM: StandardModulus 3 3 by unfold_locales auto
+  have inv: \<open>(3 * (5::int)) mod 2^3 = (- 1) mod 2^3\<close> by simp
+  have h: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>3, 3\<rbrakk> 3 = (3 + ((3 * 5) mod\<^sup>+ 2^3) * 3) div 2^3\<close>
+    using SM.mont_add_unsigned_unfold[OF inv, of 3] by simp
+  have k: \<open>((3 * 5)::int) mod\<^sup>+ 2^3 = 7\<close>
+    unfolding mod_approx_def by code_simp
+  have v: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>3, 3\<rbrakk> 3 = 3\<close> using h k by simp
+  show ?thesis unfolding v by simp
+qed
+
+subsection \<open>Tightness characterisation of the signed Montgomery bound\<close>
+
+text \<open>The signed Montgomery bound \<^term>\<open>\<bar>m\<bar> \<le> \<bar>z\<bar>/\<^sub>\<rat>R + N/\<^sub>\<rat>2\<close> is attained exactly when the
+input \<open>z\<close> has residue \<open>R/2\<close> modulo \<open>R\<close> and lies on the appropriate
+side of zero (\<open>z \<le> 0\<close> for the additive variant, \<open>z \<ge> 0\<close> for the subtractive).\<close>
+
+lemma %internal neg_half_mod_R:
+  assumes \<open>n > 0\<close>
+  shows \<open>(-(2^(n-1)::int)) mod (2^n::int) = 2^(n-1)\<close>
+proof -
+  have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close>
+    using assms by (cases n) auto
+  have h1: \<open>(2::int)^(n-1) > 0\<close> by simp
+  have h2: \<open>(2::int)^(n-1) < 2 * 2^(n-1)\<close> using h1 by linarith
+  have \<open>(-(2^(n-1)) + 2^n :: int) = 2^(n-1)\<close> using R_eq by simp
+  hence eq: \<open>(-(2^(n-1):: int)) mod (2::int)^n = ((2::int)^(n-1)) mod (2::int)^n\<close>
+    by (metis mod_add_self2)
+  also have \<open>\<dots> = 2^(n-1)\<close>
+    using h1 h2 R_eq by simp
+  finally show ?thesis .
+qed
+
+lemma %internal mod_signed_eq_neg_half_iff:
+  assumes \<open>n > 0\<close>
+  shows \<open>(z mod\<^sup>\<plusminus> (2::int)^n = -(2^(n-1))) \<longleftrightarrow> (z mod (2::int)^n = 2^(n-1))\<close>
+proof -
+  define R :: int where \<open>R = 2^n\<close>
+  have R_pos: \<open>R > 0\<close> unfolding R_def by simp
+  have R_eq: \<open>R = 2 * 2^(n-1)\<close>
+    unfolding R_def using assms by (cases n) auto
+  have lo: \<open>-(R div 2) \<le> z mod\<^sup>\<plusminus> R\<close> using mod_signed_lower[OF R_pos] .
+  have hi: \<open>z mod\<^sup>\<plusminus> R \<le> (R - 1) div 2\<close> using mod_signed_upper[OF R_pos] .
+  have neg_half: \<open>(-(2^(n-1)::int)) mod R = 2^(n-1)\<close>
+    unfolding R_def using neg_half_mod_R[OF assms] .
+  have z_eq: \<open>z = (z mod\<^sup>\<plusminus> R) + R * \<lfloor>z /\<^sub>\<rat> R\<rceil>\<close>
+    unfolding mod_approx_def by simp
+  have modR_eq: \<open>z mod R = (z mod\<^sup>\<plusminus> R) mod R\<close>
+  proof -
+    have \<open>z mod R = ((z mod\<^sup>\<plusminus> R) + R * \<lfloor>z /\<^sub>\<rat> R\<rceil>) mod R\<close> using z_eq by simp
+    thus ?thesis by (simp add: mod_mult_self1)
+  qed
+  show \<open>(z mod\<^sup>\<plusminus> R = -(2^(n-1))) \<longleftrightarrow> (z mod R = 2^(n-1))\<close>
+  proof
+    assume H: \<open>z mod\<^sup>\<plusminus> R = -(2^(n-1))\<close>
+    show \<open>z mod R = 2^(n-1)\<close> using modR_eq H neg_half by simp
+  next
+    assume H: \<open>z mod R = 2^(n-1)\<close>
+    hence modR: \<open>(z mod\<^sup>\<plusminus> R) mod R = 2^(n-1)\<close> using modR_eq by simp
+    show \<open>z mod\<^sup>\<plusminus> R = -(2^(n-1))\<close>
+    proof (cases \<open>z mod\<^sup>\<plusminus> R \<ge> 0\<close>)
+      case True
+      hence \<open>(z mod\<^sup>\<plusminus> R) mod R = z mod\<^sup>\<plusminus> R\<close> using hi R_eq by simp
+      thus ?thesis using modR hi R_eq by simp
+    next
+      case False
+      hence rng: \<open>0 \<le> z mod\<^sup>\<plusminus> R + R \<and> z mod\<^sup>\<plusminus> R + R < R\<close> using lo R_eq by linarith
+      hence \<open>(z mod\<^sup>\<plusminus> R + R) mod R = z mod\<^sup>\<plusminus> R + R\<close> using mod_pos_pos_trivial by blast
+      hence \<open>z mod\<^sup>\<plusminus> R + R = 2^(n-1)\<close> using modR by (simp add: mod_add_self2)
+      thus ?thesis using R_eq by simp
+    qed
+  qed
+qed
+
+lemma %internal half_mul_N_mod_R:
+  assumes \<open>n > 0\<close> and \<open>odd (N::int)\<close>
+  shows \<open>((2::int)^(n-1) * N) mod (2^n::int) = 2^(n-1)\<close>
+proof -
+  obtain k where Nk: \<open>N = 2 * k + 1\<close> using assms(2) oddE by blast
+  have R_eq: \<open>(2::int)^n = 2 * 2^(n-1)\<close>
+    using assms(1) by (cases n) auto
+  have \<open>(2::int)^(n-1) * N = 2^(n-1) * (2 * k + 1)\<close> using Nk by simp
+  also have \<open>\<dots> = 2 * 2^(n-1) * k + 2^(n-1)\<close> by (simp add: algebra_simps)
+  also have \<open>\<dots> = (2::int)^n * k + 2^(n-1)\<close> using R_eq by simp
+  finally have eq: \<open>(2::int)^(n-1) * N = (2::int)^n * k + 2^(n-1)\<close> .
+  have h1: \<open>(2::int)^(n-1) > 0\<close> by simp
+  have h2: \<open>(2::int)^(n-1) < (2::int)^n\<close> using R_eq h1 by linarith
+  have \<open>((2::int)^(n-1) * N) mod (2^n::int) = ((2::int)^n * k + 2^(n-1)) mod (2^n::int)\<close>
+    using eq by simp
+  also have \<open>\<dots> = ((2::int)^(n-1)) mod (2^n::int)\<close>
+    by simp
+  also have \<open>\<dots> = 2^(n-1)\<close>
+    using h1 h2 by simp
+  finally show ?thesis .
+qed
+
+lemma %internal twist_mod_half_forward:
+  assumes \<open>n > 0\<close> and \<open>odd (N::int)\<close>
+    and TN: \<open>(N * T) mod (2^n::int) = (eps::int) mod (2^n::int)\<close>
+    and eps: \<open>eps = 1 \<or> eps = -1\<close>
+    and HzT: \<open>(z * T) mod (2^n::int) = 2^(n-1)\<close>
+  shows \<open>z mod (2^n::int) = 2^(n-1)\<close>
+proof -
+  define R :: int where \<open>R = 2^n\<close>
+  have R_pos: \<open>R > 0\<close> unfolding R_def by simp
+  have R_eq: \<open>R = 2 * 2^(n-1)\<close> unfolding R_def using assms(1) by (cases n) auto
+  have HN: \<open>(N * T) mod R = eps mod R\<close> unfolding R_def using TN .
+  have half_N: \<open>(2^(n-1) * N) mod R = 2^(n-1)\<close>
+    unfolding R_def using half_mul_N_mod_R[OF assms(1,2)] .
+  have HzT': \<open>(z * T) mod R = 2^(n-1)\<close> unfolding R_def using HzT .
+  have step1: \<open>(z * T * N) mod R = (2^(n-1) * N) mod R\<close>
+    using HzT' by (metis mod_mult_left_eq mult.commute)
+  also have \<open>\<dots> = 2^(n-1)\<close> using half_N .
+  finally have step2: \<open>(z * T * N) mod R = 2^(n-1)\<close> .
+  have step3: \<open>(z * T * N) mod R = (z * eps) mod R\<close>
+  proof -
+    have \<open>(z * (T * N)) mod R = (z * ((T * N) mod R)) mod R\<close>
+      by (simp add: mod_mult_right_eq)
+    also have \<open>\<dots> = (z * (eps mod R)) mod R\<close>
+      using HN by (simp add: mult.commute)
+    also have \<open>\<dots> = (z * eps) mod R\<close> by (simp add: mod_mult_right_eq)
+    finally show ?thesis by (simp add: mult.assoc)
+  qed
+  from step2 step3 have step4: \<open>(z * eps) mod R = 2^(n-1)\<close> by simp
+  show \<open>z mod (2^n::int) = 2^(n-1)\<close>
+  proof (cases \<open>eps = 1\<close>)
+    case True
+    thus ?thesis using step4 unfolding R_def by simp
+  next
+    case False
+    hence eps_neg: \<open>eps = -1\<close> using eps by simp
+    hence negz: \<open>(-z) mod R = 2^(n-1)\<close> using step4 by simp
+    have h1: \<open>(2::int)^(n-1) > 0\<close> by simp
+    have h2: \<open>(2::int)^(n-1) < R\<close> using R_eq h1 by linarith
+    have z_mod_lt: \<open>z mod R < R\<close> using R_pos by simp
+    have z_mod_ge: \<open>z mod R \<ge> 0\<close> using R_pos by simp
+    show ?thesis
+    proof (cases \<open>z mod R = 0\<close>)
+      case True
+      hence \<open>(-z) mod R = 0\<close> by (simp add: zmod_zminus1_eq_if)
+      thus ?thesis using negz h1 by simp
+    next
+      case False
+      hence pos: \<open>z mod R > 0\<close> using z_mod_ge by linarith
+      have \<open>(-z) mod R = R - z mod R\<close>
+        using pos z_mod_lt by (simp add: zmod_zminus1_eq_if)
+      hence \<open>R - z mod R = 2^(n-1)\<close> using negz by simp
+      hence \<open>z mod R = R - 2^(n-1)\<close> by simp
+      also have \<open>\<dots> = 2^(n-1)\<close> using R_eq by simp
+      finally show ?thesis unfolding R_def .
+    qed
+  qed
+qed
+
+lemma %internal mod_inv_odd:
+  assumes \<open>n > 0\<close> and \<open>odd (N::int)\<close>
+  shows \<open>odd (N\<^sup>-\<^sup>1 mod (2^n :: int))\<close>
+proof -
+  define M where \<open>M = N\<^sup>-\<^sup>1 mod (2^n::int)\<close>
+  have inv: \<open>(N * M) mod (2^n::int) = 1 mod (2^n::int)\<close>
+    unfolding M_def using mod_inverse_correct(3)[OF assms(1,2)] .
+  have R_pos: \<open>(2::int)^n > 0\<close> by simp
+  have NM_mod: \<open>(N * M) mod (2^n::int) = 1\<close>
+    using inv assms(1) by simp
+  show \<open>odd M\<close>
+  proof (rule ccontr)
+    assume \<open>\<not> odd M\<close>
+    hence \<open>even M\<close> by simp
+    hence even_NM: \<open>(2::int) dvd (N * M)\<close> by simp
+    have \<open>(2::int) dvd (2^n :: int)\<close> using assms(1) by (simp add: dvd_power)
+    hence \<open>(2::int) dvd ((N * M) mod (2^n::int))\<close>
+      using even_NM by (metis dvd_mod)
+    hence \<open>(2::int) dvd (1::int)\<close> using NM_mod by simp
+    thus False by simp
+  qed
+qed
+
+lemma %internal twist_mod_half_backward:
+  assumes \<open>n > 0\<close> and \<open>odd (N::int)\<close>
+    and TN: \<open>(N * T) mod (2^n::int) = (eps::int) mod (2^n::int)\<close>
+    and eps: \<open>eps = 1 \<or> eps = -1\<close>
+    and Hz: \<open>z mod (2^n::int) = 2^(n-1)\<close>
+  shows \<open>(z * T) mod (2^n::int) = 2^(n-1)\<close>
+proof -
+  define R :: int where \<open>R = 2^n\<close>
+  have R_pos: \<open>R > 0\<close> unfolding R_def by simp
+  have R_eq: \<open>R = 2 * 2^(n-1)\<close> unfolding R_def using assms(1) by (cases n) auto
+  have Hz': \<open>z mod R = 2^(n-1)\<close> unfolding R_def using Hz .
+  have HN: \<open>(N * T) mod R = eps mod R\<close> unfolding R_def using TN .
+  have h1: \<open>(2::int)^(n-1) > 0\<close> by simp
+  have h2: \<open>(2::int)^(n-1) < R\<close> using R_eq h1 by linarith
+  have step1: \<open>(z * T) mod R = (2^(n-1) * T) mod R\<close>
+    using Hz' by (metis mod_mult_left_eq)
+  have h3: \<open>(2^(n-1) * T * N) mod R = (2^(n-1) * eps) mod R\<close>
+  proof -
+    have \<open>((2^(n-1)::int) * T * N) mod R = ((2^(n-1)::int) * (T * N)) mod R\<close>
+      by (simp add: mult.assoc)
+    also have \<open>\<dots> = ((2^(n-1)::int) * ((T * N) mod R)) mod R\<close>
+      by (simp add: mod_mult_right_eq)
+    also have \<open>\<dots> = ((2^(n-1)::int) * (eps mod R)) mod R\<close>
+      using HN by (simp add: mult.commute)
+    also have \<open>\<dots> = ((2^(n-1)::int) * eps) mod R\<close>
+      by (simp add: mod_mult_right_eq)
+    finally show ?thesis .
+  qed
+  have h4: \<open>((2^(n-1)::int) * eps) mod R = 2^(n-1)\<close>
+  proof (cases \<open>eps = 1\<close>)
+    case True
+    thus ?thesis using h1 h2 by simp
+  next
+    case False
+    hence eps_neg: \<open>eps = -1\<close> using eps by simp
+    have \<open>((2^(n-1)::int) * eps) mod R = (-(2^(n-1))) mod R\<close> using eps_neg by simp
+    also have \<open>\<dots> = 2^(n-1)\<close> using neg_half_mod_R[OF assms(1)] unfolding R_def .
+    finally show ?thesis .
+  qed
+  from h3 h4 have step2: \<open>(2^(n-1) * T * N) mod R = 2^(n-1)\<close> by simp
+  have step3: \<open>(2^(n-1) * T * N) mod R = (((2^(n-1) * T) mod R) * N) mod R\<close>
+    by (simp add: mod_mult_left_eq)
+  define M where \<open>M = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  define u where \<open>u = (2^(n-1) * T) mod R\<close>
+  have inv: \<open>(N * M) mod 2^n = 1 mod 2^n\<close>
+    unfolding M_def using mod_inverse_correct(3)[OF assms(1,2)] .
+  have u_eq: \<open>(u * N) mod R = 2^(n-1)\<close> using step2 step3 unfolding u_def by simp
+  have \<open>(u * N * M) mod R = (u * 1) mod R\<close>
+  proof -
+    have \<open>(u * N * M) mod R = (u * (N * M)) mod R\<close> by (simp add: mult.assoc)
+    also have \<open>\<dots> = (u * ((N * M) mod R)) mod R\<close> by (simp add: mod_mult_right_eq)
+    also have \<open>\<dots> = (u * (1 mod R)) mod R\<close> using inv unfolding R_def by simp
+    also have \<open>\<dots> = (u * 1) mod R\<close> by (simp add: mod_mult_right_eq)
+    finally show ?thesis .
+  qed
+  hence eqA: \<open>(u * N * M) mod R = u mod R\<close> by simp
+  have eqB: \<open>(u * N * M) mod R = ((u * N) mod R * M) mod R\<close>
+    by (simp add: mod_mult_left_eq)
+  from eqA eqB have \<open>u mod R = ((u * N) mod R * M) mod R\<close> by simp
+  also have \<open>\<dots> = (2^(n-1) * M) mod R\<close> using u_eq by simp
+  finally have step4: \<open>u mod R = (2^(n-1) * M) mod R\<close> .
+  have M_odd: \<open>odd M\<close> unfolding M_def using mod_inv_odd[OF assms(1,2)] .
+  have half_M: \<open>(2^(n-1) * M) mod R = 2^(n-1)\<close>
+    unfolding R_def using half_mul_N_mod_R[OF assms(1) M_odd] .
+  have u_lt: \<open>u < R\<close> using R_pos unfolding u_def by simp
+  have u_ge: \<open>u \<ge> 0\<close> using R_pos unfolding u_def by simp
+  have u_self: \<open>u mod R = u\<close> using u_lt u_ge by simp
+  from step4 u_self half_M have \<open>u = 2^(n-1)\<close> by simp
+  thus ?thesis using step1 unfolding u_def R_def by simp
+qed
+
+lemma %internal twist_signed_neg_half_iff:
+  assumes \<open>n > 0\<close> and \<open>odd (N::int)\<close>
+    and TN: \<open>(N * T) mod (2^n::int) = (eps::int) mod (2^n::int)\<close>
+    and eps: \<open>eps = 1 \<or> eps = -1\<close>
+  shows \<open>((z * T) mod\<^sup>\<plusminus> (2^n::int) = -(2^(n-1))) \<longleftrightarrow> (z mod (2^n::int) = 2^(n-1))\<close>
+proof -
+  have iff1: \<open>((z * T) mod\<^sup>\<plusminus> (2^n::int) = -(2^(n-1))) \<longleftrightarrow> ((z * T) mod (2^n::int) = 2^(n-1))\<close>
+    using mod_signed_eq_neg_half_iff[OF assms(1), of \<open>z * T\<close>] .
+  have iff2: \<open>((z * T) mod (2^n::int) = 2^(n-1)) \<longleftrightarrow> (z mod (2^n::int) = 2^(n-1))\<close>
+    using twist_mod_half_forward[OF assms(1,2) TN eps, of z]
+          twist_mod_half_backward[OF assms(1,2) TN eps, of z]
+    by blast
+  from iff1 iff2 show ?thesis by simp
+qed
+
+lemma %internal rat_int_2R_eq:
+  fixes a b R :: int
+  assumes \<open>R > 0\<close>
+  shows \<open>(\<bar>a\<bar>\<^sub>\<rat> = \<bar>b\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2) \<longleftrightarrow> (2 * \<bar>a\<bar> * R = 2 * \<bar>b\<bar> + R * N)\<close>
+proof -
+  have iR_pos: \<open>(R::int)\<^sub>\<rat> > 0\<close> using assms by simp
+  have iR_nz: \<open>(R::int)\<^sub>\<rat> \<noteq> 0\<close> using assms by simp
+  show ?thesis
+  proof
+    assume H: \<open>\<bar>a\<bar>\<^sub>\<rat> = \<bar>b\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2\<close>
+    have eq1: \<open>2 * \<bar>a\<bar>\<^sub>\<rat> * R\<^sub>\<rat> = 2 * \<bar>b\<bar>\<^sub>\<rat> + R\<^sub>\<rat> * N\<^sub>\<rat>\<close>
+      using H iR_nz by (simp add: field_simps)
+    have \<open>(2 * \<bar>a\<bar> * R)\<^sub>\<rat> = 2 * \<bar>a\<bar>\<^sub>\<rat> * R\<^sub>\<rat>\<close> by simp
+    moreover have \<open>(2 * \<bar>b\<bar> + R * N)\<^sub>\<rat> = 2 * \<bar>b\<bar>\<^sub>\<rat> + R\<^sub>\<rat> * N\<^sub>\<rat>\<close> by simp
+    ultimately have \<open>(2 * \<bar>a\<bar> * R)\<^sub>\<rat> = (2 * \<bar>b\<bar> + R * N)\<^sub>\<rat>\<close> using eq1 by simp
+    thus \<open>2 * \<bar>a\<bar> * R = 2 * \<bar>b\<bar> + R * N\<close> by (metis of_int_eq_iff)
+  next
+    assume H: \<open>2 * \<bar>a\<bar> * R = 2 * \<bar>b\<bar> + R * N\<close>
+    hence \<open>(2 * \<bar>a\<bar> * R)\<^sub>\<rat> = (2 * \<bar>b\<bar> + R * N)\<^sub>\<rat>\<close> by simp
+    hence eq1: \<open>2 * \<bar>a\<bar>\<^sub>\<rat> * R\<^sub>\<rat> = 2 * \<bar>b\<bar>\<^sub>\<rat> + R\<^sub>\<rat> * N\<^sub>\<rat>\<close> by simp
+    thus \<open>\<bar>a\<bar>\<^sub>\<rat> = \<bar>b\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2\<close>
+      using iR_nz iR_pos by (simp add: field_simps)
+  qed
+qed
+
+theorem (in StandardModulus) mont_signed_bound_iff:
+  shows mont_add_signed_bound_iff:
+    \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2 \<longleftrightarrow> z mod\<^sup>+ 2^n = 2^(n-1) \<and> z \<le> 0\<close>
+  and mont_sub_signed_bound_iff:
+    \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2 \<longleftrightarrow> z mod\<^sup>+ 2^n = 2^(n-1) \<and> z \<ge> 0\<close>
+proof -
+  have half_pos: \<open>(2::int)^(n-1) * N > 0\<close> using Npos by simp
+  have rat_iff: \<open>\<And>a. (\<bar>a\<bar>\<^sub>\<rat> = \<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2) \<longleftrightarrow> (2 * \<bar>a\<bar> * R = 2 * \<bar>z\<bar> + R * N)\<close>
+    using rat_int_2R_eq[OF R_pos] .
+  text \<open>A unified helper covering both signed variants:
+        the boolean \<open>add\<close> selects between the
+        \<^const>\<open>Montgomery_Reduction.mont_add_signed\<close> and
+        \<^const>\<open>Montgomery_Reduction.mont_sub_signed\<close> cases.\<close>
+  have generic:
+    \<open>\<And>M T eps add. (N * T) mod (2^n::int) = eps mod 2^n \<Longrightarrow> eps = 1 \<or> eps = -1 \<Longrightarrow>
+       M = (if add then z + ((z * T) mod\<^sup>\<plusminus> R) * N else z - ((z * T) mod\<^sup>\<plusminus> R) * N) div R \<Longrightarrow>
+       R dvd (if add then z + ((z * T) mod\<^sup>\<plusminus> R) * N else z - ((z * T) mod\<^sup>\<plusminus> R) * N) \<Longrightarrow>
+       (\<bar>M\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2 \<longleftrightarrow> z mod\<^sup>+ 2^n = 2^(n-1) \<and> (if add then z \<le> 0 else z \<ge> 0))\<close>
+  proof -
+    fix M T :: int and eps :: int and add :: bool
+    assume TN: \<open>(N * T) mod (2^n::int) = eps mod 2^n\<close>
+    assume eps: \<open>eps = 1 \<or> eps = -1\<close>
+    define k where \<open>k = (z * T) mod\<^sup>\<plusminus> R\<close>
+    define u where \<open>u = (if add then z + k * N else z - k * N)\<close>
+    assume Mdef: \<open>M = (if add then z + ((z * T) mod\<^sup>\<plusminus> R) * N else z - ((z * T) mod\<^sup>\<plusminus> R) * N) div R\<close>
+    assume div: \<open>R dvd (if add then z + ((z * T) mod\<^sup>\<plusminus> R) * N else z - ((z * T) mod\<^sup>\<plusminus> R) * N)\<close>
+    from Mdef have M_eq: \<open>M = u div R\<close> unfolding u_def k_def by simp
+    from div have div': \<open>R dvd u\<close> unfolding u_def k_def by simp
+    have twist_iff: \<open>\<And>w. ((w * T) mod\<^sup>\<plusminus> (2^n::int) = -(2^(n-1))) \<longleftrightarrow> (w mod (2^n::int) = 2^(n-1))\<close>
+      using twist_signed_neg_half_iff[OF npos Nodd TN eps] .
+    have abs_eq: \<open>\<bar>M\<bar> * R = \<bar>u\<bar>\<close>
+      using div' M_eq R_pos by (metis abs_mult abs_of_pos dvd_div_mult_self)
+    have k_lo': \<open>-(2^(n-1)) \<le> k\<close>
+      unfolding k_def using mod_signed_lower[OF R_pos, of \<open>z * T\<close>] R_eq by simp
+    have k_hi': \<open>k \<le> 2^(n-1) - 1\<close>
+      unfolding k_def using mod_signed_upper[OF R_pos, of \<open>z * T\<close>] R_eq by simp
+    have abs_kN: \<open>\<bar>k * N\<bar> = \<bar>k\<bar> * N\<close>
+      using N_nn by (simp add: abs_mult abs_of_nonneg)
+    have triangle: \<open>\<bar>u\<bar> \<le> \<bar>z\<bar> + \<bar>k * N\<bar>\<close> unfolding u_def
+      by (cases add) (auto simp: abs_triangle_ineq abs_minus_commute abs_triangle_ineq4)
+    have two_k_le_R: \<open>2 * \<bar>k\<bar> \<le> R\<close> using k_lo' k_hi' R_eq by linarith
+    have two_kN_le_RN: \<open>2 * \<bar>k * N\<bar> \<le> R * N\<close>
+      using two_k_le_R N_nn abs_kN by (metis mult.assoc mult_right_mono)
+    have two_k_eq_R_iff: \<open>(2 * \<bar>k\<bar> = R) \<longleftrightarrow> k = -(2^(n-1))\<close>
+      using k_lo' k_hi' R_eq by linarith
+    show \<open>(\<bar>M\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2 \<longleftrightarrow> z mod\<^sup>+ 2^n = 2^(n-1) \<and> (if add then z \<le> 0 else z \<ge> 0))\<close>
+    proof
+      assume \<open>\<bar>M\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2\<close>
+      hence Hi: \<open>2 * \<bar>M\<bar> * R = 2 * \<bar>z\<bar> + R * N\<close> using rat_iff by simp
+      have eqU: \<open>2 * \<bar>u\<bar> = 2 * \<bar>z\<bar> + R * N\<close>
+        using Hi abs_eq by (simp add: mult.assoc)
+      have triangle_tight: \<open>2 * \<bar>u\<bar> = 2 * \<bar>z\<bar> + 2 * \<bar>k * N\<bar>\<close>
+        using eqU triangle two_kN_le_RN by linarith
+      have k_tight: \<open>2 * \<bar>k\<bar> = R\<close>
+        using eqU triangle_tight abs_kN Npos by simp
+      have k_val: \<open>k = -(2^(n-1))\<close> using k_tight two_k_eq_R_iff by simp
+      have z_mod_unsigned: \<open>z mod\<^sup>+ 2^n = 2^(n-1)\<close>
+        using k_val twist_iff[of z] mod_unsigned_eq_mod[OF R_pos]
+        unfolding k_def by simp
+      have kN_neg: \<open>k * N < 0\<close> using k_val half_pos by simp
+      have z_sign: \<open>if add then z \<le> 0 else z \<ge> 0\<close>
+      proof (cases add)
+        case True
+        have \<open>z \<le> 0\<close>
+        proof (rule ccontr)
+          assume \<open>\<not> z \<le> 0\<close>
+          hence \<open>\<bar>z + k * N\<bar> < \<bar>z\<bar> + \<bar>k * N\<bar>\<close> using kN_neg by linarith
+          thus False using triangle_tight unfolding u_def using True by simp
+        qed
+        thus ?thesis using True by simp
+      next
+        case False
+        have \<open>z \<ge> 0\<close>
+        proof (rule ccontr)
+          assume \<open>\<not> z \<ge> 0\<close>
+          hence \<open>\<bar>z - k * N\<bar> < \<bar>z\<bar> + \<bar>k * N\<bar>\<close> using kN_neg by linarith
+          thus False using triangle_tight unfolding u_def using False by simp
+        qed
+        thus ?thesis using False by simp
+      qed
+      show \<open>z mod\<^sup>+ 2^n = 2^(n-1) \<and> (if add then z \<le> 0 else z \<ge> 0)\<close>
+        using z_mod_unsigned z_sign by simp
+    next
+      assume A: \<open>z mod\<^sup>+ 2^n = 2^(n-1) \<and> (if add then z \<le> 0 else z \<ge> 0)\<close>
+      hence Hz: \<open>z mod\<^sup>+ 2^n = 2^(n-1)\<close> and z_sign: \<open>if add then z \<le> 0 else z \<ge> 0\<close> by auto
+      have z_mod: \<open>z mod R = 2^(n-1)\<close>
+        using Hz mod_unsigned_eq_mod[OF R_pos] by simp
+      have k_val: \<open>k = -(2^(n-1))\<close>
+        using twist_iff[of z] z_mod unfolding k_def by simp
+      hence kN_eq: \<open>k * N = -(2^(n-1) * N)\<close> by simp
+      have abs_kN_eq: \<open>\<bar>k * N\<bar> = 2^(n-1) * N\<close> using kN_eq half_pos by simp
+      have abs_u: \<open>\<bar>u\<bar> = \<bar>z\<bar> + \<bar>k * N\<bar>\<close>
+      proof (cases add)
+        case True
+        hence z_le: \<open>z \<le> 0\<close> using z_sign by simp
+        have \<open>u = z - 2^(n-1) * N\<close> unfolding u_def using True kN_eq by simp
+        thus ?thesis using z_le half_pos abs_kN_eq by linarith
+      next
+        case False
+        hence z_ge: \<open>z \<ge> 0\<close> using z_sign by simp
+        have \<open>u = z + 2^(n-1) * N\<close> unfolding u_def using False kN_eq by simp
+        thus ?thesis using z_ge half_pos abs_kN_eq by linarith
+      qed
+      have eqU: \<open>2 * \<bar>u\<bar> = 2 * \<bar>z\<bar> + R * N\<close>
+        using abs_u abs_kN_eq R_eq by (simp add: algebra_simps)
+      hence Hi: \<open>2 * \<bar>M\<bar> * R = 2 * \<bar>z\<bar> + R * N\<close>
+        using abs_eq by (simp add: mult.assoc)
+      show \<open>\<bar>M\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> R + N\<^sub>\<rat> / 2\<close> using rat_iff Hi by simp
+    qed
+  qed
+  show \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2 \<longleftrightarrow> z mod\<^sup>+ 2^n = 2^(n-1) \<and> z \<le> 0\<close>
+  proof -
+    define T :: int where \<open>T = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+    have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close> using mod_inverse_correct(3) .
+    have T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+      unfolding T_def using inv by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+    have eps_disj: \<open>((-1)::int) = 1 \<or> ((-1)::int) = -1\<close> by simp
+    have m_eq: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z + ((z * T) mod\<^sup>\<plusminus> R) * N) div R\<close>
+      using mont_add_signed_unfold[OF T_inv, of z] by simp
+    have div: \<open>R dvd (z + ((z * T) mod\<^sup>\<plusminus> R) * N)\<close>
+      using mont_add_signed_divisible[OF T_inv, of z] by simp
+    show ?thesis
+      using generic[where add=True and M=\<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<close> and T=T and eps=\<open>-1\<close>,
+                    OF T_inv eps_disj] m_eq div by simp
+  qed
+  show \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z)\<^sub>\<rat>\<bar> = \<bar>z\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2 \<longleftrightarrow> z mod\<^sup>+ 2^n = 2^(n-1) \<and> z \<ge> 0\<close>
+  proof -
+    define T :: int where \<open>T = N\<^sup>-\<^sup>1 mod 2^n\<close>
+    have T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+      unfolding T_def using mod_inverse_correct(3) .
+    have eps_disj: \<open>((1)::int) = 1 \<or> ((1)::int) = -1\<close> by simp
+    have m_eq: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z = (z - ((z * T) mod\<^sup>\<plusminus> R) * N) div R\<close>
+      using mont_sub_signed_unfold[OF T_inv, of z] by simp
+    have div: \<open>R dvd (z - ((z * T) mod\<^sup>\<plusminus> R) * N)\<close>
+      using mont_sub_signed_divisible[OF T_inv, of z] by simp
+    show ?thesis
+      using generic[where add=False and M=\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> z\<close> and T=T and eps=1,
+                    OF T_inv eps_disj] m_eq div by simp
+  qed
+qed
+
+
+section \<open>Montgomery multiplication with a known constant\<close>
+
+text \<open>Montgomery reduction of the product \<^term>\<open>a * b\<close> can be simplified in case one
+operand, say \<^term>\<open>b\<close>, is known. In this case, one can precompute the `twist'
+\<open>b_tw \<equiv> b \<sqdot> N\<^sup>-\<^sup>1 (mod R)\<close> and compute the Montgomery multiplication as follows:\<close>
+
+definition mont_mul_sub_signed (\<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>_,_\<rbrakk>\<langle>_,_\<rangle>\<close>) where
+  \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> \<equiv>
+     \<comment>\<open>\<open>b_tw\<close> should be precomputed in practice\<close>
+     (let b_tw = (b * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n in
+        (a * b - ((a * b_tw) mod\<^sup>\<plusminus> 2^n) * N) div 2^n)\<close>
+
+definition mont_mul_add_signed (\<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>_,_\<rbrakk>\<langle>_,_\<rangle>\<close>) where
+  \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> \<equiv>
+     \<comment>\<open>\<open>b_tw\<close> should be precomputed in practice\<close>
+     (let b_tw = (b * ((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n)) mod 2^n in
+        (a * b + ((a * b_tw) mod\<^sup>\<plusminus> 2^n) * N) div 2^n)\<close>
+
+definition mont_mul_add_unsigned (\<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>_,_\<rbrakk>\<langle>_,_\<rangle>\<close>) where
+  \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> \<equiv>
+     \<comment>\<open>\<open>b_tw\<close> should be precomputed in practice\<close>
+     (let b_tw = (b * ((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n)) mod 2^n in
+        (a * b + (a * b_tw mod\<^sup>+ 2^n) * N) div 2^n)\<close>
+
+subsection %internal \<open>Precomputed twist \<open>b_tw\<close>\<close>
+
+text %internal \<open>Any \<^term>\<open>b_tw\<close> congruent to \<^term>\<open>b*T mod R\<close> (for \<^term>\<open>T\<close> with the right inverse
+relation) yields the same result.\<close>
+
+
+lemma %internal mul_smod_shift:
+  fixes a b_tw bT :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>b_tw mod 2^n = bT mod 2^n\<close>
+  shows \<open>(a * b_tw) mod\<^sup>\<plusminus> 2^n = (a * bT) mod\<^sup>\<plusminus> 2^n\<close>
+  using mod_approx_smod_cong[OF assms(1), of b_tw bT a] assms(2) by simp
+
+lemma %internal mul_umod_shift:
+  fixes a b_tw bT :: int and n :: nat
+  assumes \<open>n > 0\<close> and \<open>b_tw mod 2^n = bT mod 2^n\<close>
+  shows \<open>(a * b_tw) mod\<^sup>+ 2^n = (a * bT) mod\<^sup>+ 2^n\<close>
+  using mod_approx_umod_cong[OF assms(1), of b_tw bT a] assms(2) by simp
+
+lemma %internal (in StandardModulus) mont_mul_sub_signed_unfold:
+  assumes T_inv: \<open>(N * T) mod 2^n = 1 mod 2^n\<close>
+  assumes bT_def: \<open>b_tw mod 2^n = (b * T) mod 2^n\<close>
+  shows \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = (a * b - ((a * b_tw) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+proof -
+  define c where \<open>c = (b * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+    using mod_inverse_correct(3) .
+  have T_eq: \<open>T mod 2^n = (N\<^sup>-\<^sup>1 mod 2^n) mod 2^n\<close>
+    using mod_inverse_alt[OF npos Nodd T_inv]
+          mod_inverse_idem[OF npos Nodd] by simp
+  have c_eq: \<open>c mod 2^n = (b * T) mod 2^n\<close>
+    unfolding c_def using T_eq
+    by (metis mod_mod_trivial mod_mult_right_eq)
+  hence btw_eq: \<open>b_tw mod 2^n = c mod 2^n\<close>
+    using bT_def by simp
+  have \<open>(a * b_tw) mod\<^sup>\<plusminus> 2^n = (a * c) mod\<^sup>\<plusminus> 2^n\<close>
+    using mul_smod_shift[OF npos btw_eq, of a] .
+  thus ?thesis
+    unfolding mont_mul_sub_signed_def Let_def c_def[symmetric] by simp
+qed
+
+lemma %internal (in StandardModulus) mont_mul_add_signed_unfold:
+  assumes T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  assumes bT_def: \<open>b_tw mod 2^n = (b * T) mod 2^n\<close>
+  shows \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = (a * b + ((a * b_tw) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+proof -
+  define c where \<open>c = (b * ((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n)) mod 2^n\<close>
+  have T_eq: \<open>T mod 2^n = ((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n) mod 2^n\<close>
+    using mod_inverse_neg_alt[OF npos Nodd T_inv]
+          mod_inverse_neg_idem[OF npos Nodd] by simp
+  have c_eq: \<open>c mod 2^n = (b * T) mod 2^n\<close>
+    unfolding c_def using T_eq
+    by (metis mod_mod_trivial mod_mult_right_eq)
+  hence btw_eq: \<open>b_tw mod 2^n = c mod 2^n\<close>
+    using bT_def by simp
+  have \<open>(a * b_tw) mod\<^sup>\<plusminus> 2^n = (a * c) mod\<^sup>\<plusminus> 2^n\<close>
+    using mul_smod_shift[OF npos btw_eq, of a] .
+  thus ?thesis
+    unfolding mont_mul_add_signed_def Let_def c_def[symmetric] by simp
+qed
+
+lemma %internal (in StandardModulus) mont_mul_add_unsigned_unfold:
+  assumes T_inv: \<open>(N * T) mod 2^n = (- 1) mod 2^n\<close>
+  assumes bT_def: \<open>b_tw mod 2^n = (b * T) mod 2^n\<close>
+  shows \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = (a * b + ((a * b_tw) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+proof -
+  define c where \<open>c = (b * ((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n)) mod 2^n\<close>
+  have T_eq: \<open>T mod 2^n = ((- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n) mod 2^n\<close>
+    using mod_inverse_neg_alt[OF npos Nodd T_inv]
+          mod_inverse_neg_idem[OF npos Nodd] by simp
+  have c_eq: \<open>c mod 2^n = (b * T) mod 2^n\<close>
+    unfolding c_def using T_eq
+    by (metis mod_mod_trivial mod_mult_right_eq)
+  hence btw_eq: \<open>b_tw mod 2^n = c mod 2^n\<close>
+    using bT_def by simp
+  have \<open>(a * b_tw) mod\<^sup>+ 2^n = (a * c) mod\<^sup>+ 2^n\<close>
+    using mul_umod_shift[OF npos btw_eq, of a] .
+  thus ?thesis
+    unfolding mont_mul_add_unsigned_def Let_def c_def[symmetric] by simp
+qed
+
+
+text \<open>The multiplication operator coincides with the reduction operator applied
+to \<^term>\<open>a*b\<close>: by associativity, \<^term>\<open>(a * b_tw) mod R = (a*b * T) mod R\<close>.\<close>
+
+lemma (in StandardModulus) mont_mul_eq_red:
+  shows \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk> (a * b)\<close>
+    and \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk> (a * b)\<close>
+    and \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk> (a * b)\<close>
+proof -
+  define Tpos where \<open>Tpos = N\<^sup>-\<^sup>1 mod 2^n\<close>
+  define Tneg where \<open>Tneg = (- (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n\<close>
+  have Tpos_inv: \<open>(N * Tpos) mod 2^n = 1 mod 2^n\<close>
+    unfolding Tpos_def using mod_inverse_correct(3) .
+  have inv: \<open>(N * (N\<^sup>-\<^sup>1 mod 2^n)) mod 2^n = 1 mod 2^n\<close>
+    using mod_inverse_correct(3) .
+  have Tneg_inv: \<open>(N * Tneg) mod 2^n = (- 1) mod 2^n\<close>
+    unfolding Tneg_def using inv
+    by (metis mod_minus_eq mod_mult_right_eq mult_minus_right)
+  have bT_def_pos: \<open>((b * Tpos) mod 2^n) mod 2^n = (b * Tpos) mod 2^n\<close> by simp
+  have bT_def_neg: \<open>((b * Tneg) mod 2^n) mod 2^n = (b * Tneg) mod 2^n\<close> by simp
+  show \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk> (a * b)\<close>
+  proof -
+    have lhs: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>
+                = (a * b - ((a * ((b * Tpos) mod 2^n)) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+      using mont_mul_sub_signed_unfold[OF Tpos_inv bT_def_pos, of a] .
+    have shift: \<open>(a * ((b * Tpos) mod 2^n)) mod\<^sup>\<plusminus> 2^n = (a * b * Tpos) mod\<^sup>\<plusminus> 2^n\<close>
+    proof -
+      have \<open>(a * ((b * Tpos) mod 2^n)) mod 2^n = (a * (b * Tpos)) mod 2^n\<close>
+        by (metis mod_mult_right_eq)
+      hence \<open>(a * ((b * Tpos) mod 2^n)) mod 2^n = (a * b * Tpos) mod 2^n\<close>
+        by (simp add: mult.assoc)
+      thus ?thesis
+        using mod_approx_smod_cong[OF npos,
+          of \<open>a * ((b * Tpos) mod 2^n)\<close> \<open>a * b * Tpos\<close> 1]
+        by simp
+    qed
+    have rhs: \<open>mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b) = (a * b - ((a * b * Tpos) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+      using mont_sub_signed_unfold[OF Tpos_inv, of \<open>a*b\<close>] .
+    show ?thesis using lhs rhs shift by simp
+  qed
+  show \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk> (a * b)\<close>
+  proof -
+    have lhs: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>
+                = (a * b + ((a * ((b * Tneg) mod 2^n)) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+      using mont_mul_add_signed_unfold[OF Tneg_inv bT_def_neg, of a] .
+    have shift: \<open>(a * ((b * Tneg) mod 2^n)) mod\<^sup>\<plusminus> 2^n = (a * b * Tneg) mod\<^sup>\<plusminus> 2^n\<close>
+    proof -
+      have \<open>(a * ((b * Tneg) mod 2^n)) mod 2^n = (a * b * Tneg) mod 2^n\<close>
+        by (metis mod_mult_right_eq mult.assoc)
+      thus ?thesis
+        using mod_approx_smod_cong[OF npos,
+          of \<open>a * ((b * Tneg) mod 2^n)\<close> \<open>a * b * Tneg\<close> 1]
+        by simp
+    qed
+    have rhs: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus>\<lbrakk>N, n\<rbrakk> (a * b) = (a * b + ((a * b * Tneg) mod\<^sup>\<plusminus> 2^n) * N) div 2^n\<close>
+      using mont_add_signed_unfold[OF Tneg_inv, of \<open>a*b\<close>] .
+    show ?thesis using lhs rhs shift by simp
+  qed
+  show \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> = mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk> (a * b)\<close>
+  proof -
+    have lhs: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>
+                = (a * b + ((a * ((b * Tneg) mod 2^n)) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+      using mont_mul_add_unsigned_unfold[OF Tneg_inv bT_def_neg, of a] .
+    have shift: \<open>(a * ((b * Tneg) mod 2^n)) mod\<^sup>+ 2^n = (a * b * Tneg) mod\<^sup>+ 2^n\<close>
+    proof -
+      have \<open>(a * ((b * Tneg) mod 2^n)) mod 2^n = (a * b * Tneg) mod 2^n\<close>
+        by (metis mod_mult_right_eq mult.assoc)
+      thus ?thesis
+        using mod_approx_umod_cong[OF npos,
+          of \<open>a * ((b * Tneg) mod 2^n)\<close> \<open>a * b * Tneg\<close> 1]
+        by simp
+    qed
+    have rhs: \<open>mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+\<lbrakk>N, n\<rbrakk> (a * b) = (a * b + ((a * b * Tneg) mod\<^sup>+ 2^n) * N) div 2^n\<close>
+      using mont_add_unsigned_unfold[OF Tneg_inv, of \<open>a*b\<close>] .
+    show ?thesis using lhs rhs shift by simp
+  qed
+qed
+
+lemmas %internal (in StandardModulus) mont_mul_sub_signed_eq_red   = mont_mul_eq_red(1)
+lemmas %internal (in StandardModulus) mont_mul_add_signed_eq_red   = mont_mul_eq_red(2)
+lemmas %internal (in StandardModulus) mont_mul_add_unsigned_eq_red = mont_mul_eq_red(3)
+
+subsection \<open>Correctness and bounds\<close>
+
+text \<open>Since Montgomery multiplication is the same as Montgomery reduction
+of the product, the bounds from the previous section readily carry over to
+Montgomery multiplication:\<close>
+
+theorem (in StandardModulus) mont_mul_correct:
+  shows \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> * 2^n) mod N = (a * b) mod N\<close>
+    and \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> * 2^n) mod N = (a * b) mod N\<close>
+    and \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> * 2^n) mod N = (a * b) mod N\<close>
+proof -
+  show \<open>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> * 2^n) mod N = (a * b) mod N\<close>
+    using mont_mul_sub_signed_eq_red
+          mont_sub_signed_correct[of \<open>a * b\<close>]
+    by simp
+  show \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> * 2^n) mod N = (a * b) mod N\<close>
+    using mont_mul_add_signed_eq_red
+          mont_add_signed_correct[of \<open>a * b\<close>]
+    by simp
+  show \<open>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle> * 2^n) mod N = (a * b) mod N\<close>
+    using mont_mul_add_unsigned_eq_red
+          mont_add_unsigned_correct[of \<open>a * b\<close>]
+    by simp
+qed
+
+lemmas %internal (in StandardModulus) mont_mul_sub_signed_correct   = mont_mul_correct(1)
+lemmas %internal (in StandardModulus) mont_mul_add_signed_correct   = mont_mul_correct(2)
+lemmas %internal (in StandardModulus) mont_mul_add_unsigned_correct = mont_mul_correct(3)
+
+theorem (in StandardModulus) mont_mul_bound:
+  shows \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a * b\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+    and \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a * b\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+    and \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a * b\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+proof -
+  show \<open>\<bar>(mont\<^sub>s\<^sub>u\<^sub>b\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a * b\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+    using mont_mul_sub_signed_eq_red
+          mont_sub_signed_bound[of \<open>a * b\<close>]
+    by simp
+  show \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>\<plusminus> \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a * b\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> / 2\<close>
+    using mont_mul_add_signed_eq_red
+          mont_add_signed_bound[of \<open>a * b\<close>]
+    by simp
+  show \<open>\<bar>(mont\<^sub>a\<^sub>d\<^sub>d\<^sup>+ \<lbrakk>N, n\<rbrakk>\<langle>a, b\<rangle>)\<^sub>\<rat>\<bar> \<le> \<bar>a * b\<bar> /\<^sub>\<rat> 2^n + N\<^sub>\<rat> - N /\<^sub>\<rat> 2^n\<close>
+    using mont_mul_add_unsigned_eq_red
+          mont_add_unsigned_bound[of \<open>a * b\<close>]
+    by simp
+qed
+
+lemmas %internal (in StandardModulus) mont_mul_sub_signed_bound   = mont_mul_bound(1)
+lemmas %internal (in StandardModulus) mont_mul_add_signed_bound   = mont_mul_bound(2)
+lemmas %internal (in StandardModulus) mont_mul_add_unsigned_bound = mont_mul_bound(3)
+
+end
+

--- a/proofs/isabelle/neon_ntt/README.md
+++ b/proofs/isabelle/neon_ntt/README.md
@@ -1,0 +1,148 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Neon NTT — Isabelle/HOL Formalisation
+
+This directory provides additional formal documentation of the approach to
+modular arithmetic used in various assembly kernels in `mldsa-native` and
+`mlkem-native`. Specifically, it contains the source for an Isabelle/HOL
+formalisation of the original "Neon NTT" paper [^NeonNTT] of Becker, Hwang,
+Kannwischer, Yang, and Yang. A companion PDF — generated directly from the
+theory sources via Isabelle's document-preparation system — is produced by
+[`make`](#building) and is also published as the `neon_ntt_autoformalized`
+artifact of the [Isabelle CI workflow](../../../.github/workflows/isabelle.yml).
+
+## What the PDF covers
+
+The PDF reads as a paper but is auto-generated from the `.thy` files in this
+directory: every chapter corresponds to a theory and the prose, displayed
+terms, and theorem statements are the formal text. There is no separate
+narrative to drift out of sync.
+
+Two layers of content:
+
+- **Abstract algebra.** Parametric Barrett and Montgomery reduction and
+  multiplication, uniform in modulus, word width, and integer approximation;
+  the Barrett–Montgomery equivalence; the doubling- and rounding-Montgomery
+  variants; a recasting of the equivalence as Euclidean / 2-adic rounding
+  duality; and an empirical bound-quality study at the ML-KEM (`N = 3329`)
+  and ML-DSA (`N = 8380417`) moduli.
+- **Concrete kernels.** A model of the relevant Armv8-A Neon instructions
+  (`MUL`, `MLA`, `MLS`, `MULH`, `UMULH`, `SQDMULH`, `SQRDMULH`, `SQRDMLAH`,
+  `SHSUB`, `SRSHR`) as parametric word operations, and correctness and
+  bounds theorems for the signed-word Barrett and Montgomery kernels shipped
+  by `mldsa-native` (and `mlkem-native`).
+
+Methodologically, the development is a human-directed auto-formalisation:
+theory text was drafted by Claude Opus 4.7 driving Isabelle through
+AutoCorrode's I/Q (jEdit/MCP) and I/R (REPL) interfaces [^AutoCorrode], with
+the human author owning architecture, abstractions, and editorial control.
+
+## Relation to the mldsa-native source
+
+The kernels analysed here are the modular-arithmetic primitives used inside
+the AArch64 NTT and pointwise-multiplication assembly under
+[`mldsa/src/native/aarch64/src/`](../../../mldsa/src/native/aarch64/src/) —
+in particular `ntt_aarch64_asm.S`, `intt_aarch64_asm.S`,
+`pointwise_montgomery_aarch64_asm.S`, and the
+`mld_polyvecl_pointwise_acc_montgomery_l{4,5,7}_aarch64_asm.S` variants.
+
+The proofs are stated against an abstract word model assumed to match the
+Armv8-A semantics; agreement of the model with actual silicon is
+exercised separately, see [Conformance testing](#conformance-testing) below.
+The development does **not** descend to a concrete instruction decoder
+or to NTT- and butterfly-level correctness. End-to-end, binary-level
+verification of the deployed kernels is covered separately by the HOL Light +
+[s2n-bignum](https://github.com/awslabs/s2n-bignum) proofs under
+[`proofs/hol_light`](../../hol_light). The two efforts are complementary:
+this development isolates the algebraic content shared across kernels so
+that a new kernel or parameter set reuses the bounds rather than reproving
+them.
+
+## Theory layout
+
+| File | Role |
+|---|---|
+| `Introduction.thy` | Motivation, methodology, roadmap |
+| `Integer_Approximation.thy` | Parametric integer approximation `⟦·⟧ : ℚ → ℤ` |
+| `Montgomery_Reduction.thy` | Abstract Montgomery reduction / multiplication |
+| `Barrett_Reduction.thy` | Abstract Barrett reduction / multiplication |
+| `Barrett_Montgomery.thy` | Barrett–Montgomery equivalence and Barrett bounds |
+| `Barrett_Bound_Quality.thy` | Empirical bound study at `N ∈ {97, 3329, 8380417}` |
+| `Montgomery_Doubling.thy` | Doubling / rounding Montgomery variants |
+| `Bridge_Conceptual.thy` | Euclidean / 2-adic rounding duality |
+| `Word_Ops.thy` | Width-parametric model of the Neon instructions |
+| `Asm_Barrett.thy` | Correctness of the Neon Barrett kernels |
+| `Asm_Montgomery.thy` | Correctness of the Neon Montgomery kernels |
+| `Conclusions.thy` | Summary |
+
+`document/` holds the LaTeX preamble, bibliography, and IACR class.
+`model/` holds executable harnesses (SML/C) used for the bound-quality study
+and conformance testing of the word model against actual hardware.
+
+## Prerequisites
+
+- [Isabelle/HOL](https://isabelle.in.tum.de/) (tested with `Isabelle2025-2`;
+  CI builds against the
+  [`makarius/isabelle:Isabelle2025-1_ARM_X11_Latex`](https://hub.docker.com/r/makarius/isabelle)
+  Docker image).
+- A TeX distribution providing `luacode.sty` (loaded transitively by
+  `iacrtrans` → `hyperref` → `hyperxmp`). On Debian/Ubuntu this is
+  `texlive-luatex`; the Isabelle macOS app already bundles it.
+- For the conformance harnesses under `model/hw` and `model/sml`: a C
+  toolchain (`gcc`, `libc`, `make`) and Python 3. `model/hw/hw_exec.c`
+  requires an AArch64 host (it rejects other architectures at compile time).
+
+## Building
+
+Build with the included Makefile:
+
+```
+make           # build PDF
+make jedit     # open Asm_Montgomery.thy in Isabelle/jEdit
+```
+
+The Makefile defaults assume the macOS `Isabelle2025-2.app` install layout.
+On other platforms, set `ISABELLE_HOME` to the directory containing the
+`isabelle` binary (and `ISABELLE_VERSION` if your version differs).
+
+The default build is heavily abridged — auxiliary lemmas and most proof
+bodies are elided via Isabelle document tags. A full-proof build can be
+produced by overriding the `internal` and `proof` tags in `document/root.tex`.
+
+## Conformance testing
+
+The `Word_Ops` theory provides an ad-hoc model of the relevant Neon
+instructions; the correctness theorems for the assembly kernels are stated
+against that model. Conformance testing empirically confirms that this
+ad-hoc model agrees with native execution on an AArch64 host.
+
+Two binaries are compared side-by-side, both reading the same stream of
+`MNEMONIC BITWIDTH ARGS...` cases on stdin and emitting one hex result per
+line on stdout:
+
+- `model/sml/model_exec` — Isabelle-exported SML code for `Word_Ops`. The
+  Isabelle build produces `model.ML` via `export_code` (driven by
+  `Word_Ops_Export.thy` and `Conformance_Testing.thy`); the Makefile under
+  `model/sml/` wraps it in a thin script that invokes Isabelle's bundled
+  PolyML.
+- `model/hw/hw_exec` — a small C harness that issues the corresponding Neon
+  intrinsics directly. It must be built and run on an AArch64 host.
+
+`model/conformance/run.py` drives both processes through random, edge-value,
+and (for 8-bit ops) exhaustive case streams across all instruction /
+bit-width combinations covered in `Word_Ops`.
+
+To build and run conformance from the `neon_ntt` root:
+
+```
+make conformance                       # edge cases + 50k random per op
+make conformance CONFORMANCE_RUNS=1000000
+```
+
+The underlying driver also exposes `full` (exhaustive, 8-bit only) and
+`all` modes, plus `--mnemonic` / `--bitwidth` filters; invoke
+`python3 model/conformance/run.py --help` for details.
+
+<!--- bibliography --->
+[^AutoCorrode]: Becker, Chong, Dockins, Grundy, Hu, Mulder, Mulligan, Mure, Paulson, Slind: AutoCorrode software verification framework for Isabelle/HOL, [https://github.com/awslabs/autocorrode](https://github.com/awslabs/autocorrode)
+[^NeonNTT]: Becker, Hwang, Kannwischer, Yang, Yang: Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1, [https://eprint.iacr.org/2021/986](https://eprint.iacr.org/2021/986)

--- a/proofs/isabelle/neon_ntt/ROOT
+++ b/proofs/isabelle/neon_ntt/ROOT
@@ -1,0 +1,24 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+session NeonNTT = "HOL-Number_Theory" +
+  options [document = pdf, document_output = "output"]
+  sessions
+    "HOL-Library"
+  theories
+    Introduction
+    Integer_Approximation
+    Montgomery_Reduction
+    Barrett_Reduction
+    Barrett_Montgomery
+    Barrett_Bound_Quality
+    Montgomery_Doubling
+    Bridge_Conceptual
+    Word_Ops
+    Asm_Barrett
+    Asm_Montgomery
+    Conclusions
+    Word_Ops_Export
+  document_files
+    "root.tex"
+    "root.bib"
+    "iacrtrans.cls"

--- a/proofs/isabelle/neon_ntt/Word_Ops.thy
+++ b/proofs/isabelle/neon_ntt/Word_Ops.thy
@@ -1,0 +1,1105 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Word_Ops
+  imports Integer_Approximation "HOL-Library.Word"
+begin
+
+chapter \<open>Models of common word operations \label{ch:word_ops}\<close>
+
+text \<open>
+In this chapter, we provide word-level models of common assembly instructions
+used in modular arithmetic kernels. The names for our models are aligned with
+the Armv8-A Neon instruction mnemonics. However, we emphasise that our models
+operate on individual words, while the corresponding Neon operations would ---
+in the spirit of Single Instruction Multiple Data (SIMD) --- apply them to
+each lane of the corresponding vector.
+
+We model fixed-width words using Isabelle's standard \emph{word library}
+(\<open>HOL-Library.Word\<close>). The type \<open>'a word\<close> represents bitvectors whose length is
+encoded by the type variable \<open>'a\<close> via the type class \<open>len\<close>; \<^term>\<open>LENGTH('a::len)\<close> is the
+corresponding bit-width. \<^term>\<open>sint :: 'a::len word \<Rightarrow> int\<close> is the two's-complement signed
+interpretation. Working at this level of generality lets us state every kernel
+correctness theorem once, without committing to a specific lane width.
+
+For each instruction --- the low-half multiplies \asminst{MUL}, \asminst{MLA},
+\asminst{MLS}; the high-half multiplies \asminst{MULH} and \asminst{UMULH};
+the doubling high-half multipliers \asminst{SQDMULH} and \asminst{SQRDMULH};
+the multiply-accumulate \asminst{SQRDMLAH}; and the halving subtract
+\asminst{SHSUB} --- we give an abstract integer specification, define the
+corresponding word operation on \<open>'a::len\<close>-bit lanes, and prove that
+\<open>sint\<close> (or \<open>uint\<close>) of the word operation matches the spec.\<close>
+
+section %internal \<open>Word \<^latex>\<open>$\leftrightarrow$\<close> int interpretation\<close>
+
+text %internal \<open>
+With \<open>n = LENGTH('a)\<close>, the \emph{canonical signed range} is the integer interval
+\<^latex>\<open>$\{-2^{n-1}, \dots, 2^{n-1}-1\}$\<close>, the two's-complement output range of
+an \<open>n\<close>-bit signed lane. Every saturation analysis below relies on the shape
+constraint that \<open>sint\<close> lands in this range.
+\<close>
+
+lemma %internal sint_in_signed_range:
+  fixes w :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>-(2^(n-1)) \<le> sint w \<and> sint w < 2 ^ (n - 1)\<close>
+  unfolding n_def
+  using sint_range_size[of w] by (simp add: word_size)
+
+lemma %internal sint_word_of_int_in_range:
+  fixes x :: int and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a::len)\<close>
+  assumes \<open>-(2^(n-1)) \<le> x\<close>
+      and \<open>x < 2 ^ (n - 1)\<close>
+  shows \<open>sint ((word_of_int x) :: 'a word) = x\<close>
+proof -
+  have \<open>sint ((word_of_int x) :: 'a word) = signed_take_bit (n - 1) x\<close>
+    unfolding n_def by (rule sint_sbintrunc')
+  also have \<open>\<dots> = x\<close>
+    using signed_take_bit_int_eq_self[OF assms(2) assms(3)] .
+  finally show ?thesis .
+qed
+
+section \<open>Low-half multiply (\<open>MUL\<close>) and multiply-accumulate (\<open>MLA\<close>, \<open>MLS\<close>)\<close>
+
+text \<open>
+\asminst{MUL} computes the low half of the product, i.e.\ the signed
+reduction of \<open>a * b\<close> modulo the word size.
+\asminst{MLA}/\asminst{MLS} combine that product with an accumulator.
+\<close>
+
+definition mul_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mul_word a b \<equiv> a * b\<close>
+
+definition mla_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mla_word acc a b \<equiv> acc + a * b\<close>
+
+definition mls_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mls_word acc a b \<equiv> acc - a * b\<close>
+
+lemma %internal round_int_div_2pow:
+  fixes z :: int and n :: nat
+  assumes \<open>n \<ge> 1\<close>
+  shows \<open>\<lfloor>z /\<^sub>\<rat> (2^n)\<rceil> = (z + 2^(n-1)) div 2^n\<close>
+proof -
+  have npos: \<open>(2::int)^n > 0\<close> by simp
+  have nhalf: \<open>(2::int)^n = 2 * 2^(n-1)\<close> using assms
+    by (metis One_nat_def Suc_pred neq0_conv not_one_le_zero power_Suc)
+  have \<open>z /\<^sub>\<rat> (2^n) + 1/2 = (z + 2^(n-1)) /\<^sub>\<rat> (2^n)\<close>
+  proof -
+    have \<open>(2^n :: int)\<^sub>\<rat> = (2 * 2^(n-1))\<close> using nhalf by simp
+    thus ?thesis by (simp add: field_simps)
+  qed
+  hence \<open>\<lfloor>z /\<^sub>\<rat> (2^n)\<rceil> = \<lfloor>(z + 2^(n-1)) /\<^sub>\<rat> (2^n)\<rfloor>\<close>
+    unfolding round_def by simp
+  also have \<open>\<dots> = (z + 2^(n-1)) div 2^n\<close>
+    using floor_divide_of_int_eq[of "z + 2^(n-1)" "2^n :: int"] by simp
+  finally show ?thesis .
+qed
+
+lemma %internal signed_take_bit_eq_smod:
+  fixes x :: int and n :: nat
+  assumes \<open>n \<ge> 1\<close>
+  shows \<open>signed_take_bit (n - 1) x = x mod\<^sup>\<plusminus> 2^n\<close>
+proof -
+  have nSuc: \<open>Suc (n - 1) = n\<close> using assms by simp
+  have h1: \<open>signed_take_bit (n - 1) x = take_bit n (x + 2 ^ (n - 1)) - 2 ^ (n - 1)\<close>
+    using signed_take_bit_eq_take_bit_shift[of "n-1" x] nSuc by simp
+  also have \<open>\<dots> = (x + 2 ^ (n - 1)) mod 2 ^ n - 2 ^ (n - 1)\<close>
+    by (simp add: take_bit_eq_mod)
+  finally have h: \<open>signed_take_bit (n - 1) x = (x + 2 ^ (n - 1)) mod 2 ^ n - 2 ^ (n - 1)\<close> .
+  have \<open>x mod\<^sup>\<plusminus> 2^n = x - 2^n * \<lfloor>x /\<^sub>\<rat> (2^n)\<rceil>\<close>
+    unfolding mod_approx_def by simp
+  also have \<open>\<dots> = x - 2^n * ((x + 2^(n-1)) div 2^n)\<close>
+    using round_int_div_2pow[OF assms] by simp
+  also have \<open>\<dots> = (x + 2^(n-1)) - 2^n * ((x + 2^(n-1)) div 2^n) - 2^(n-1)\<close>
+    by simp
+  also have \<open>\<dots> = (x + 2^(n-1)) mod 2^n - 2^(n-1)\<close>
+    by (simp add: minus_div_mult_eq_mod[symmetric])
+  finally have \<open>x mod\<^sup>\<plusminus> 2^n = (x + 2^(n-1)) mod 2^n - 2^(n-1)\<close> .
+  thus ?thesis using h by simp
+qed
+
+lemma %internal sint_eq_signed_take_bit_self:
+  fixes w :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>signed_take_bit (n - 1) (sint w) = sint w\<close>
+  unfolding n_def
+  using sint_range_size[of w] len_gt_0[where 'a='a]
+  by (auto intro!: signed_take_bit_int_eq_self simp: word_size)
+
+lemma %internal sint_mul_low:
+  fixes a b :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (a * b) = (sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+proof -
+  have \<open>sint (a * b) = signed_take_bit (n - 1) (sint a * sint b)\<close>
+    unfolding n_def by (simp add: sint_word_ariths)
+  also have \<open>\<dots> = (sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+    using signed_take_bit_eq_smod[of n \<open>sint a * sint b\<close>]
+          len_gt_0[where 'a='a]
+    unfolding n_def by simp
+  finally show \<open>sint (a * b) = (sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close> .
+qed
+
+lemma %internal sint_mla:
+  fixes acc a b :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (acc + a * b) = (sint acc + sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+proof -
+  let ?n1 = \<open>n - 1\<close>
+  have \<open>sint (acc + a * b) = signed_take_bit ?n1 (sint acc + sint (a * b))\<close>
+    unfolding n_def by (rule sint_word_add)
+  also have \<open>sint (a * b) = signed_take_bit ?n1 (sint a * sint b)\<close>
+    unfolding n_def by (rule sint_word_mult)
+  also have \<open>signed_take_bit ?n1 (sint acc + signed_take_bit ?n1 (sint a * sint b))
+            = signed_take_bit ?n1 (signed_take_bit ?n1 (sint acc)
+                                  + signed_take_bit ?n1 (sint a * sint b))\<close>
+    using sint_eq_signed_take_bit_self[OF n_def, of acc] by simp
+  also have \<open>\<dots> = signed_take_bit ?n1 (sint acc + sint a * sint b)\<close>
+    by (rule signed_take_bit_add)
+  also have \<open>\<dots> = (sint acc + sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+    using signed_take_bit_eq_smod[of n \<open>sint acc + sint a * sint b\<close>]
+          len_gt_0[where 'a='a]
+    unfolding n_def by simp
+  finally show \<open>sint (acc + a * b) = (sint acc + sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close> .
+qed
+
+lemma %internal sint_mls:
+  fixes acc a b :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (acc - a * b) = (sint acc - sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+proof -
+  let ?n1 = \<open>n - 1\<close>
+  have \<open>sint (acc - a * b) = signed_take_bit ?n1 (sint acc - sint (a * b))\<close>
+    unfolding n_def by (rule sint_word_diff)
+  also have \<open>sint (a * b) = signed_take_bit ?n1 (sint a * sint b)\<close>
+    unfolding n_def by (rule sint_word_mult)
+  also have \<open>signed_take_bit ?n1 (sint acc - signed_take_bit ?n1 (sint a * sint b))
+            = signed_take_bit ?n1 (signed_take_bit ?n1 (sint acc)
+                                  - signed_take_bit ?n1 (sint a * sint b))\<close>
+    using sint_eq_signed_take_bit_self[OF n_def, of acc] by simp
+  also have \<open>\<dots> = signed_take_bit ?n1 (sint acc - sint a * sint b)\<close>
+    by (rule signed_take_bit_diff)
+  also have \<open>\<dots> = (sint acc - sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+    using signed_take_bit_eq_smod[of n \<open>sint acc - sint a * sint b\<close>]
+          len_gt_0[where 'a='a]
+    unfolding n_def by simp
+  finally show \<open>sint (acc - a * b) = (sint acc - sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close> .
+qed
+
+text \<open>The signed correctness theorems are uniform: \<^term>\<open>sint\<close> of each
+operation equals the corresponding integer expression reduced by symmetric
+modulo \<^term>\<open>2 ^ n\<close>. There is no precondition --- the low-half family is
+unconditionally well-behaved on signed inputs.\<close>
+
+lemma sint_mul_ops:
+  fixes a b acc :: \<open>'a::len word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (mul_word a b) = (sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+    and \<open>sint (mla_word acc a b) = (sint acc + sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+    and \<open>sint (mls_word acc a b) = (sint acc - sint a * sint b) mod\<^sup>\<plusminus> (2 ^ n)\<close>
+  unfolding mul_word_def mla_word_def mls_word_def
+  by (rule sint_mul_low[OF n_def] sint_mla[OF n_def] sint_mls[OF n_def])+
+
+lemmas %internal sint_mul_word = sint_mul_ops(1)
+lemmas %internal sint_mla_word = sint_mul_ops(2)
+lemmas %internal sint_mls_word = sint_mul_ops(3)
+
+lemma sint_uint_low_mul:
+  fixes a b :: \<open>'a::len word\<close>
+  shows \<open>(sint a * sint b) mod 2^LENGTH('a) = (uint a * uint b) mod 2^LENGTH('a)\<close>
+proof -
+  have mod_eq: \<open>sint w mod 2^LENGTH('a) = uint w mod 2^LENGTH('a)\<close> for w :: \<open>'a word\<close>
+    by (simp add: take_bit_eq_mod [symmetric] sint_uint take_bit_signed_take_bit)
+  thus ?thesis by (metis mod_mult_cong)
+qed
+
+text \<open>By the nature of two's complement, low-half multiplication is the same
+operation regardless of whether words are interpreted as signed or unsigned:
+@{thm [show_question_marks=false] sint_uint_low_mul}.
+There is therefore no distinction between signed and unsigned low-half multiply.\<close>
+
+lemma uint_mul_ops:
+  fixes a b acc :: \<open>'a::len word\<close>
+  shows \<open>uint (mul_word a b) = (uint a * uint b) mod 2^LENGTH('a)\<close>
+    and \<open>uint (mla_word acc a b) = (uint acc + uint a * uint b) mod 2^LENGTH('a)\<close>
+    and \<open>uint (mls_word acc a b) = (uint acc - uint a * uint b) mod 2^LENGTH('a)\<close>
+  unfolding mul_word_def mla_word_def mls_word_def
+  by (simp_all add: uint_word_ariths mod_simps)
+
+section \<open>Plain high-half multiply: \<open>MULH\<close>\<close>
+
+text \<open>
+This models \emph{signed} high multiplication (\<open>SMULH\<close> in some ISAs):
+\<open>mulh_word\<close> interprets both operands via \<open>sint\<close> and returns the high \<open>n\<close> bits
+of the full \<open>2n\<close>-bit signed product.
+With no doubling, signed-word inputs yield \<^term>\<open>\<bar>sint a * sint b\<bar> \<le> 2^(2*n-2)\<close>, so the
+magnitude after dividing by \<^term>\<open>2^n :: int\<close> is at most \<^term>\<open>(2^(n-2) :: int) < 2^(n-1)\<close>: \<open>sint_mulh_word\<close>
+carries no saturation precondition.
+
+Unlike the low-half operations where signed and unsigned interpretations agree
+(since taking the low \<open>n\<close> bits of \<open>a * b\<close> is the same regardless of sign
+interpretation), high multiplication is \emph{not} sign-agnostic: the high half
+of the product depends on whether operands are treated as signed or unsigned.
+The unsigned variant \<open>UMULH\<close> is given separately below.
+\<close>
+
+definition \<open>mulh_int n a b \<equiv> (a * b) div 2^n\<close>
+
+definition mulh_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>mulh_word a b \<equiv> word_of_int (mulh_int (LENGTH('a)) (sint a) (sint b))\<close>
+
+lemma %internal mulh_int_no_sat_lo:
+  fixes a b :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>-(2^(n-1)) \<le> mulh_int n (sint a) (sint b)\<close>
+proof -
+  let ?n = n
+  let ?H = \<open>2 ^ (?n - 1) :: int\<close>
+  let ?R = \<open>2 ^ ?n :: int\<close>
+  have npos: \<open>?n \<ge> 1\<close> using len_gt_0[where 'a='a] n_def by linarith
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using npos by (cases ?n) auto
+  have Hpos: \<open>?H > 0\<close> by simp
+  have Rpos: \<open>?R > 0\<close> by simp
+  have ra1: \<open>- ?H \<le> sint a\<close> and ra2: \<open>sint a < ?H\<close>
+    using sint_in_signed_range[OF n_def, of a] by auto
+  have rb1: \<open>- ?H \<le> sint b\<close> and rb2: \<open>sint b < ?H\<close>
+    using sint_in_signed_range[OF n_def, of b] by auto
+  have abs_a: \<open>\<bar>sint a\<bar> \<le> ?H\<close> using ra1 ra2 by linarith
+  have abs_b: \<open>\<bar>sint b\<bar> \<le> ?H\<close> using rb1 rb2 by linarith
+  have prod_bound: \<open>\<bar>sint a * sint b\<bar> \<le> ?H * ?H\<close>
+  proof -
+    have \<open>\<bar>sint a * sint b\<bar> = \<bar>sint a\<bar> * \<bar>sint b\<bar>\<close> by (simp add: abs_mult)
+    also have \<open>\<dots> \<le> ?H * ?H\<close> using abs_a abs_b by (simp add: mult_mono)
+    finally show ?thesis .
+  qed
+  have prod_lo: \<open>- (?H * ?H) \<le> sint a * sint b\<close> using prod_bound by linarith
+  have step_lo: \<open>?R * (- ?H) \<le> sint a * sint b\<close>
+  proof -
+    have \<open>?R * (- ?H) = - (2 * (?H * ?H))\<close> using R_eq by (simp add: algebra_simps)
+    also have \<open>\<dots> \<le> - (?H * ?H)\<close> using Hpos by (simp add: mult_left_mono)
+    also have \<open>\<dots> \<le> sint a * sint b\<close> using prod_lo .
+    finally show ?thesis .
+  qed
+  have div_lo: \<open>- ?H \<le> (sint a * sint b) div ?R\<close>
+  proof -
+    have h: \<open>(?R * (- ?H)) div ?R = - ?H\<close>
+      using Rpos nonzero_mult_div_cancel_left[of \<open>?R\<close> \<open>- ?H\<close>] by simp
+    have \<open>(?R * (- ?H)) div ?R \<le> (sint a * sint b) div ?R\<close>
+      using step_lo Rpos zdiv_mono1 by blast
+    thus ?thesis using h by simp
+  qed
+  show ?thesis unfolding mulh_int_def using div_lo .
+qed
+
+lemma %internal mulh_int_no_sat_hi:
+  fixes a b :: \<open>'a::len word\<close> and n :: nat  \<comment> \<open>number of bits in 'a word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>mulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+proof -
+  let ?n = n
+  let ?H = \<open>2 ^ (?n - 1) :: int\<close>
+  let ?R = \<open>2 ^ ?n :: int\<close>
+  have npos: \<open>?n \<ge> 1\<close> using len_gt_0[where 'a='a] n_def by linarith
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using npos by (cases ?n) auto
+  have Hpos: \<open>?H > 0\<close> by simp
+  have Rpos: \<open>?R > 0\<close> by simp
+  have ra1: \<open>- ?H \<le> sint a\<close> and ra2: \<open>sint a < ?H\<close>
+    using sint_in_signed_range[OF n_def, of a] by auto
+  have rb1: \<open>- ?H \<le> sint b\<close> and rb2: \<open>sint b < ?H\<close>
+    using sint_in_signed_range[OF n_def, of b] by auto
+  have abs_a: \<open>\<bar>sint a\<bar> \<le> ?H\<close> using ra1 ra2 by linarith
+  have abs_b: \<open>\<bar>sint b\<bar> \<le> ?H\<close> using rb1 rb2 by linarith
+  have prod_bound: \<open>sint a * sint b \<le> ?H * ?H\<close>
+  proof -
+    have \<open>sint a * sint b \<le> \<bar>sint a * sint b\<bar>\<close> by simp
+    also have \<open>\<bar>sint a * sint b\<bar> = \<bar>sint a\<bar> * \<bar>sint b\<bar>\<close> by (simp add: abs_mult)
+    also have \<open>\<dots> \<le> ?H * ?H\<close> using abs_a abs_b by (simp add: mult_mono)
+    finally show ?thesis .
+  qed
+  have prod_lt: \<open>sint a * sint b < ?H * ?R\<close>
+  proof -
+    have \<open>?H * ?R = 2 * (?H * ?H)\<close> using R_eq by (simp add: algebra_simps)
+    moreover have \<open>?H * ?H < 2 * (?H * ?H)\<close> using Hpos by simp
+    ultimately show ?thesis using prod_bound by linarith
+  qed
+  have div_hi: \<open>(sint a * sint b) div ?R < ?H\<close>
+  proof (rule ccontr)
+    assume \<open>\<not> (sint a * sint b) div ?R < ?H\<close>
+    hence H_le: \<open>?H \<le> (sint a * sint b) div ?R\<close> by simp
+    have \<open>?H * ?R \<le> (sint a * sint b) div ?R * ?R\<close>
+      using H_le Rpos by (intro mult_right_mono) auto
+    also have \<open>(sint a * sint b) div ?R * ?R \<le> sint a * sint b\<close>
+      using Rpos
+      by (metis mult.commute mult_div_mod_eq pos_mod_sign le_add_same_cancel1)
+    finally have \<open>?H * ?R \<le> sint a * sint b\<close> .
+    thus False using prod_lt by simp
+  qed
+  show ?thesis unfolding mulh_int_def using div_hi .
+qed
+
+text \<open>The signed product of two \<open>n\<close>-bit operands has magnitude at most
+\<^term>\<open>2^(2*n-2)\<close>, so its top \<open>n\<close> bits never leave the signed range and the
+specification holds unconditionally:\<close>
+
+lemma sint_mulh_word:
+  fixes a b :: \<open>'a::len word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (mulh_word a b) = mulh_int n (sint a) (sint b)\<close>
+  unfolding mulh_word_def n_def
+  by (rule sint_word_of_int_in_range[OF refl mulh_int_no_sat_lo[OF refl] mulh_int_no_sat_hi[OF refl]])
+
+subsection \<open>Unsigned high-half multiply: \<open>UMULH\<close>\<close>
+
+text \<open>
+The unsigned variant interprets both operands via \<open>uint\<close> instead of \<open>sint\<close>.
+The integer-level formula is the same as \<open>mulh_int\<close>; only the word-level
+wrapper differs.
+\<close>
+
+definition umulh_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>umulh_word a b \<equiv> word_of_int (mulh_int (LENGTH('a)) (uint a) (uint b))\<close>
+
+lemma uint_umulh_word:
+  shows \<open>uint (umulh_word a b :: 'a::len word) = (uint a * uint b) div 2^LENGTH('a)\<close>
+proof -
+  let ?n = \<open>LENGTH('a)\<close>
+  have bound: \<open>uint a * uint b div 2^?n < 2^?n\<close>
+  proof -
+    have au: \<open>uint a < 2^?n\<close> using uint_range_size[of a] by (simp add: word_size)
+    have bu: \<open>uint b < 2^?n\<close> using uint_range_size[of b] by (simp add: word_size)
+    have pos: \<open>(0::int) < 2^?n\<close> by simp
+    have prod: \<open>uint a * uint b < 2^?n * 2^?n\<close>
+      using au bu uint_ge_0[of a] uint_ge_0[of b]
+      by (meson mult_strict_mono' order_le_less_trans)
+    have \<open>uint a * uint b \<le> 2^?n * 2^?n - 1\<close> using prod by linarith
+    hence \<open>uint a * uint b div 2^?n \<le> (2^?n * 2^?n - 1) div 2^?n\<close>
+      using pos by (intro zdiv_mono1) auto
+    also have \<open>((2::int)^?n * 2^?n - 1) div 2^?n < 2^?n\<close>
+    proof -
+      have eq: \<open>((2::int)^?n * 2^?n - 1) div 2^?n = 2^?n - 1\<close>
+      proof -
+        have decomp: \<open>(2::int)^?n * 2^?n - 1 = (2^?n - 1) * 2^?n + (2^?n - 1)\<close>
+          by (simp add: algebra_simps)
+        have r: \<open>(2^?n - 1) div 2^?n = (0::int)\<close>
+          using pos by (intro div_pos_pos_trivial) linarith+
+        show ?thesis by (simp add: decomp pos r)
+      qed
+      show ?thesis using eq pos by linarith
+    qed
+    finally show ?thesis .
+  qed
+  have nonneg: \<open>0 \<le> uint a * uint b div 2^?n\<close>
+    by (simp add: div_int_pos_iff uint_ge_0)
+  show ?thesis
+    unfolding umulh_word_def mulh_int_def
+    by (simp add: uint_word_of_int take_bit_eq_mod mod_pos_pos_trivial[OF nonneg] bound)
+qed
+
+section \<open>High-half doubling multiplies: \<open>SQDMULH\<close> and \<open>SQRDMULH\<close>\<close>
+
+text \<open>
+Next we model saturating high multiplications. To extract the high part, we use
+Isabelle's \<open>div\<close> operation on \<open>int\<close>. We note that \<open>div\<close> on \<open>int\<close> is a floor division, 
+matching the arithmetic right shift used by signed two's-complement high-half instructions 
+like ARM Neon \<open>SQDMULH\<close> and PowerPC \<open>vmhraddshs\<close>. This is \emph{not} C's \<open>/\<close> on \<open>int32_t\<close>, which
+truncates toward zero and would diverge on negative dividends.
+\<close>
+
+value \<open>(-1::int) div 2 = -1\<close>  \<comment> \<open>Sanity check\<close>
+
+definition \<open>sqdmulh_int n a b \<equiv> (2 * a * b) div 2^n\<close>
+
+text \<open>
+The rounding variant \<open>SQRDMULH\<close> uses Isabelle's \<^term>\<open>round x = \<lfloor>x + 1/2\<rfloor>\<close> — round-to-nearest
+with ties broken toward \<open>+\<infinity>\<close>.
+\<close>
+
+definition \<open>sqrdmulh_int n a b \<equiv> \<lfloor>(2 * a * b) /\<^sub>\<rat> 2^n\<rceil>\<close>
+
+text \<open>
+The word-level operations saturate: when both operands equal the extreme
+negative \<open>-2\<^sup>n\<^sup>-\<^sup>1\<close>, the doubled product overflows the signed range and the
+hardware clamps to \<open>2\<^sup>n\<^sup>-\<^sup>1 - 1\<close>. This is the only input pair that triggers
+saturation. We capture this with a signed saturation function that clamps an
+integer to the \<open>n\<close>-bit signed range.
+\<close>
+
+definition signed_saturate :: \<open>int \<Rightarrow> 'a::len word\<close> where
+  \<open>signed_saturate x \<equiv>
+     word_of_int (max (-(2^(LENGTH('a)-1))) (min x (2^(LENGTH('a)-1) - 1)))\<close>
+
+definition sqdmulh_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>sqdmulh_word a b \<equiv> signed_saturate (sqdmulh_int (LENGTH('a)) (sint a) (sint b))\<close>
+
+definition sqrdmulh_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>sqrdmulh_word a b \<equiv> signed_saturate (sqrdmulh_int (LENGTH('a)) (sint a) (sint b))\<close>
+
+
+
+
+text %internal \<open>
+The saturation analyses come in two flavours: \emph{two-sided},
+\<open>sqdmulh_int_no_sat\<close> / \<open>sqrdmulh_int_no_sat\<close>, requiring strict bounds on both
+operands; and \emph{one-sided}, \<open>sqdmulh_int_no_sat_one_side\<close>, relaxing the
+first operand to \<^term>\<open>\<bar>a\<bar> \<le> 2^(n-1)\<close> — the form needed by the Barrett kernel. The
+helper \<open>sqrdmulh_int_alt\<close> rewrites the rounding division as
+\<^term>\<open>(2 * a * b + 2^(n-1)) div 2^n\<close>, on which both \<open>sqrdmulh\<close>-style analyses are based.
+With the saturation case excluded — i.e.\ the inputs are not both at the
+extreme negative \<^term>\<open>-(2^(n-1))\<close> — \<open>sint\<close> of the word operation matches the abstract
+integer spec; this is captured by \<open>sint_sqdmulh_word\<close> and \<open>sint_sqrdmulh_word\<close>
+below.
+\<close>
+
+lemma %internal round_div_int:
+  fixes x N :: int
+  assumes Npos: \<open>N > 0\<close> and Neven: \<open>even N\<close>
+  shows \<open>\<lfloor>x /\<^sub>\<rat> N\<rceil> = (x + N div 2) div N\<close>
+proof -
+  have h: \<open>2 * (N div 2) = N\<close> using Neven by simp
+  have step1: \<open>\<lfloor>x /\<^sub>\<rat> N\<rceil> = \<lfloor>x /\<^sub>\<rat> N + 1/2\<rfloor>\<close> unfolding round_def by simp
+  have step2: \<open>x /\<^sub>\<rat> N + 1/2 = (2 * x + N) /\<^sub>\<rat> (2 * N)\<close>
+    using Npos by (simp add: field_simps)
+  have step3: \<open>\<lfloor>(2 * x + N) /\<^sub>\<rat> (2 * N)\<rfloor> = (2 * x + N) div (2 * N)\<close>
+    using floor_divide_of_int_eq[where ?'a=rat] by metis
+  have step5: \<open>\<And>y. 2 * y div (2 * N) = y div N\<close>
+    by (simp add: div_mult2_eq[symmetric])
+  have step6: \<open>(2 * (x + N div 2)) div (2 * N) = (x + N div 2) div N\<close>
+    using step5[of \<open>x + N div 2\<close>] .
+  have step7: \<open>2 * x + N = 2 * (x + N div 2)\<close> using h by (simp add: distrib_left)
+  have step8: \<open>(2 * x + N) div (2 * N) = (x + N div 2) div N\<close>
+    using step6 step7 by argo
+  show ?thesis
+    using step1 step2 step3 step8 by simp
+qed
+
+lemma %internal sqrdmulh_int_alt:
+  fixes a b :: int and n :: nat
+  assumes npos: \<open>n > 0\<close>
+  shows \<open>sqrdmulh_int n a b = (2 * a * b + 2^(n-1)) div 2^n\<close>
+proof -
+  have R_eq: \<open>(2::int) ^ n = 2 * 2 ^ (n-1)\<close> using npos by (cases n) auto
+  have Reven: \<open>even ((2 :: int) ^ n)\<close> using npos by simp
+  have Rpos: \<open>(2 :: int) ^ n > 0\<close> by simp
+  have hd: \<open>((2::int)^n) div 2 = (2::int)^(n-1)\<close>
+    using R_eq by simp
+  have \<open>sqrdmulh_int n a b = \<lfloor>(2 * a * b) /\<^sub>\<rat> (2^n)\<rceil>\<close>
+    unfolding sqrdmulh_int_def ..
+  also have \<open>\<dots> = (2 * a * b + 2^n div 2) div 2^n\<close>
+    using round_div_int[OF Rpos Reven] .
+  also have \<open>\<dots> = (2 * a * b + 2^(n-1)) div 2^n\<close>
+    using hd by simp
+  finally show ?thesis .
+qed
+
+lemma %internal sqdmulh_int_no_sat:
+  fixes a b :: int and n :: nat
+  assumes npos: \<open>n > 0\<close>
+      and absa: \<open>\<bar>a\<bar> < 2^(n-1)\<close> and absb: \<open>\<bar>b\<bar> < 2^(n-1)\<close>
+  shows \<open>-(2^(n-1)) \<le> sqdmulh_int n a b\<close> and \<open>sqdmulh_int n a b < 2^(n-1)\<close>
+proof -
+  let ?H = \<open>2 ^ (n - 1) :: int\<close>
+  let ?R = \<open>2 ^ n :: int\<close>
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using npos by (cases n) auto
+  have Hpos: \<open>?H > 0\<close> by simp
+  have Rpos: \<open>?R > 0\<close> by simp
+  have abs_prod: \<open>\<bar>a * b\<bar> < ?H * ?H\<close>
+  proof -
+    have \<open>\<bar>a * b\<bar> = \<bar>a\<bar> * \<bar>b\<bar>\<close> by (simp add: abs_mult)
+    also have \<open>\<dots> < ?H * ?H\<close>
+      using absa absb Hpos
+      by (simp add: abs_ge_zero mult_strict_mono)
+    finally show ?thesis .
+  qed
+  have prod_abs2: \<open>\<bar>2 * a * b\<bar> < ?H * ?R\<close>
+    using abs_prod R_eq by (simp add: abs_mult algebra_simps)
+  show \<open>-(2^(n-1)) \<le> sqdmulh_int n a b\<close>
+  proof -
+    have \<open>- (?H * ?R) \<le> 2 * a * b\<close> using prod_abs2 by linarith
+    hence step: \<open>(- ?H) * ?R \<le> 2 * a * b\<close> by (simp add: algebra_simps)
+    have h: \<open>((- ?H) * ?R) div ?R = - ?H\<close>
+      using Rpos nonzero_mult_div_cancel_right[of ?R \<open>- ?H\<close>] by simp
+    have \<open>((- ?H) * ?R) div ?R \<le> (2 * a * b) div ?R\<close>
+      using step Rpos zdiv_mono1 by blast
+    thus ?thesis unfolding sqdmulh_int_def using h by simp
+  qed
+  show \<open>sqdmulh_int n a b < 2^(n-1)\<close>
+  proof (rule ccontr)
+    assume \<open>\<not> sqdmulh_int n a b < ?H\<close>
+    hence \<open>?H \<le> (2 * a * b) div ?R\<close> unfolding sqdmulh_int_def by simp
+    hence \<open>?H * ?R \<le> ((2 * a * b) div ?R) * ?R\<close>
+      using Rpos by (intro mult_right_mono) auto
+    moreover have \<open>((2 * a * b) div ?R) * ?R \<le> 2 * a * b\<close>
+      using Rpos
+      by (metis mult.commute mult_div_mod_eq pos_mod_sign le_add_same_cancel1)
+    ultimately have \<open>?H * ?R \<le> 2 * a * b\<close> by linarith
+    thus False using prod_abs2 by linarith
+  qed
+qed
+
+lemma %internal sqdmulh_int_no_sat_one_side:
+  fixes a b :: int and n :: nat
+  assumes npos: \<open>n > 0\<close>
+      and absa: \<open>\<bar>a\<bar> \<le> 2^(n-1)\<close> and absb: \<open>\<bar>b\<bar> < 2^(n-1)\<close>
+  shows \<open>-(2^(n-1)) \<le> sqdmulh_int n a b\<close> and \<open>sqdmulh_int n a b < 2^(n-1)\<close>
+proof -
+  let ?H = \<open>2 ^ (n - 1) :: int\<close>
+  let ?R = \<open>2 ^ n :: int\<close>
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using npos by (cases n) auto
+  have Hpos: \<open>?H > 0\<close> by simp
+  have Rpos: \<open>?R > 0\<close> by simp
+  have bH: \<open>\<bar>b\<bar> \<le> ?H - 1\<close> using absb by linarith
+  have abs_prod: \<open>\<bar>a * b\<bar> \<le> ?H * (?H - 1)\<close>
+  proof -
+    have \<open>\<bar>a * b\<bar> = \<bar>a\<bar> * \<bar>b\<bar>\<close> by (simp add: abs_mult)
+    also have \<open>\<dots> \<le> ?H * (?H - 1)\<close>
+      using absa bH Hpos by (intro mult_mono) auto
+    finally show ?thesis .
+  qed
+  have prod_abs2: \<open>\<bar>2 * a * b\<bar> \<le> 2 * ?H * (?H - 1)\<close>
+    using abs_prod by (simp add: abs_mult algebra_simps)
+  have lt_HR: \<open>2 * ?H * (?H - 1) < ?H * ?R\<close>
+  proof -
+    have \<open>2 * ?H * (?H - 1) = 2 * ?H * ?H - 2 * ?H\<close>
+      by (simp add: algebra_simps)
+    also have \<open>\<dots> < 2 * ?H * ?H\<close> using Hpos by linarith
+    also have \<open>2 * ?H * ?H = ?H * ?R\<close> using R_eq by (simp add: algebra_simps)
+    finally show ?thesis .
+  qed
+  show \<open>-(2^(n-1)) \<le> sqdmulh_int n a b\<close>
+  proof -
+    have \<open>- (?H * ?R) < 2 * a * b\<close> using prod_abs2 lt_HR by linarith
+    hence step: \<open>(- ?H) * ?R \<le> 2 * a * b\<close> by (simp add: algebra_simps)
+    have h: \<open>((- ?H) * ?R) div ?R = - ?H\<close>
+      using Rpos nonzero_mult_div_cancel_right[of ?R \<open>- ?H\<close>] by simp
+    have \<open>((- ?H) * ?R) div ?R \<le> (2 * a * b) div ?R\<close>
+      using step Rpos zdiv_mono1 by blast
+    thus ?thesis unfolding sqdmulh_int_def using h by simp
+  qed
+  show \<open>sqdmulh_int n a b < 2^(n-1)\<close>
+  proof (rule ccontr)
+    assume \<open>\<not> sqdmulh_int n a b < ?H\<close>
+    hence \<open>?H \<le> (2 * a * b) div ?R\<close> unfolding sqdmulh_int_def by simp
+    hence \<open>?H * ?R \<le> ((2 * a * b) div ?R) * ?R\<close>
+      using Rpos by (intro mult_right_mono) auto
+    moreover have \<open>((2 * a * b) div ?R) * ?R \<le> 2 * a * b\<close>
+      using Rpos
+      by (metis mult.commute mult_div_mod_eq pos_mod_sign le_add_same_cancel1)
+    ultimately have \<open>?H * ?R \<le> 2 * a * b\<close> by linarith
+    thus False using prod_abs2 lt_HR by linarith
+  qed
+qed
+
+text %internal \<open>The rounding variant follows the same template, with the rounding offset
+absorbed into the \<^term>\<open>(+) (2^(n-1) :: int)\<close> shift of @{thm [source] sqrdmulh_int_alt}.\<close>
+
+lemma %internal sqrdmulh_int_no_sat:
+  fixes a b :: int and n :: nat
+  assumes npos: \<open>n > 0\<close>
+      and absa: \<open>\<bar>a\<bar> < 2^(n-1)\<close> and absb: \<open>\<bar>b\<bar> < 2^(n-1)\<close>
+  shows \<open>-(2^(n-1)) \<le> sqrdmulh_int n a b\<close> and \<open>sqrdmulh_int n a b < 2^(n-1)\<close>
+proof -
+  let ?H = \<open>2 ^ (n - 1) :: int\<close>
+  let ?R = \<open>2 ^ n :: int\<close>
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using npos by (cases n) auto
+  have Hpos: \<open>?H > 0\<close> by simp
+  have Rpos: \<open>?R > 0\<close> by simp
+  have aH: \<open>\<bar>a\<bar> \<le> ?H - 1\<close> using absa by linarith
+  have bH: \<open>\<bar>b\<bar> \<le> ?H - 1\<close> using absb by linarith
+  have abs_prod: \<open>\<bar>a * b\<bar> \<le> (?H - 1) * (?H - 1)\<close>
+  proof -
+    have \<open>\<bar>a * b\<bar> = \<bar>a\<bar> * \<bar>b\<bar>\<close> by (simp add: abs_mult)
+    also have \<open>\<dots> \<le> (?H - 1) * (?H - 1)\<close>
+      using aH bH by (intro mult_mono) auto
+    finally show ?thesis .
+  qed
+  have prod_abs2: \<open>\<bar>2 * a * b\<bar> \<le> 2 * (?H - 1) * (?H - 1)\<close>
+    using abs_prod by (simp add: abs_mult algebra_simps)
+  have lt_HR: \<open>2 * (?H - 1) * (?H - 1) < ?H * ?R\<close>
+  proof -
+    have \<open>2 * (?H - 1) * (?H - 1) = 2 * ?H * ?H - 4 * ?H + 2\<close>
+      by (simp add: algebra_simps power2_eq_square)
+    also have \<open>\<dots> < 2 * ?H * ?H\<close> using Hpos by linarith
+    also have \<open>2 * ?H * ?H = ?H * ?R\<close> using R_eq by (simp add: algebra_simps)
+    finally show ?thesis .
+  qed
+  have alt: \<open>sqrdmulh_int n a b = (2 * a * b + ?H) div ?R\<close>
+    using sqrdmulh_int_alt[OF npos] .
+  have div_neg: \<open>(- (?H * ?R)) div ?R = - ?H\<close>
+  proof -
+    have \<open>- (?H * ?R) = (- ?H) * ?R\<close> by simp
+    thus ?thesis using Rpos
+      by (metis nonzero_mult_div_cancel_right order.strict_iff_not)
+  qed
+  have div_aux: \<open>(?H * ?R - 1) div ?R = ?H - 1\<close>
+  proof -
+    have eq: \<open>?H * ?R - 1 = (?H - 1) * ?R + (?R - 1)\<close>
+      by (simp add: algebra_simps)
+    have \<open>((?H - 1) * ?R + (?R - 1)) div ?R = (?H - 1) + (?R - 1) div ?R\<close>
+      using Rpos by simp
+    also have \<open>\<dots> = ?H - 1\<close> using Rpos by simp
+    finally have eq2: \<open>((?H - 1) * ?R + (?R - 1)) div ?R = ?H - 1\<close> .
+    show ?thesis using eq eq2 by argo
+  qed
+  show \<open>-(2^(n-1)) \<le> sqrdmulh_int n a b\<close>
+  proof -
+    have lo: \<open>- (?H * ?R) \<le> 2 * a * b\<close>
+      using prod_abs2 lt_HR by linarith
+    hence step: \<open>- (?H * ?R) \<le> 2 * a * b + ?H\<close> using Hpos by linarith
+    have \<open>(- (?H * ?R)) div ?R \<le> (2 * a * b + ?H) div ?R\<close>
+      using step Rpos zdiv_mono1 by blast
+    thus ?thesis using div_neg alt by simp
+  qed
+  show \<open>sqrdmulh_int n a b < 2^(n-1)\<close>
+  proof -
+    have \<open>2 * a * b \<le> 2 * (?H - 1) * (?H - 1)\<close> using prod_abs2 by linarith
+    moreover have \<open>2 * (?H - 1) * (?H - 1) + ?H < ?H * ?R\<close>
+    proof -
+      have \<open>2 * (?H - 1) * (?H - 1) = 2 * ?H * ?H - 4 * ?H + 2\<close>
+        by (simp add: algebra_simps power2_eq_square)
+      also have \<open>\<dots> + ?H < 2 * ?H * ?H\<close> using Hpos by linarith
+      also have \<open>2 * ?H * ?H = ?H * ?R\<close> using R_eq by (simp add: algebra_simps)
+      finally show ?thesis by linarith
+    qed
+    ultimately have hi: \<open>2 * a * b + ?H \<le> ?H * ?R - 1\<close> by linarith
+    have \<open>(2 * a * b + ?H) div ?R \<le> (?H * ?R - 1) div ?R\<close>
+      using hi Rpos zdiv_mono1 by force
+    also have \<open>\<dots> = ?H - 1\<close> using div_aux .
+    also have \<open>\<dots> < ?H\<close> by simp
+    finally show ?thesis using alt by simp
+  qed
+qed
+
+text %internal \<open>The one-sided variant for \<open>SQRDMULH\<close>, mirroring
+\<open>sqdmulh_int_no_sat_one_side\<close>: relax the bound on the first operand to
+\<^term>\<open>\<bar>a\<bar> \<le> 2^(n-1)\<close>, keep the strict bound on the second.
+Used by the rounding doubling-Montgomery kernel where \<open>k\<close> is the
+output of a low-half multiply.\<close>
+
+lemma %internal sqrdmulh_int_no_sat_one_side:
+  fixes a b :: int and n :: nat
+  assumes npos: \<open>n > 0\<close>
+      and absa: \<open>\<bar>a\<bar> \<le> 2^(n-1)\<close> and absb: \<open>\<bar>b\<bar> < 2^(n-1)\<close>
+  shows \<open>-(2^(n-1)) \<le> sqrdmulh_int n a b\<close> and \<open>sqrdmulh_int n a b < 2^(n-1)\<close>
+proof -
+  let ?H = \<open>2 ^ (n - 1) :: int\<close>
+  let ?R = \<open>2 ^ n :: int\<close>
+  have R_eq: \<open>?R = 2 * ?H\<close>
+    using npos by (cases n) auto
+  have Hpos: \<open>?H > 0\<close> by simp
+  have Rpos: \<open>?R > 0\<close> by simp
+  have bH: \<open>\<bar>b\<bar> \<le> ?H - 1\<close> using absb by linarith
+  have abs_prod: \<open>\<bar>a * b\<bar> \<le> ?H * (?H - 1)\<close>
+  proof -
+    have \<open>\<bar>a * b\<bar> = \<bar>a\<bar> * \<bar>b\<bar>\<close> by (simp add: abs_mult)
+    also have \<open>\<dots> \<le> ?H * (?H - 1)\<close>
+      using absa bH Hpos by (intro mult_mono) auto
+    finally show ?thesis .
+  qed
+  have prod_abs2: \<open>\<bar>2 * a * b\<bar> \<le> 2 * ?H * (?H - 1)\<close>
+    using abs_prod by (simp add: abs_mult algebra_simps)
+  have HR_eq: \<open>?H * ?R = 2 * ?H * ?H\<close>
+    using R_eq by (simp add: algebra_simps)
+  have lt_HR_strict: \<open>2 * ?H * (?H - 1) + ?H < ?H * ?R\<close>
+  proof -
+    have e1: \<open>2 * ?H * (?H - 1) + ?H = 2 * ?H * ?H - ?H\<close>
+      by (simp add: algebra_simps)
+    have \<open>2 * ?H * ?H - ?H < 2 * ?H * ?H\<close> using Hpos by simp
+    thus ?thesis using e1 HR_eq by linarith
+  qed
+  have le_HR: \<open>2 * ?H * (?H - 1) \<le> ?H * ?R\<close>
+    using lt_HR_strict Hpos by linarith
+  have alt: \<open>sqrdmulh_int n a b = (2 * a * b + ?H) div ?R\<close>
+    using sqrdmulh_int_alt[OF npos] .
+  have div_neg: \<open>(- (?H * ?R)) div ?R = - ?H\<close>
+  proof -
+    have \<open>- (?H * ?R) = (- ?H) * ?R\<close> by simp
+    thus ?thesis using Rpos
+      by (metis nonzero_mult_div_cancel_right order.strict_iff_not)
+  qed
+  have div_aux: \<open>(?H * ?R - 1) div ?R = ?H - 1\<close>
+  proof -
+    have eq: \<open>?H * ?R - 1 = (?H - 1) * ?R + (?R - 1)\<close>
+      by (simp add: algebra_simps)
+    have \<open>((?H - 1) * ?R + (?R - 1)) div ?R = (?H - 1) + (?R - 1) div ?R\<close>
+      using Rpos by simp
+    also have \<open>\<dots> = ?H - 1\<close> using Rpos by simp
+    finally have eq2: \<open>((?H - 1) * ?R + (?R - 1)) div ?R = ?H - 1\<close> .
+    show ?thesis using eq eq2 by argo
+  qed
+  show \<open>-(2^(n-1)) \<le> sqrdmulh_int n a b\<close>
+  proof -
+    have lo: \<open>- (?H * ?R) \<le> 2 * a * b\<close>
+      using prod_abs2 le_HR by linarith
+    hence step: \<open>- (?H * ?R) \<le> 2 * a * b + ?H\<close> using Hpos by linarith
+    have \<open>(- (?H * ?R)) div ?R \<le> (2 * a * b + ?H) div ?R\<close>
+      using step Rpos zdiv_mono1 by blast
+    thus ?thesis using div_neg alt by simp
+  qed
+  show \<open>sqrdmulh_int n a b < 2^(n-1)\<close>
+  proof -
+    have hi_part: \<open>2 * a * b \<le> 2 * ?H * (?H - 1)\<close> using prod_abs2 by linarith
+    hence hi: \<open>2 * a * b + ?H \<le> ?H * ?R - 1\<close> using lt_HR_strict by linarith
+    have \<open>(2 * a * b + ?H) div ?R \<le> (?H * ?R - 1) div ?R\<close>
+      using hi Rpos zdiv_mono1 by force
+    also have \<open>\<dots> = ?H - 1\<close> using div_aux .
+    also have \<open>\<dots> < ?H\<close> by simp
+    finally show ?thesis using alt by simp
+  qed
+qed
+
+text \<open>The word-level lifts: as long as the inputs are not both at the
+extreme \<open>-2\<^sup>n\<^sup>-\<^sup>1\<close> (the only saturating case), the signed-integer
+specifications transfer to fixed-width word operands.\<close>
+
+lemma sint_sqdmulh_word:
+  fixes a b :: \<open>'a::len word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes not_extreme: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint b = -(2^(n-1)))\<close>
+  shows \<open>sint (sqdmulh_word a b) = sqdmulh_int n (sint a) (sint b)\<close>
+proof -
+  let ?H = \<open>2 ^ (n - 1) :: int\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have ra: \<open>- ?H \<le> sint a\<close> \<open>sint a < ?H\<close>
+    using sint_in_signed_range[OF n_def, of a] by auto
+  have rb: \<open>- ?H \<le> sint b\<close> \<open>sint b < ?H\<close>
+    using sint_in_signed_range[OF n_def, of b] by auto
+  have abs_a: \<open>\<bar>sint a\<bar> \<le> ?H\<close> using ra by linarith
+  have abs_b: \<open>\<bar>sint b\<bar> \<le> ?H\<close> using rb by linarith
+  have sym: \<open>sqdmulh_int n (sint a) (sint b) = sqdmulh_int n (sint b) (sint a)\<close>
+    unfolding sqdmulh_int_def by (simp add: algebra_simps)
+  have lo: \<open>-(2^(n-1)) \<le> sqdmulh_int n (sint a) (sint b)\<close>
+   and hi: \<open>sqdmulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+  proof (atomize(full), cases \<open>sint a = -(2^(n-1))\<close>)
+    case True
+    hence b_ne: \<open>sint b \<noteq> -(2^(n-1))\<close> using not_extreme by blast
+    hence absb_strict: \<open>\<bar>sint b\<bar> < ?H\<close> using rb by linarith
+    show \<open>-(2^(n-1)) \<le> sqdmulh_int n (sint a) (sint b) \<and>
+          sqdmulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+      using sqdmulh_int_no_sat_one_side(1)[OF npos abs_a absb_strict]
+            sqdmulh_int_no_sat_one_side(2)[OF npos abs_a absb_strict]
+      by simp
+  next
+    case False
+    hence absa_strict: \<open>\<bar>sint a\<bar> < ?H\<close> using ra by linarith
+    show \<open>-(2^(n-1)) \<le> sqdmulh_int n (sint a) (sint b) \<and>
+          sqdmulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+      using sqdmulh_int_no_sat_one_side(1)[OF npos abs_b absa_strict]
+            sqdmulh_int_no_sat_one_side(2)[OF npos abs_b absa_strict]
+            sym
+      by simp
+  qed
+  show ?thesis
+    unfolding sqdmulh_word_def signed_saturate_def n_def
+    using lo[unfolded n_def] hi[unfolded n_def]
+    by (simp add: sint_word_of_int_in_range)
+qed
+
+lemma sint_sqrdmulh_word:
+  fixes a b :: \<open>'a::len word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes not_extreme: \<open>\<not> (sint a = -(2^(n-1)) \<and> sint b = -(2^(n-1)))\<close>
+  shows \<open>sint (sqrdmulh_word a b) = sqrdmulh_int n (sint a) (sint b)\<close>
+proof -
+  let ?H = \<open>2 ^ (n - 1) :: int\<close>
+  have npos: \<open>n > 0\<close> unfolding n_def using len_gt_0[where 'a='a] .
+  have ra: \<open>- ?H \<le> sint a\<close> \<open>sint a < ?H\<close>
+    using sint_in_signed_range[OF n_def, of a] by auto
+  have rb: \<open>- ?H \<le> sint b\<close> \<open>sint b < ?H\<close>
+    using sint_in_signed_range[OF n_def, of b] by auto
+  have abs_a: \<open>\<bar>sint a\<bar> \<le> ?H\<close> using ra by linarith
+  have abs_b: \<open>\<bar>sint b\<bar> \<le> ?H\<close> using rb by linarith
+  have sym: \<open>sqrdmulh_int n (sint a) (sint b) = sqrdmulh_int n (sint b) (sint a)\<close>
+    unfolding sqrdmulh_int_def by (simp add: algebra_simps)
+  have lo: \<open>-(2^(n-1)) \<le> sqrdmulh_int n (sint a) (sint b)\<close>
+   and hi: \<open>sqrdmulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+  proof (atomize(full), cases \<open>sint a = -(2^(n-1))\<close>)
+    case True
+    hence b_ne: \<open>sint b \<noteq> -(2^(n-1))\<close> using not_extreme by blast
+    hence absb_strict: \<open>\<bar>sint b\<bar> < ?H\<close> using rb by linarith
+    show \<open>-(2^(n-1)) \<le> sqrdmulh_int n (sint a) (sint b) \<and>
+          sqrdmulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+      using sqrdmulh_int_no_sat_one_side(1)[OF npos abs_a absb_strict]
+            sqrdmulh_int_no_sat_one_side(2)[OF npos abs_a absb_strict]
+      by simp
+  next
+    case False
+    hence absa_strict: \<open>\<bar>sint a\<bar> < ?H\<close> using ra by linarith
+    show \<open>-(2^(n-1)) \<le> sqrdmulh_int n (sint a) (sint b) \<and>
+          sqrdmulh_int n (sint a) (sint b) < 2 ^ (n - 1)\<close>
+      using sqrdmulh_int_no_sat_one_side(1)[OF npos abs_b absa_strict]
+            sqrdmulh_int_no_sat_one_side(2)[OF npos abs_b absa_strict]
+            sym
+      by simp
+  qed
+  show ?thesis
+    unfolding sqrdmulh_word_def signed_saturate_def n_def
+    using lo[unfolded n_def] hi[unfolded n_def]
+    by (simp add: sint_word_of_int_in_range)
+qed
+
+
+section \<open>Rounding multiply-accumulate high: \<open>SQRDMLAH\<close>\<close>
+
+text \<open>
+\<open>SQRDMLAH\<close> is the rounding multiply-accumulate variant: it computes
+\<^term>\<open>acc + \<lfloor>(2 * a * b) /\<^sub>\<rat> 2^n\<rceil>\<close>, fusing the high-half rounding multiplication of
+\<open>SQRDMULH\<close> with an accumulator add. It is used in the doubled rounding
+Montgomery kernel of \cite[Algorithm~13]{NeonNTT}, where the
+final \<open>SHSUB\<close> is dropped and the correction is folded into the
+multiply-accumulate.
+\<close>
+
+definition \<open>sqrdmlah_int n acc a b \<equiv> acc + sqrdmulh_int n a b\<close>
+
+definition sqrdmlah_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>sqrdmlah_word acc a b \<equiv>
+     signed_saturate (sqrdmlah_int (LENGTH('a)) (sint acc) (sint a) (sint b))\<close>
+
+text \<open>With the integer result inside the canonical signed range,
+\<open>sint\<close> of the word operation matches the integer specification.\<close>
+
+lemma sint_sqrdmlah_word:
+  fixes acc a b :: \<open>'a::len word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  assumes lo: \<open>-(2^(n-1)) \<le> sqrdmlah_int n (sint acc) (sint a) (sint b)\<close>
+      and hi: \<open>sqrdmlah_int n (sint acc) (sint a) (sint b) < 2 ^ (n - 1)\<close>
+  shows \<open>sint (sqrdmlah_word acc a b)
+           = sqrdmlah_int n (sint acc) (sint a) (sint b)\<close>
+  unfolding sqrdmlah_word_def signed_saturate_def n_def
+  using lo[unfolded n_def] hi[unfolded n_def]
+  by (simp add: sint_word_of_int_in_range)
+
+
+
+
+section \<open>Halving subtract: \<open>SHSUB\<close>\<close>
+
+text \<open>
+\<open>SHSUB\<close> absorbs a factor of two inside the Barrett-reduction kernel without losing
+the high bit; with no doubling, saturation cannot occur, so the \<open>sint\<close> specification
+is unconditional.
+\<close>
+
+definition \<open>shsub_int a b \<equiv> (a - b) div 2\<close>
+
+definition shsub_word :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>shsub_word a b \<equiv> word_of_int (shsub_int (sint a) (sint b))\<close>
+
+lemma sint_shsub_word:
+  shows \<open>sint (shsub_word a b :: 'a::len word) = shsub_int (sint a) (sint b)\<close>
+proof -
+  define n :: nat where n_def: \<open>n = LENGTH('a)\<close>
+  have ra: \<open>-(2^(n-1)) \<le> sint a \<and> sint a < 2 ^ (n - 1)\<close>
+    using sint_in_signed_range[OF n_def, of a] .
+  have rb: \<open>-(2^(n-1)) \<le> sint b \<and> sint b < 2 ^ (n - 1)\<close>
+    using sint_in_signed_range[OF n_def, of b] .
+  have lo: \<open>-(2^(n-1)) \<le> shsub_int (sint a) (sint b)\<close>
+    unfolding shsub_int_def using ra rb by linarith
+  have hi: \<open>shsub_int (sint a) (sint b) < 2 ^ (n - 1)\<close>
+    unfolding shsub_int_def using ra rb by linarith
+  show ?thesis
+    unfolding shsub_word_def by (rule sint_word_of_int_in_range[OF n_def lo hi])
+qed
+
+
+section \<open>Rounding right shift: \<^verbatim>\<open>SRSHR\<close>\<close>
+
+text \<open>\<^verbatim>\<open>SRSHR\<close> shifts a signed lane right by a compile-time constant \<^term>\<open>k\<close>,
+rounding to nearest. We use it in refined Barrett reduction, where it follows
+a \<^verbatim>\<open>SQDMULH\<close> to realise an approximation at an inflated effective radix.\<close>
+
+definition \<open>srshr_int k x \<equiv> \<lfloor>x /\<^sub>\<rat> 2^k\<rceil>\<close>
+
+definition srshr_word :: \<open>nat \<Rightarrow> 'a::len word \<Rightarrow> 'a word\<close> where
+  \<open>srshr_word k x \<equiv> word_of_int (srshr_int k (sint x))\<close>
+
+lemma sint_srshr_word:
+  fixes x :: \<open>'a::len word\<close>
+  assumes n_def: \<open>n = LENGTH('a)\<close>
+  shows \<open>sint (srshr_word k x) = srshr_int k (sint x)\<close>
+proof -
+  have npos: \<open>n \<ge> 1\<close> unfolding n_def using len_gt_0[where 'a='a] by linarith
+  have rx: \<open>-(2^(n-1)) \<le> sint x\<close> \<open>sint x < 2^(n-1)\<close>
+    using sint_in_signed_range[OF n_def, of x] by auto
+  have lo: \<open>-(2^(n-1)) \<le> srshr_int k (sint x)\<close>
+  proof -
+    define H :: int where \<open>H = 2^(n-1)\<close>
+    have Hpos: \<open>H > 0\<close> unfolding H_def by simp
+    have x_lo: \<open>sint x \<ge> -H\<close> using rx(1) unfolding H_def by simp
+    have pow_pos: \<open>(of_int ((2::int)^k) :: rat) > 0\<close> by simp
+    have pow_ge1: \<open>(of_int ((2::int)^k) :: rat) \<ge> 1\<close> by simp
+    have rat_lo: \<open>(of_int (sint x) :: rat) / of_int ((2::int)^k) \<ge> - of_int H\<close>
+    proof -
+      have h1: \<open>(of_int (sint x) :: rat) \<ge> - of_int H\<close>
+        using x_lo by (metis of_int_le_iff of_int_minus)
+      have h1b: \<open>(of_int (sint x) :: rat) / of_int ((2::int)^k) \<ge> (- of_int H) / of_int ((2::int)^k)\<close>
+        using h1 pow_pos by (intro divide_right_mono) auto
+      have h2: \<open>(- of_int H :: rat) / of_int ((2::int)^k) \<ge> - of_int H\<close>
+      proof -
+        have neg: \<open>(- of_int H :: rat) \<le> 0\<close> using Hpos by simp
+        have \<open>(- of_int H :: rat) = (- of_int H) * 1\<close> by simp
+        also have \<open>\<dots> \<le> (- of_int H) * (1 / of_int ((2::int)^k))\<close>
+          using neg pow_ge1 by (intro mult_left_mono_neg) auto
+        also have \<open>\<dots> = (- of_int H) / of_int ((2::int)^k)\<close> by simp
+        finally show ?thesis .
+      qed
+      show ?thesis using h1b h2 by linarith
+    qed
+    have \<open>\<lfloor>(of_int (sint x) :: rat) / of_int ((2::int)^k) + 1/2\<rfloor> \<ge> -H\<close>
+      using rat_lo by linarith
+    thus ?thesis unfolding srshr_int_def round_def H_def by simp
+  qed
+  have hi: \<open>srshr_int k (sint x) < 2^(n-1)\<close>
+  proof -
+    define H :: int where \<open>H = 2^(n-1)\<close>
+    have Hpos: \<open>H > 0\<close> unfolding H_def by simp
+    have x_hi: \<open>sint x < H\<close> using rx(2) unfolding H_def by simp
+    hence x_le: \<open>sint x \<le> H - 1\<close> by linarith
+    have pow_pos: \<open>(of_int ((2::int)^k) :: rat) > 0\<close> by simp
+    have pow_ge1: \<open>(of_int ((2::int)^k) :: rat) \<ge> 1\<close> by simp
+    have rat_hi: \<open>(of_int (sint x) :: rat) / of_int ((2::int)^k) \<le> of_int (H - 1)\<close>
+    proof (cases \<open>sint x \<ge> 0\<close>)
+      case True
+      have h1: \<open>(of_int (sint x) :: rat) \<le> of_int (H - 1)\<close>
+        using x_le by (metis of_int_le_iff)
+      have nn: \<open>(of_int (sint x) :: rat) \<ge> 0\<close>
+        using True by (metis of_int_0_le_iff)
+      have \<open>(of_int (sint x) :: rat) / of_int ((2::int)^k) \<le> of_int (sint x)\<close>
+      proof -
+        have \<open>of_int (sint x) = (of_int (sint x) :: rat) * 1\<close> by simp
+        also have \<open>\<dots> \<le> (of_int (sint x) :: rat) * of_int ((2::int)^k)\<close>
+          using nn pow_ge1 by (intro mult_left_mono) auto
+        finally show ?thesis using pow_pos by (simp add: pos_divide_le_eq)
+      qed
+      thus ?thesis using h1 by linarith
+    next
+      case False
+      hence \<open>sint x < 0\<close> by simp
+      hence \<open>(of_int (sint x) :: rat) < 0\<close>
+        by (metis of_int_0 of_int_less_iff)
+      hence \<open>(of_int (sint x) :: rat) / of_int ((2::int)^k) < 0\<close>
+        using pow_pos by (simp add: divide_neg_pos)
+      moreover have \<open>(of_int (H - 1) :: rat) \<ge> 0\<close> using Hpos by simp
+      ultimately show ?thesis by linarith
+    qed
+    have \<open>\<lfloor>(of_int (sint x) :: rat) / of_int ((2::int)^k) + 1/2\<rfloor> < H\<close>
+    proof -
+      have \<open>(of_int (sint x) :: rat) / of_int ((2::int)^k) + 1/2 \<le> of_int (H - 1) + 1/2\<close>
+        using rat_hi by linarith
+      also have \<open>\<dots> < of_int H\<close> by simp
+      finally show ?thesis by linarith
+    qed
+    thus ?thesis unfolding srshr_int_def round_def H_def by simp
+  qed
+  show ?thesis
+    unfolding srshr_word_def by (rule sint_word_of_int_in_range[OF n_def lo hi])
+qed
+
+
+
+
+
+
+
+
+
+
+section \<open>Assembly-style notation for kernel definitions\<close>
+
+text \<open>
+We use simple syntax sugar around HOL \<open>let\<close> bindings to provide a shallow
+embedding of symbolic assembly sequences using the instructions above:
+\begin{quote}
+\<open>let ASM \<laquo> MUL z a b; SQRDMULH t a halfBT; MLS r z t N \<raquo> in r\<close>
+\end{quote}
+desugars to nested \<open>let\<close>-bindings over the \<open>*_word\<close> operations above.
+An \<open>ASM \<laquo>\<dots>\<raquo>\<close> block must sit at the tail of its enclosing \<open>let\<close>.
+\<close>
+
+(*<*)
+nonterminal asm_letbinds and asm_letbind
+
+bundle ASM_syntax
+begin
+
+syntax
+  "_asm_mul"      :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"           ("MUL _ _ _")
+  "_asm_mulh"     :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"           ("MULH _ _ _")
+  "_asm_sqdmulh"  :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"           ("SQDMULH _ _ _")
+  "_asm_sqrdmulh" :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"           ("SQRDMULH _ _ _")
+  "_asm_shsub"    :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"           ("SHSUB _ _ _")
+  "_asm_srshr"    :: "pttrn \<Rightarrow> 'a \<Rightarrow> nat \<Rightarrow> asm_letbind"          ("SRSHR _ _ #_")
+  "_asm_mla"      :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"     ("MLA _ _ _ _")
+  "_asm_mls"      :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"     ("MLS _ _ _ _")
+  "_asm_sqrdmlah" :: "pttrn \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> 'a \<Rightarrow> asm_letbind"     ("SQRDMLAH _ _ _ _")
+  ""              :: "asm_letbind \<Rightarrow> asm_letbinds"                ("_")
+  "_asm_binds"    :: "[asm_letbind, asm_letbinds] \<Rightarrow> asm_letbinds"  ("_;/ _")
+  "_ASM_block"    :: "asm_letbinds \<Rightarrow> letbinds"                   ("ASM \<guillemotleft> _ / \<guillemotright>")
+
+translations
+  "_asm_mul d a b"      \<rightleftharpoons> "_bind d (CONST mul_word a b)"
+  "_asm_mulh d a b"     \<rightleftharpoons> "_bind d (CONST mulh_word a b)"
+  "_asm_sqdmulh d a b"  \<rightleftharpoons> "_bind d (CONST sqdmulh_word a b)"
+  "_asm_sqrdmulh d a b" \<rightleftharpoons> "_bind d (CONST sqrdmulh_word a b)"
+  "_asm_shsub d a b"    \<rightleftharpoons> "_bind d (CONST shsub_word a b)"
+  "_asm_srshr d a k"    \<rightleftharpoons> "_bind d (CONST srshr_word k a)"
+  "_asm_mla d a b c"    \<rightleftharpoons> "_bind d (CONST mla_word a b c)"
+  "_asm_mls d a b c"    \<rightleftharpoons> "_bind d (CONST mls_word a b c)"
+  "_asm_sqrdmlah d a b c" \<rightleftharpoons> "_bind d (CONST sqrdmlah_word a b c)"
+  "_ASM_block (_asm_binds b bs)" \<rightharpoonup> "_binds b (_ASM_block bs)"
+  "_ASM_block b"                 \<rightharpoonup> "b"
+
+
+
+end
+
+context
+    includes ASM_syntax
+  begin
+(*>*)
+text \<open>Let's look at a simple example:\<close>
+
+definition asm_test :: \<open>'a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word \<Rightarrow> 'a word\<close> where
+  \<open>asm_test a b N \<equiv>
+     let ASM \<guillemotleft>
+       MUL      z a b;
+       SQRDMULH t a b;
+       MLS      r z t N
+     \<guillemotright> in r\<close>
+
+text \<open>\noindent This definitionally desugars to the following:\<close>
+
+lemma asm_test_eq:
+  \<open>asm_test a b N
+     \<equiv> (let z = mul_word a b;
+            t = sqrdmulh_word a b
+        in mls_word z t N)\<close>
+  unfolding asm_test_def Let_def by (rule reflexive)
+
+(*<*)
+end
+(*>*)
+
+section \<open>Conformance testing\<close>
+
+text \<open>The instruction models above are pen-and-paper. To gain confidence
+that they faithfully reflect the AArch64 ISA, the development ships a small
+conformance harness under \<^verbatim>\<open>model/\<close>. Each modelled operation is exposed
+through Isabelle's code extractor as a string-keyed dispatcher
+\<^verbatim>\<open>model_exec MNEMONIC BITWIDTH ARG ...\<close>, exported to SML; a sibling C
+program \<^verbatim>\<open>hw_exec\<close> with the same CLI executes the corresponding instruction
+through inline assembly on real silicon (Neon for 8/16/32-bit lanes; scalar
+\<^verbatim>\<open>SMULH\<close>/\<^verbatim>\<open>UMULH\<close> at 64 bits). A Python driver pipes identical hex inputs into
+both and compares outputs bit-for-bit. The default \<^verbatim>\<open>all\<close> mode runs the 8-bit
+operations exhaustively (33M cases) and one million random plus all
+edge-value cases per 16/32/64-bit operation; current results are zero
+divergences across roughly 50M cases.\<close>
+
+end

--- a/proofs/isabelle/neon_ntt/Word_Ops_Export.thy
+++ b/proofs/isabelle/neon_ntt/Word_Ops_Export.thy
@@ -1,0 +1,102 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+theory Word_Ops_Export
+  imports Word_Ops "HOL-Library.Code_Target_Numeral"
+begin
+
+type_synonym w8  = "8 word"
+type_synonym w16 = "16 word"
+type_synonym w32 = "32 word"
+type_synonym w64 = "64 word"
+
+definition mul_w8     :: "w8 \<Rightarrow> w8 \<Rightarrow> w8" where "mul_w8     = mul_word"
+definition mul_w16    :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word"           where "mul_w16    = mul_word"
+definition mul_w32    :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word"           where "mul_w32    = mul_word"
+
+definition mla_w8     :: "8  word \<Rightarrow> 8  word \<Rightarrow> 8  word \<Rightarrow> 8  word"  where "mla_w8     = mla_word"
+definition mla_w16    :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word \<Rightarrow> 16 word" where "mla_w16    = mla_word"
+definition mla_w32    :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word \<Rightarrow> 32 word" where "mla_w32    = mla_word"
+
+definition mls_w8     :: "8  word \<Rightarrow> 8  word \<Rightarrow> 8  word \<Rightarrow> 8  word"  where "mls_w8     = mls_word"
+definition mls_w16    :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word \<Rightarrow> 16 word" where "mls_w16    = mls_word"
+definition mls_w32    :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word \<Rightarrow> 32 word" where "mls_w32    = mls_word"
+
+definition sqdmulh_w16   :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word"          where "sqdmulh_w16   = sqdmulh_word"
+definition sqdmulh_w32   :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word"          where "sqdmulh_w32   = sqdmulh_word"
+
+definition sqrdmulh_w16  :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word"          where "sqrdmulh_w16  = sqrdmulh_word"
+definition sqrdmulh_w32  :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word"          where "sqrdmulh_w32  = sqrdmulh_word"
+
+definition sqrdmlah_w16  :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word \<Rightarrow> 16 word" where "sqrdmlah_w16  = sqrdmlah_word"
+definition sqrdmlah_w32  :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word \<Rightarrow> 32 word" where "sqrdmlah_w32  = sqrdmlah_word"
+
+definition shsub_w8      :: "8  word \<Rightarrow> 8  word \<Rightarrow> 8  word"          where "shsub_w8      = shsub_word"
+definition shsub_w16     :: "16 word \<Rightarrow> 16 word \<Rightarrow> 16 word"          where "shsub_w16     = shsub_word"
+definition shsub_w32     :: "32 word \<Rightarrow> 32 word \<Rightarrow> 32 word"          where "shsub_w32     = shsub_word"
+
+definition srshr_w8      :: "nat \<Rightarrow> 8  word \<Rightarrow> 8  word"               where "srshr_w8      = srshr_word"
+definition srshr_w16     :: "nat \<Rightarrow> 16 word \<Rightarrow> 16 word"               where "srshr_w16     = srshr_word"
+definition srshr_w32     :: "nat \<Rightarrow> 32 word \<Rightarrow> 32 word"               where "srshr_w32     = srshr_word"
+
+definition mulh_w64      :: "64 word \<Rightarrow> 64 word \<Rightarrow> 64 word"          where "mulh_w64      = mulh_word"
+definition umulh_w64     :: "64 word \<Rightarrow> 64 word \<Rightarrow> 64 word"          where "umulh_w64     = umulh_word"
+
+
+definition mk8  :: "integer \<Rightarrow> 8  word" where "mk8  x = word_of_int (int_of_integer x)"
+definition mk16 :: "integer \<Rightarrow> 16 word" where "mk16 x = word_of_int (int_of_integer x)"
+definition mk32 :: "integer \<Rightarrow> 32 word" where "mk32 x = word_of_int (int_of_integer x)"
+definition mk64 :: "integer \<Rightarrow> 64 word" where "mk64 x = word_of_int (int_of_integer x)"
+
+definition u8  :: "8  word \<Rightarrow> integer" where "u8  w = integer_of_int (uint w)"
+definition u16 :: "16 word \<Rightarrow> integer" where "u16 w = integer_of_int (uint w)"
+definition u32 :: "32 word \<Rightarrow> integer" where "u32 w = integer_of_int (uint w)"
+definition u64 :: "64 word \<Rightarrow> integer" where "u64 w = integer_of_int (uint w)"
+
+fun model_exec :: "String.literal \<Rightarrow> integer \<Rightarrow> integer list \<Rightarrow> integer option" where
+  \<comment> \<open>MUL\<close>
+  "model_exec mn bw [a, b] =
+     (if mn = STR ''MUL'' then
+        (if bw =  8 then Some (u8  (mul_w8  (mk8  a) (mk8  b))) else
+         if bw = 16 then Some (u16 (mul_w16 (mk16 a) (mk16 b))) else
+         if bw = 32 then Some (u32 (mul_w32 (mk32 a) (mk32 b))) else None)
+      else if mn = STR ''SQDMULH'' then
+        (if bw = 16 then Some (u16 (sqdmulh_w16 (mk16 a) (mk16 b))) else
+         if bw = 32 then Some (u32 (sqdmulh_w32 (mk32 a) (mk32 b))) else None)
+      else if mn = STR ''SQRDMULH'' then
+        (if bw = 16 then Some (u16 (sqrdmulh_w16 (mk16 a) (mk16 b))) else
+         if bw = 32 then Some (u32 (sqrdmulh_w32 (mk32 a) (mk32 b))) else None)
+      else if mn = STR ''SHSUB'' then
+        (if bw =  8 then Some (u8  (shsub_w8  (mk8  a) (mk8  b))) else
+         if bw = 16 then Some (u16 (shsub_w16 (mk16 a) (mk16 b))) else
+         if bw = 32 then Some (u32 (shsub_w32 (mk32 a) (mk32 b))) else None)
+      else if mn = STR ''SRSHR'' then
+        \<comment> \<open>SRSHR k x: first arg is the shift amount k, second is the lane.\<close>
+        (if bw =  8 then Some (u8  (srshr_w8  (nat (int_of_integer a)) (mk8  b))) else
+         if bw = 16 then Some (u16 (srshr_w16 (nat (int_of_integer a)) (mk16 b))) else
+         if bw = 32 then Some (u32 (srshr_w32 (nat (int_of_integer a)) (mk32 b))) else None)
+      else if mn = STR ''MULH'' then
+        (if bw = 64 then Some (u64 (mulh_w64 (mk64 a) (mk64 b))) else None)
+      else if mn = STR ''UMULH'' then
+        (if bw = 64 then Some (u64 (umulh_w64 (mk64 a) (mk64 b))) else None)
+      else None)"
+| "model_exec mn bw [a, b, c] =
+     (if mn = STR ''MLA'' then
+        (if bw =  8 then Some (u8  (mla_w8  (mk8  a) (mk8  b) (mk8  c))) else
+         if bw = 16 then Some (u16 (mla_w16 (mk16 a) (mk16 b) (mk16 c))) else
+         if bw = 32 then Some (u32 (mla_w32 (mk32 a) (mk32 b) (mk32 c))) else None)
+      else if mn = STR ''MLS'' then
+        (if bw =  8 then Some (u8  (mls_w8  (mk8  a) (mk8  b) (mk8  c))) else
+         if bw = 16 then Some (u16 (mls_w16 (mk16 a) (mk16 b) (mk16 c))) else
+         if bw = 32 then Some (u32 (mls_w32 (mk32 a) (mk32 b) (mk32 c))) else None)
+      else if mn = STR ''SQRDMLAH'' then
+        (if bw = 16 then Some (u16 (sqrdmlah_w16 (mk16 a) (mk16 b) (mk16 c))) else
+         if bw = 32 then Some (u32 (sqrdmlah_w32 (mk32 a) (mk32 b) (mk32 c))) else None)
+      else None)"
+| "model_exec _ _ _ = None"
+
+
+export_code model_exec
+  in SML module_name Model file_prefix "model"
+
+end

--- a/proofs/isabelle/neon_ntt/document/iacrtrans.cls
+++ b/proofs/isabelle/neon_ntt/document/iacrtrans.cls
@@ -1,0 +1,669 @@
+% SPDX-License-Identifier: CC0-1.0
+\def\fileversion{0.92}
+\def\filedate{2020/08/24}
+
+\NeedsTeXFormat{LaTeX2e}[1995/12/01]
+\typeout{^^J  ***  LaTeX class for IACR Transactions v\fileversion\space ***^^J}
+\ProvidesClass{iacrtrans}[\filedate]
+
+% IACR Transactions DOCUMENT CLASS
+% Written by Gaetan Leurent gaetan.leurent@inria.fr and others (2016-2020)
+%
+% To the extent possible under law, the author(s) have dedicated all
+% copyright and related and neighboring rights to this software to the
+% public domain worldwide. This software is distributed without any
+% warranty.
+%
+% You should have received a copy of the CC0 Public Domain Dedication
+% along with this software. If not, see
+% <http://creativecommons.org/publicdomain/zero/1.0/>.
+%
+%
+%%% Class options:
+%
+%% Document mode
+% [preprint]      Preprint (no copyright info) -- default mode
+% [submission]    Anonymous submission
+% [notanonymous]  Keep author names in submission mode
+% [final]         Final version
+% [journal=tosc]
+% [journal=tches]
+% [draft]
+%% Package options
+% [spthm]         Emulate llncs sptheorem and remove automatic \qed in proof
+% [floatrow]      Load floatrow package with correct captions
+% [nohyperref]    Disable automatic loading of hyperref
+% [nolastpage]    Disable automatic loading of lastpage
+% [xcolor=xxx]    Pass xxx to xcolor package
+% [hyperref=xxx]  Pass xxx to hyperref package
+%
+%%% HOWTO use this class
+%
+%% Title
+% \title[short]{Long title}
+%
+%% Authors/affiliation:
+% \author{Alice \and Bob}
+% \institute{ABC\\ \email{alice@abc} \and DEF\\ \email{bob@def}}
+%
+%% Keywords/abstract:
+% \keywords{banana \and apple}
+% \begin{abstract}
+% Lorem ipsum dolor sit amet...
+% \end{abstract}
+%
+%% Warnings
+% - please don't use any \pagestyle or \thispagestyle command
+% - if you have proof with explicit \qed inside, you should either
+%   remove \qed symbols, replace them by \qedhere, or add option [spthm]
+
+
+% Common definitions
+\RequirePackage{xkeyval}
+\def\publname{IACR Transactions}
+\def\publnameshort{IACR Transactions}
+\define@choicekey*+{IACR}{journal}[\val\nr]{tosc,tches}{%
+    \ifcase\nr\relax
+        \def\publname{IACR Transactions on Symmetric Cryptology}%
+        \def\publnameshort{IACR ToSC}%
+    \or
+        \def\publname{IACR Transactions on Cryptographic Hardware and Embedded Systems}%
+        \def\publnameshort{IACR TCHES}%
+    \fi
+}{%
+    \ClassError{iacrtrans}{journal value is only allowed to be: tosc, or tches}%
+}
+\def\IACR@vol{0}
+\def\IACR@no{0}
+\def\IACR@fp{1}
+\def\IACR@lp{\if@loadhr\pageref*{LastPage}\else\pageref{LastPage}\fi}
+\def\IACR@ISSN{XXXX-XXXX}
+\def\IACR@DOI{XXXXXXXX}
+\def\IACR@Received{20XX-XX-XX}
+\def\IACR@Revised{20XX-XX-XX}
+\def\IACR@Accepted{20XX-XX-XX}
+\def\IACR@Published{20XX-XX-XX}
+\newif\if@IACR@Received \@IACR@Receivedfalse
+\newif\if@IACR@Revised \@IACR@Revisedfalse
+\newif\if@IACR@Accepted \@IACR@Acceptedfalse
+\newif\if@IACR@Published \@IACR@Publishedfalse
+
+\newcommand{\setfirstpage}[1]{\def\IACR@fp{#1}\setcounter{page}{#1}}
+\newcommand{\setlastpage}[1]{\def\IACR@lp{#1}}
+\newcommand{\setvolume}[1]{\def\IACR@vol{#1}}
+\newcommand{\setnumber}[1]{\def\IACR@no{#1}}
+\newcommand{\setISSN}[1]{\def\IACR@ISSN{#1}}
+\newcommand{\setDOI}[1]{\def\IACR@DOI{#1}}
+
+\newcommand{\setReceived}[1]{\@IACR@Receivedtrue\def\IACR@Received{#1}}
+\newcommand{\setRevised}[1]{\@IACR@Revisedtrue\def\IACR@Revised{#1}}
+\newcommand{\setAccepted}[1]{\@IACR@Acceptedtrue\def\IACR@Accepted{#1}}
+\newcommand{\setPublished}[1]{\@IACR@Publishedtrue\def\IACR@Published{#1}}
+
+% Options
+\newif\if@loadhr
+\@loadhrtrue
+\newif\if@hyperxmp@doi
+\@hyperxmp@doifalse
+\define@key{IACR}{nohyperref}[]{\@loadhrfalse}
+\newif\if@floatrow
+\@floatrowfalse
+\define@key{IACR}{floatrow}[]{\@floatrowtrue}
+\newif\if@submission
+\@submissionfalse
+\newif\if@anonymous
+\@anonymousfalse
+\newif\if@preprint
+\@preprinttrue
+\define@key{IACR}{final}[]{\PassOptionsToClass{\CurrentOption}{article}\@preprintfalse}
+\define@key{IACR}{preprint}[]{\@preprinttrue}      % Default
+\define@key{IACR}{submission}[]{\@submissiontrue\@anonymoustrue}
+\define@key{IACR}{draft}[]{\@preprinttrue\PassOptionsToClass{\CurrentOption}{article}}
+\define@key{IACR}{notanonymous}[]{\@anonymousfalse}
+\newif\if@spthm
+\@spthmfalse
+\define@key{IACR}{spthm}[]{\@spthmtrue}
+\newif\if@IACR@lastpage
+\@IACR@lastpagetrue
+\define@key{IACR}{nolastpage}[]{\@IACR@lastpagefalse}
+
+\define@key{IACR}{xcolor}{\PassOptionsToPackage{#1}{xcolor}}
+\define@key{IACR}{hyperref}{\PassOptionsToPackage{#1}{hyperref}}
+
+\DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{article}}
+\ProcessOptionsX<IACR>\relax
+
+% article class with a4paper
+\LoadClass[10pt,twoside]{article}[2007/10/19]
+
+% Hyperref must be loaded last, but before other AtEndPreamble hooks
+\if@loadhr
+  \RequirePackage{xcolor}
+  \RequirePackage{etoolbox}
+  \AtEndPreamble{
+    \@ifpackageloaded{hyperref}{}{\RequirePackage{hyperref}}
+    \hypersetup{pdflang=en}
+    \hypersetup{colorlinks=true,
+      citecolor=black!70!green,
+      linkcolor=black!70!red}
+    % Disable latexdiff commands in PDF links
+    \pdfstringdefDisableCommands{%
+      \def\DIFadd#1{#1}%
+      \def\DIFdel#1{}%
+    }
+    % Old versions of hyperxmp do not support DOI
+    \@ifpackagelater{hyperxmp}{2019/03/14}{\@hyperxmp@doitrue\hypersetup{keeppdfinfo=true}}{}
+  }
+  % Patch: newer hyperxmp requires hyperref already loaded.
+  \@ifpackageloaded{hyperref}{}{\RequirePackage{hyperref}}
+  \RequirePackage{hyperxmp} % hyperxmp 5.x has issues with AtEndPreamble
+  \setcounter{tocdepth}{2}
+\fi
+
+
+% Geometry
+\RequirePackage[a4paper,hscale=0.65,vscale=0.75,marginratio=1:1,marginparwidth=2.7cm]{geometry}
+\RequirePackage{afterpage}
+% Title fonts: bf+sf
+\RequirePackage{sectsty}
+\allsectionsfont{\sffamily\boldmath}
+% Also for descriptions
+\renewcommand*\descriptionlabel[1]{\hspace\labelsep
+                                   \normalfont\bfseries\sffamily\boldmath #1}
+
+
+% Title/Author/affiliations
+\def\@institute{No institute given.}
+\newcommand{\institute}[1]{\gdef\@institute{#1}}
+\newcommand{\authorrunning}[1]{\gdef\IACR@runningauthors{#1}}
+\newcommand{\titlerunning}[1]{\gdef\IACR@runningtitle{#1}}
+
+\newcounter{IACR@author@cnt}
+\newcounter{IACR@inst@cnt}
+\newif\if@IACR@autoinst
+\@IACR@autoinsttrue
+\def\IACR@author@last{0}
+
+\renewcommand\maketitle{\par
+  \begingroup
+    \renewcommand\thefootnote{\@fnsymbol\c@footnote}%
+    \long\def\@makefntext##1{\parindent 1em\noindent
+            \hb@xt@1.8em{%
+                \hss\@textsuperscript{\normalfont\@thefnmark}}##1}%
+    \newpage
+    \global\@topnum\z@   % Prevents figures from going at top of page.
+    \@maketitle
+    \thispagestyle{title}\@thanks
+  \endgroup
+  \setcounter{footnote}{0}%
+  \global\let\thanks\relax
+  \global\let\maketitle\relax
+  \global\let\@maketitle\relax
+  \global\let\@thanks\@empty
+%  \global\let\@author\@empty
+  \global\let\@date\@empty
+%  \global\let\@title\@empty
+  \global\let\title\relax
+  \global\let\author\relax
+  \global\let\date\relax
+  \global\let\and\relax
+  % Adjust header size for title page
+  \addtolength{\headheight}{\baselineskip}%
+  \addtolength{\headsep}{-\baselineskip}%
+  \afterpage{%
+    \global\advance\headheight by -\baselineskip%
+    \global\advance\headsep by \baselineskip%
+  }%
+}
+\def\@maketitle{%
+  % Count authors and affiliations
+  \setcounter{IACR@author@cnt}{1}%
+  \setcounter{IACR@inst@cnt}{1}%
+  \setbox0\hbox{\def\thanks##1{\global\@IACR@autoinstfalse}\def\inst##1{\global\@IACR@autoinstfalse}\def\and{\stepcounter{IACR@author@cnt}}\@author}%
+  \setbox0\hbox{\def\and{\stepcounter{IACR@inst@cnt}}\@institute}%
+  \xdef\IACR@author@last{\theIACR@author@cnt}%
+  \edef\IACR@inst@last{\theIACR@inst@cnt}%
+  \ifnum\IACR@author@last=\IACR@inst@last\else\@IACR@autoinstfalse\fi
+  \ifnum\IACR@author@last=1 \@IACR@autoinstfalse\fi
+  \newpage
+  \null
+  \vskip 2em%
+  \begin{center}%
+  \let \footnote \thanks
+    {\def\@makefnmark{\rlap{\@textsuperscript{\normalfont\@thefnmark}}}%
+      {\LARGE \bfseries\sffamily\boldmath \@title\par}
+    \ifdefined\@subtitle\vskip .5em{\large\sffamily\bfseries\@subtitle\par}\fi}%
+    \vskip 1.5em%
+    {\large
+      \lineskip .5em%
+        \if@anonymous
+        Anonymous Submission
+        \else
+        \setcounter{IACR@author@cnt}{1}%
+        \def\and{\if@IACR@autoinst\inst{\theIACR@author@cnt} \fi
+          \stepcounter{IACR@author@cnt}%
+          \ifnum\theIACR@author@cnt=\IACR@author@last\unskip\space and \ignorespaces\else\unskip, \ignorespaces\fi}
+        \@author\if@IACR@autoinst\inst{\theIACR@author@cnt}\fi
+        \vskip 1em\par
+        \small
+        \setcounter{IACR@author@cnt}{1}%
+        \def\and{\par\stepcounter{IACR@author@cnt}$^\theIACR@author@cnt$~}
+        \ifnum\IACR@inst@last>1 $^1$~\fi\ignorespaces%
+        \@institute
+        \fi
+      }%
+  \end{center}%
+  \par
+  \vskip 1.5em}
+
+\def\author{\@ifnextchar[{\IACR@@@author}{\IACR@@author}}
+\def\IACR@@@author[#1]#2{\authorrunning{#1}\gdef\@author{#2}}
+\def\IACR@@author#1{\gdef\@author{#1}}
+
+\if@anonymous
+\gdef\@author{Anonymous Submission to \publnameshort}
+\renewcommand{\author}[2][]{}
+\renewcommand{\authorrunning}[1]{}
+\renewcommand{\institute}[2][]{}
+\fi
+
+
+\def\title{\@ifnextchar[{\IACR@@@title}{\IACR@@title}}
+\def\IACR@@@title[#1]#2{\gdef\@title{#2}\titlerunning{#1}}
+\def\IACR@@title#1{\gdef\@title{#1}}
+
+\newcommand{\subtitle}[1]{\gdef\@subtitle{#1}}
+
+\newcommand{\inst}[1]{\unskip$^{#1}$}
+\def\fnmsep{\unskip$^,$}
+
+
+% Head/foot
+\RequirePackage{fancyhdr}
+\RequirePackage{graphicx}
+
+\if@submission
+\else
+  \if@preprint
+  \else
+    \if@IACR@lastpage
+      \RequirePackage{lastpage}
+    \else
+      \typeout{IACR Trans: not loading lastpage, please use \@backslashchar setlastpage}
+    \fi%!lastpage
+  \fi%!preprint
+\fi%!submission
+
+\fancypagestyle{title}{%
+\fancyhf{} % clear all header and footer fields
+\if@submission
+\else
+  \if@preprint
+  \else
+    \fancyhead[L]{%
+      \small%
+      \publname{}\\
+      ISSN~\IACR@ISSN, Vol.~\IACR@vol, No.~\IACR@no, pp.~\IACR@fp--\IACR@lp. \hfill{}%
+      \if@loadhr{\href{https://doi.org/\IACR@DOI}{DOI:\IACR@DOI}}\else{DOI:\IACR@DOI}\fi%
+    }
+    \fancyfoot[L]{%
+      \small%
+      Licensed under %
+      \if@loadhr{\href{http://creativecommons.org/licenses/by/4.0/}{Creative Commons License CC-BY 4.0.}}%
+      \else{Creative Commons License CC-BY 4.0.}%
+      \fi%
+      \hfill{}%
+      \includegraphics[clip,height=2ex]{CC-by}\\[.1em]%
+      \if@IACR@Received Received: \IACR@Received \hfill{} \fi%
+      \if@IACR@Revised Revised: \IACR@Revised \hfill{} \fi%
+      \if@IACR@Accepted Accepted: \IACR@Accepted \hfill{} \fi%
+      \if@IACR@Published Published: \IACR@Published \fi%
+    }%
+    \if@loadhr
+      \hypersetup{pdfcopyright={Licensed under Creative Commons License CC-BY 4.0.}}
+      \hypersetup{pdflicenseurl={http://creativecommons.org/licenses/by/4.0/}}
+      \hypersetup{pdfsubject={\publname{}, DOI:\IACR@DOI}}
+    \fi
+  \fi%!preprint
+\fi%!submission
+
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{0pt}
+}%fancypagestyle
+
+\fancyhf{}
+\fancyhead[RO,LE]{\thepage}
+\fancyhead[RE]{%
+  \ifdefined\IACR@runningtitle\IACR@runningtitle%
+  \else%
+    \def\thanks##1{}%
+    \def\fnmsep{}%
+    \def\\{}%
+    \def\footnote##1{}%
+    \@title%
+  \fi}
+\fancyhead[LO]{%
+  \ifdefined\IACR@runningauthors\IACR@runningauthors%
+  \else%
+    \def\thanks##1{}%
+    \def\inst##1{}%
+    \def\fnmsep{}%
+    \def\\{}%
+    \def\footnote##1{}%
+    \setcounter{IACR@author@cnt}{1}%
+    \def\and{\stepcounter{IACR@author@cnt}%
+      \ifnum\theIACR@author@cnt=\IACR@author@last\unskip\space and \ignorespaces \else\unskip, \ignorespaces\fi}
+    \@author%
+  \fi}
+
+\renewcommand{\markboth}[2]{}
+\pagestyle{fancy}
+
+\def\subtitle#1{\gdef\@subtitle{#1}}
+
+%Abstract style, keywords
+\def\@IACR@keywords{No keywords given.}
+
+\def\keywords{\@ifnextchar[{\IACR@@@keywords}{\IACR@@keywords}}
+\def\IACR@@@keywords[#1]#2{\gdef\@IACR@PDFkeywords{#1}\gdef\@IACR@keywords{#2}}
+\def\IACR@@keywords#1{\gdef\@IACR@keywords{#1}}
+
+\renewenvironment{abstract}{%
+  \small\quotation\setlength{\parindent}{0pt}\noindent
+  \textbf{\textsf{Abstract.}}}
+  {\smallskip\par\textbf{\textsf{Keywords:}}
+    \def\and{\unskip\space\textperiodcentered\space\ignorespaces}\@IACR@keywords
+  \endquotation%
+  \if@loadhr
+    %% PDF keywords
+    \def\and{, }%
+    \def\thanks##1{}%
+    \def\footnote##1{}%
+    \def\inst##1{}%
+    \def\fnmsep{}%
+    \def\\{}%
+    \def\zap@first@space ##1{##1}
+    \def\insert@last@space##1,##2{%
+      ##1%
+      \ifx##2\@empty\space\else, \expandafter\insert@last@space##2\fi}
+    \def\zap@comma@space##1 ,##2{%
+      ##1%
+      \ifx##2\@empty\else, \expandafter\zap@comma@space##2\fi}
+    \def\zap@dbl@space##1 ##2{%
+      ##1%
+      \ifx##2\@empty\else\space\expandafter\zap@dbl@space##2\fi}
+    \ifdefined\@IACR@PDFkeywords
+      \hypersetup{pdfkeywords=\@IACR@PDFkeywords}
+    \else
+      \protected@edef\@tmp{\expandafter\@IACR@keywords}
+      \protected@edef\@tmp{\expandafter\insert@last@space\@tmp,\@empty}
+      \protected@edef\@tmp{\expandafter\zap@comma@space\@tmp ,\@empty}
+      \protected@edef\@tmp{\expandafter\insert@last@space\@tmp,\@empty}
+      \protected@edef\@tmp{\expandafter\zap@dbl@space\@tmp \@empty}
+      \protected@edef\@tmp{\expandafter\zap@first@space \@tmp}
+      \hypersetup{pdfkeywords=\@tmp}
+    \fi
+    %% PDF author
+    \def\zap@one##1,##2{##1}
+    \def\zap@last##1,##2{\ifx##1\@empty\else\space and \expandafter\zap@one##1\fi}
+    \def\zap@last@comma##1,##2,##3{%
+      ##1%
+      \ifx##3\@empty%
+      \expandafter\zap@last\else
+      ,\expandafter\zap@last@comma\fi%
+      ##2,##3}
+    \ifdefined\IACR@runningauthors
+      \hypersetup{pdfauthor=\IACR@runningauthors}
+      \typeout{IACR@AUTHOR: \IACR@runningauthors}
+    \else
+      \protected@edef\@tmp{\expandafter\@author}
+      \protected@edef\@tmp{\expandafter\insert@last@space\@tmp,\@empty}
+      \protected@edef\@tmp{\expandafter\zap@comma@space\@tmp ,\@empty}
+      \protected@edef\@tmp{\expandafter\insert@last@space\@tmp,\@empty}
+      \protected@edef\@tmp{\expandafter\zap@dbl@space\@tmp \@empty}
+      \ifx\@tmp\empty\else
+        \protected@edef\@tmp{\expandafter\zap@first@space \@tmp}
+        \typeout{IACR@AUTHOR: \@tmp}
+        \hypersetup{pdfauthor=\@tmp}
+      \fi
+    \fi
+    %% PDF title
+    \ifdefined\IACR@runningtitle
+      \hypersetup{pdftitle=\IACR@runningtitle}
+      \typeout{IACR@TITLE: \IACR@runningtitle^^J}
+    \else
+      \protected@edef\@tmp{\expandafter\@title}
+      \protected@edef\@tmp{\expandafter\insert@last@space\@tmp,\@empty}
+      \protected@edef\@tmp{\expandafter\zap@dbl@space\@tmp \@empty}
+      \ifx\@tmp\empty\else
+        \protected@edef\@tmp{\expandafter\zap@first@space \@tmp}
+        \hypersetup{pdftitle=\@tmp}
+        \typeout{IACR@TITLE: \@tmp^^J}
+      \fi
+    \fi
+    % PDF metadata
+    \if@submission\else
+      \if@preprint\else
+        \if@hyperxmp@doi{
+          \hypersetup{%
+            pdfdoi=\IACR@DOI,%
+            pdfissn=\IACR@ISSN,%
+            pdfpubtype=journal,%
+            pdfpublication=\publname,%
+            pdfvolumenum=\IACR@vol,%
+            pdfissuenum=\IACR@no,%
+            pdfpagerange={\IACR@fp-\IACR@lp},%
+        }}
+      \fi
+    \fi
+  \fi
+}
+
+
+% autoref: capitals for Sections, and adding Algorithm
+\def\equationautorefname{Equation}%
+\def\footnoteautorefname{footnote}%
+\def\itemautorefname{item}%
+\def\figureautorefname{Figure}%
+\def\tableautorefname{Table}%
+\def\partautorefname{Part}%
+\def\appendixautorefname{Appendix}%
+\def\chapterautorefname{Chapter}%
+\def\sectionautorefname{Section}%
+\def\subsectionautorefname{Subsection}%
+\def\subsubsectionautorefname{Subsubsection}%
+\def\paragraphautorefname{paragraph}%
+\def\subparagraphautorefname{subparagraph}%
+\def\FancyVerbLineautorefname{line}%
+\def\theoremautorefname{Theorem}%
+\def\pageautorefname{page}%
+
+\def\algorithmautorefname{Algorithm}
+
+\def\definitionautorefname{Definition}
+\def\exampleautorefname{Example}
+\def\exerciseautorefname{Exercise}
+\def\propertyautorefname{Property}
+\def\questionautorefname{Question}
+\def\solutionautorefname{Solution}
+\def\propositionautorefname{Proposition}
+\def\problemautorefname{Problem}
+\def\lemmaautorefname{Lemma}
+\def\conjectureautorefname{Conjecture}
+\def\corollaryautorefname{Corollary}
+\def\claimautorefname{Claim}
+\def\remarkautorefname{Remark}
+\def\noteautorefname{Note}
+\def\caseautorefname{Case}
+
+% AMS math
+\RequirePackage{amsmath,amssymb,amsthm}
+\RequirePackage{mathtools}
+\theoremstyle{definition}
+\newtheorem{definition}{Definition}
+\newtheorem{example}{Example}
+\newtheorem{exercise}{Exercise}
+\newtheorem{property}{Property}
+\newtheorem{question}{Question}
+\newtheorem{solution}{Solution}
+
+\theoremstyle{plain}
+\newtheorem{theorem}{Theorem}
+\newtheorem{proposition}{Proposition}
+\newtheorem{problem}{Problem}
+\newtheorem{lemma}{Lemma}
+\newtheorem{conjecture}{Conjecture}
+\newtheorem{corollary}{Corollary}
+\newtheorem*{claim}{Claim}
+
+\theoremstyle{remark}
+\newtheorem{remark}{Remark}
+\newtheorem{note}{Note}
+\newtheorem{case}{Case}
+
+\theoremstyle{plain}
+
+%Emulate LLNCS spnewtheorem
+\if@spthm
+\def\spnewtheorem{\@ifstar{\IACR@spstar}{\IACR@sp}}
+\def\IACR@spstar#1#2#3#4{%
+  \expandafter\def\csname th@#1\endcsname{\thm@headfont{#3}#4}\thm@style{#1}
+  \newtheorem*{#1}{#2}}
+\def\IACR@sp#1{\@ifnextchar[{\IACR@sp@b{#1}}{\IACR@sp@a{#1}}}
+\def\IACR@sp@a#1#2{%
+  \@ifnextchar[{\IACR@sp@ab{#1}{#2}}{\IACR@sp@aa{#1}{#2}}}
+\def\IACR@sp@ab#1#2[#3]#4#5{%
+ \expandafter\def\csname th@#1\endcsname{\thm@headfont{#4}#5}\thm@style{#1}
+  \newtheorem{#1}{#2}[#3]}
+\def\IACR@sp@aa#1#2#3#4{%
+ \expandafter\def\csname th@#1\endcsname{\thm@headfont{#3}#4}\thm@style{#1}
+  \newtheorem{#1}{#2}}
+\def\IACR@sp@b#1[#2]#3#4#5{%
+ \expandafter\def\csname th@#1\endcsname{\thm@headfont{#4}#5}\thm@style{#1}
+  \newtheorem{#1}[#2]{#3}}
+\let\real@proof\proof
+\def\proof{\@ifnextchar[{\proof@sptm}{\proof@@sptm}}
+\def\proof@sptm[#1]{\real@proof[\proofname{} (#1)]}
+\def\proof@@sptm{\real@proof}
+\let\real@pushQED\pushQED
+\let\real@qed\qed
+\def\pushQED#1{\real@pushQED{\real@qed}}
+\let\qed\qedhere
+\fi
+\theoremstyle{plain} %back to default
+
+\iffalse %mychange
+% Floats and captions
+\if@floatrow
+\RequirePackage{floatrow}
+\floatsetup[table]{style=Plaintop}
+\RequirePackage{caption}
+\captionsetup{labelfont={sf,bf}}
+\else
+\RequirePackage{float}
+\newcommand\fs@iacrabove{%
+  % Swap \abovecaptionskip and \belowcaptionskip
+  \addtolength\abovecaptionskip{-\belowcaptionskip}
+  \addtolength\belowcaptionskip{\abovecaptionskip}
+  \addtolength\abovecaptionskip{-\belowcaptionskip}
+  \setlength\abovecaptionskip{-\abovecaptionskip}
+  \fs@plaintop%
+  \def\@fs@cfont{\sffamily\bfseries}}
+\newcommand\fs@iacrbelow{%
+  \fs@plain%
+  \def\@fs@cfont{\sffamily\bfseries}}
+\floatstyle{iacrabove}
+\restylefloat{table}
+\floatstyle{iacrbelow}
+\restylefloat{figure}
+\fi
+\fi
+
+% Floats and captions
+\if@floatrow
+\RequirePackage{floatrow}
+\floatsetup[table]{style=Plaintop} 
+\RequirePackage{caption}
+\captionsetup{labelfont={sf,bf}}
+\else
+\RequirePackage{float}
+\newcommand\fs@iacrabove{%
+   %Swap \abovecaptionskip and \belowcaptionskip
+  \addtolength\belowcaptionskip{-\abovecaptionskip}
+  \addtolength\abovecaptionskip{\belowcaptionskip}
+  \addtolength\belowcaptionskip{-\abovecaptionskip}
+  \setlength\belowcaptionskip{-\belowcaptionskip}
+  \fs@plaintop%
+  \def\@fs@cfont{\sffamily\bfseries}}
+\newcommand\fs@iacrbelow{%
+  \fs@plain%
+  \def\@fs@cfont{\sffamily\bfseries}}
+\floatstyle{iacrbelow}
+\restylefloat{table}
+\floatstyle{iacrbelow}
+\restylefloat{figure}
+\fi
+
+% Extra commands
+\def\email{\@ifnextchar[{\IACR@@email}{\IACR@email}}
+\if@loadhr
+\def\IACR@@email[#1]#2{\href{mailto:#1}{\nolinkurl{#2}}}
+\def\IACR@email#1{\href{mailto:#1}{\nolinkurl{#1}}}
+\else
+\RequirePackage{url}
+\def\IACR@@email[#1]#2{\url{#2}}
+\def\IACR@email#1{\url{#1}}
+\fi
+
+% Line # for submission
+\newcommand\linenomathWithnumbersforAMS{%
+  \ifLineNumbers
+%%  \ifx\@@par\@@@par\else
+    \ifnum\interlinepenalty>-\linenopenaltypar
+      \global\holdinginserts\thr@@
+      \advance\interlinepenalty \linenopenalty
+     \ifhmode                                   % v4.3
+      \advance\predisplaypenalty \linenopenalty
+     \fi
+%%      \advance\postdisplaypenalty \linenopenalty
+      \advance\interdisplaylinepenalty \linenopenalty
+    \fi
+  \fi
+  \ignorespaces
+  }
+
+\if@submission
+\RequirePackage[mathlines]{lineno}
+\RequirePackage{xcolor}
+\linenumbers
+\def\linenumberfont{\normalfont\tiny\sffamily\color{gray}}
+
+% Taken from http://phaseportrait.blogspot.fr/2007/08/lineno-and-amsmath-compatibility.html
+\newcommand*\patchAmsMathEnvironmentForLineno[1]{%
+  \expandafter\let\csname old#1\expandafter\endcsname\csname #1\endcsname
+  \expandafter\let\csname oldend#1\expandafter\endcsname\csname end#1\endcsname
+  \renewenvironment{#1}%
+     {\linenomathWithnumbersforAMS\csname old#1\endcsname}%
+     {\csname oldend#1\endcsname\endlinenomath}}%
+\newcommand*\patchBothAmsMathEnvironmentsForLineno[1]{%
+  \patchAmsMathEnvironmentForLineno{#1}%
+  \patchAmsMathEnvironmentForLineno{#1*}}%
+\AtBeginDocument{%
+\patchAmsMathEnvironmentForLineno{equation*}%
+\patchBothAmsMathEnvironmentsForLineno{align}%
+\patchBothAmsMathEnvironmentsForLineno{flalign}%
+\patchBothAmsMathEnvironmentsForLineno{alignat}%
+\patchBothAmsMathEnvironmentsForLineno{gather}%
+\patchBothAmsMathEnvironmentsForLineno{multline}%
+}
+\fi
+
+% Microtype
+\RequirePackage{microtype}
+
+% Fonts
+\RequirePackage[T1]{fontenc}
+\RequirePackage{lmodern}
+
+\endinput
+%end of file iacrtrans.cls

--- a/proofs/isabelle/neon_ntt/document/root.bib
+++ b/proofs/isabelle/neon_ntt/document/root.bib
@@ -1,0 +1,116 @@
+% Copyright (c) The mldsa-native project authors
+% SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+@article{NeonNTT,
+  author  = {Hanno Becker and Vincent Hwang and Matthias J. Kannwischer and Bo-Yin Yang and Shang-Yi Yang},
+  title   = {{Neon NTT}: Faster {Dilithium}, {Kyber}, and {Saber} on {Cortex-A72} and {Apple M1}},
+  journal = {{IACR} Transactions on Cryptographic Hardware and Embedded Systems},
+  volume  = {2022},
+  number  = {1},
+  pages   = {221--244},
+  year    = {2022},
+  note    = {Available at \url{https://eprint.iacr.org/2021/986}},
+  eprint  = {2021/986},
+}
+
+@misc{Becker2022NeonNTTtalk,
+  author       = {Hanno Becker and Vincent Hwang and Matthias J. Kannwischer and Bo-Yin Yang and Shang-Yi Yang},
+  title        = {{Neon NTT}: Faster {Dilithium}, {Kyber}, and {Saber} on {Cortex-A72} and {Apple M1}},
+  howpublished = {Talk at CHES 2022},
+  year         = {2022},
+}
+
+@misc{AutoCorrode,
+  author       = {Becker, Hanno and Chong, Nathan and Dockins, Robert and Grundy, Jim and Hu, Jason Z. S. and Mulder, Ike and Mulligan, Dominic P. and Mure, Paul and Paulson, Lawrence C. and Slind, Konrad},
+  title        = {{AutoCorrode} software verification framework for {Isabelle/HOL}},
+  year         = {2025},
+  howpublished = {\url{https://github.com/awslabs/autocorrode}},
+}
+
+@inproceedings{Klein2009seL4,
+  author    = {Klein, Gerwin and Elphinstone, Kevin and Heiser, Gernot and Andronick, June and Cock, David and Derrin, Philip and Elkaduwe, Dhammika and Engelhardt, Kai and Kolanski, Rafal and Norrish, Michael and Sewell, Thomas and Tuch, Harvey and Winwood, Simon},
+  title     = {{seL4}: Formal verification of an {OS} kernel},
+  booktitle = {Proceedings of the 22nd ACM Symposium on Operating Systems Principles (SOSP)},
+  year      = {2009},
+}
+
+@article{Klein2014seL4,
+  author  = {Klein, Gerwin and Andronick, June and Elphinstone, Kevin and Murray, Toby and Sewell, Thomas and Kolanski, Rafal and Heiser, Gernot},
+  title   = {Comprehensive formal verification of an {OS} microkernel},
+  journal = {ACM Transactions on Computer Systems},
+  volume  = {32},
+  number  = {1},
+  year    = {2014},
+}
+
+@article{Hales2017Kepler,
+  author  = {Hales, Thomas and Adams, Mark and Bauer, Gertrud and Dang, Tat Dat and Harrison, John and Hoang, Le Truong and Kaliszyk, Cezary and Magron, Victor and McLaughlin, Sean and Nguyen, Tat Thang and others},
+  title   = {A formal proof of the {Kepler} conjecture},
+  journal = {Forum of Mathematics, Pi},
+  volume  = {5},
+  year    = {2017},
+}
+
+@misc{AppleCorecrypto2025,
+  author       = {{Apple Security Engineering and Architecture}},
+  title        = {Formal verification of {corecrypto}},
+  year         = {2025},
+  howpublished = {\url{https://security.apple.com/blog/formal-verification-corecrypto/}},
+}
+
+@misc{AWSNitro2025,
+  author       = {{Amazon Web Services}},
+  title        = {{Isabelle/HOL}: The proof assistant behind the {Nitro Isolation Engine}},
+  year         = {2025},
+  howpublished = {\url{https://www.amazon.science/blog/isabelle-hol-the-proof-assistant-behind-the-nitro-isolation-engine}},
+}
+
+@misc{AFP,
+  author       = {{Archive of Formal Proofs}},
+  title        = {Archive of Formal Proofs},
+  howpublished = {\url{https://www.isa-afp.org}},
+}
+
+@article{CryptoLine2022,
+  author  = {Hwang, Vincent and Liu, Jiaxiang and Seiler, Gregor and Shi, Xiaomu and Tsai, Ming-Hsien and Wang, Bow-Yaw and Yang, Bo-Yin},
+  title   = {Verified {NTT} Multiplications for {NISTPQC} {KEM} Lattice Finalists: {Kyber}, {SABER}, and {NTRU}},
+  journal = {IACR Transactions on Cryptographic Hardware and Embedded Systems},
+  volume  = {2022},
+  number  = {4},
+  pages   = {718--750},
+  year    = {2022},
+}
+
+@article{CryptoLine2025,
+  author  = {Chiu, Chun-Ming and Liu, Jiaxiang and Tsai, Ming-Hsien and Shi, Xiaomu and Wang, Bow-Yaw and Yang, Bo-Yin},
+  title   = {Algebraic Linear Analysis for Number Theoretic Transform in Lattice-Based Cryptography},
+  journal = {IACR Transactions on Cryptographic Hardware and Embedded Systems},
+  volume  = {2025},
+  number  = {3},
+  pages   = {668--692},
+  year    = {2025},
+}
+
+@article{FormosaCrypto,
+  author  = {Bacelar Almeida, Jos\'{e} and Barbosa, Manuel and Barthe, Gilles and Gr\'{e}goire, Benjamin and Laporte, Vincent and L\'{e}chenet, Jean-Christophe and Oliveira, Tiago and Pacheco, Hugo and Quaresma, Miguel and Schwabe, Peter and S\'{e}r\'{e}, Antoine and Strub, Pierre-Yves},
+  title   = {Formally verifying {Kyber}: Episode {IV}: Implementation correctness},
+  journal = {IACR Transactions on Cryptographic Hardware and Embedded Systems},
+  volume  = {2023},
+  number  = {3},
+  pages   = {164--193},
+  year    = {2023},
+}
+
+@misc{mlkemnative,
+  author       = {{pq-code-package contributors}},
+  title        = {\texttt{mlkem-native}: Secure, fast, and portable {C90} implementation of {ML-KEM} / {FIPS}~203},
+  year         = {2025},
+  howpublished = {\url{https://github.com/pq-code-package/mlkem-native}},
+}
+
+@misc{mldsanative,
+  author       = {{pq-code-package contributors}},
+  title        = {\texttt{mldsa-native}: Secure, fast, and portable {C90} implementation of {ML-DSA} / {FIPS}~204},
+  year         = {2025},
+  howpublished = {\url{https://github.com/pq-code-package/mldsa-native}},
+}

--- a/proofs/isabelle/neon_ntt/document/root.tex
+++ b/proofs/isabelle/neon_ntt/document/root.tex
@@ -1,0 +1,154 @@
+% Copyright (c) The mldsa-native project authors
+% SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+\documentclass[preprint]{iacrtrans}
+
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{isabelle,isabellesym}
+\usepackage{amssymb,amsmath}
+\usepackage[only,bigsqcap,bigparallel,fatsemi,interleave,sslash,llbracket,rrbracket,llparenthesis,rrparenthesis,binampersand,bindnasrepma]{stmaryrd}
+\usepackage{wasysym}
+\usepackage{eurosym}
+\usepackage[english]{babel}
+\usepackage{textcomp}
+\usepackage{titlesec}
+
+% Issue 4: uniform vertical spacing around section heads
+\titlespacing*{\section}{0pt}{3.2ex plus 1.2ex minus 0.5ex}{2ex plus 0.4ex}
+\titlespacing*{\subsection}{0pt}{2.6ex plus 1ex minus 0.4ex}{1.3ex plus 0.3ex}
+\titlespacing*{\subsubsection}{0pt}{2ex plus 0.8ex minus 0.3ex}{1ex plus 0.2ex}
+
+% iacrtrans already loads hyperref+hyperxmp; do not load Isabelle's pdfsetup.sty
+% which would load hyperref a second time and confuse hyperxmp.
+
+\isabellestyle{tt}
+
+% Syntax-highlighting colour scheme for the embedded Isar source,
+% loosely matching jEdit's default theme.
+\usepackage{xcolor}
+\definecolor{kw}{HTML}{6F00E5}     % Isabelle keywords (theorem, definition, …) – violet
+\definecolor{cmd}{HTML}{0000B0}    % outer-syntax commands – blue
+\definecolor{ty}{HTML}{006400}     % type / class names – dark green
+\definecolor{varc}{HTML}{8B4513}   % free variables / parameters – brown
+\definecolor{lit}{HTML}{B8860B}    % numeric / literal – goldenrod
+\definecolor{cmt}{HTML}{C75300}    % Isar comments (-- ‹...›) – orange
+% Isabelle emits keywords via \isakeywordONE/TWO/THREE (outer-syntax classes).
+% Map them to jEdit-style colours.
+\renewcommand{\isakeywordONE}[1]{\textcolor{cmd}{\textbf{#1}}}     % theorem, lemma, definition, …
+\renewcommand{\isakeywordTWO}[1]{\textcolor{kw}{\textbf{#1}}}      % proof, qed, by, …
+\renewcommand{\isakeywordTHREE}[1]{\textcolor{ty}{\textbf{#1}}}    % where, assumes, shows, …
+\renewcommand{\isakeyword}[1]{\textcolor{kw}{\textbf{#1}}}         % inner-syntax: if/then/else/let/in/case/of
+\renewcommand{\isadigit}[1]{\textcolor{lit}{#1}}
+% Isar inline comments ‹-- ‹...››: Isabelle wraps the content in \isamarkupcmt.
+\renewcommand{\isamarkupcmt}[1]{\textcolor{cmt}{\textit{#1}}}
+
+% Define Isabelle symbols missing in the default isabellesym.sty
+\providecommand{\isasymbmod}{\isamath{\;\bmod\;}}
+\providecommand{\isasympmod}{\isamath{\,\mathrm{mod}\,}}
+\providecommand{\isasymlaquo}{\guillemotleft}
+\providecommand{\isasymraquo}{\guillemotright}
+
+% Suppress proof bodies in PDF output
+\isafoldtag{proof}
+
+% Asides explaining why a proof is exceptionally retained.  Visible in the
+% abridged (default) build; a full-proof build can override with
+% \isadroptag{proof_note} so the aside disappears when the proof itself
+% becomes visible.
+\isakeeptag{proofnote}
+
+% Drop auxiliary helper material tagged ‹internal› from the outline-mode PDF.
+% A second session can override this with \isakeeptag{internal} for full mode.
+\isadroptag{internal}
+\isadroptag{invisible}
+
+% After \isadroptag{internal}, the comment package leaves behind kept
+% \isadeliminternal / \endisadeliminternal markers around each dropped block.
+% Override \endisadeliminternal to swallow the trailing \isanewline tokens.
+\makeatletter
+\def\isabelle@swallow@nl{%
+  \@ifnextchar\isanewline
+    {\expandafter\isabelle@swallow@nl\@gobble}
+    {}}
+\@namedef{isadeliminternal}{\isabelle@swallow@nl}
+\@namedef{endisadeliminternal}{\isabelle@swallow@nl}
+\makeatother
+
+
+% Issue 3: Fully suppress theory/imports/begin/end boilerplate
+\isadroptag{theory}
+
+% Issue 2: Allow Isabelle identifiers to break at underscores (small stretch only)
+\def\BreakableUnderscore{\discretionary{\textunderscore}{}{\textunderscore}}
+\renewcommand{\isacharunderscore}{\BreakableUnderscore}
+\renewcommand{\isacharunderscorekeyword}{\BreakableUnderscore}
+
+% iacrtrans is article-based and has no \chapter; map Isabelle chapters to top-level sections.
+\renewcommand{\isamarkupchapter}[1]{\section{#1}}
+\renewcommand{\isamarkupsection}[1]{\subsection{#1}}
+\renewcommand{\isamarkupsubsection}[1]{\subsubsection{#1}}
+\renewcommand{\isamarkupsubsubsection}[1]{\paragraph{#1}}
+
+% Override \phi to use straight phi (ϕ) rather than curly varphi (φ)
+\renewcommand{\isasymphi}{\isamath{\phi}}
+
+% Uniform styling for assembly instruction mnemonics in prose
+\newcommand{\asminst}[1]{\texttt{#1}}
+
+\title{Neon NTT -- (Auto)formalised}
+\subtitle{Human-Directed, Agentic Verification of Montgomery and Barrett Modular Arithmetic}
+\author{Hanno Becker}
+\institute{Amazon Web Services, \email{beckphan@amazon.com}}
+
+\begin{document}
+
+\maketitle
+\urlstyle{rm}
+
+\keywords{Isabelle/HOL \and Formal verification \and Auto-formalisation
+  \and Large language models \and Cryptographic implementation
+  \and Neon NTT \and Modular arithmetic
+  \and Barrett reduction \and Montgomery multiplication}
+
+\begin{abstract}
+  This document provides machine-checked Isabelle/HOL documentation for the
+  modular-arithmetic core of the Neon NTT paper of Becker, Hwang,
+  Kannwischer, Yang, and Yang~\cite{NeonNTT}. We develop
+  parametric theories of Barrett and Montgomery reduction and
+  multiplication; the equivalence of Barrett and Montgomery arithmetic;
+  the doubling- and rounding-Montgomery variants; and correctness and
+  bounds theorems for Neon assembly kernels, against a hand-written
+  model of the word arithmetic underlying the relevant Neon instructions.
+
+  The development is a directed auto-formalisation: definitions, theorem
+  statements, and proofs were produced by Claude~Opus~4.7 connecting to
+  Isabelle through \texttt{AutoCorrode}~\cite{AutoCorrode}. The human
+  author set the architecture, chose abstractions and proof strategies,
+  often nudged the model toward shorter or cleaner proofs, and
+  controlled which output entered the development.
+
+  This document is auto-generated from the Isabelle sources through
+  Isabelle's document preparation system, eliminating drift between
+  prose and formal artifact.
+\end{abstract}
+
+\tableofcontents
+
+\input{Introduction.tex}
+\input{Integer_Approximation.tex}
+\input{Montgomery_Reduction.tex}
+\input{Barrett_Reduction.tex}
+\input{Barrett_Montgomery.tex}
+\input{Barrett_Bound_Quality.tex}
+\input{Montgomery_Doubling.tex}
+\input{Bridge_Conceptual.tex}
+\input{Word_Ops.tex}
+\input{Asm_Barrett.tex}
+\input{Asm_Montgomery.tex}
+\input{Conclusions.tex}
+
+\bibliographystyle{alpha}
+\bibliography{root}
+
+\end{document}

--- a/proofs/isabelle/neon_ntt/model/conformance/run.py
+++ b/proofs/isabelle/neon_ntt/model/conformance/run.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+#
+# Conformance testing driver: empirically validates that the formal model of
+# the ISA matches real hardware.
+#
+# Subcommands:
+#   random  --runs N         random unsigned inputs in [0, 2^bw)
+#   full                     exhaustive over the input space (8-bit only feasible)
+#   edge                     cartesian product of edge values
+#   all                      `full` for 8-bit ops; `random N + edge` for the rest
+#                            (N defaults to 1,000,000)
+#
+# Each subcommand also accepts --mnemonic / --bitwidth filters.
+#
+# Both binaries support a streaming mode (--stream): one space-separated
+# case per line on stdin, one hex result per line on stdout. We use that
+# to avoid per-case process overhead.
+#
+
+import argparse
+import itertools
+import pathlib
+import random
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+
+# Standard color definitions (mirrors scripts/check-magic).
+GREEN = "\033[32m"
+RED = "\033[31m"
+NORMAL = "\033[0m"
+
+OK_TAG = f"{GREEN}OK{NORMAL}"
+
+
+def fail_tag(n):
+    return f"{RED}FAIL({n}){NORMAL}"
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+MODEL_EXEC = (HERE / ".." / "sml" / "model_exec").resolve()
+HW_EXEC = (HERE / ".." / "hw" / "hw_exec").resolve()
+
+
+@dataclass(frozen=True)
+class Spec:
+    mnemonic: str
+    bitwidth: int
+    arity: int  # how many integer ARG fields after MNEMONIC BITWIDTH
+
+
+SPECS = [
+    Spec("MUL", 8, 2),
+    Spec("MUL", 16, 2),
+    Spec("MUL", 32, 2),
+    Spec("MLA", 8, 3),
+    Spec("MLA", 16, 3),
+    Spec("MLA", 32, 3),
+    Spec("MLS", 8, 3),
+    Spec("MLS", 16, 3),
+    Spec("MLS", 32, 3),
+    Spec("SQDMULH", 16, 2),
+    Spec("SQDMULH", 32, 2),
+    Spec("SQRDMULH", 16, 2),
+    Spec("SQRDMULH", 32, 2),
+    Spec("SQRDMLAH", 16, 3),
+    Spec("SQRDMLAH", 32, 3),
+    Spec("SHSUB", 8, 2),
+    Spec("SHSUB", 16, 2),
+    Spec("SHSUB", 32, 2),
+    Spec("SRSHR", 8, 2),
+    Spec("SRSHR", 16, 2),
+    Spec("SRSHR", 32, 2),
+    Spec("MULH", 64, 2),
+    Spec("UMULH", 64, 2),
+]
+
+
+def edge_values(bw):
+    mask = (1 << bw) - 1
+    pow_n_1 = 1 << (bw - 1)
+    return sorted(
+        {
+            0,
+            1,
+            2,
+            mask,  # all ones (-1 signed)
+            mask - 1,  # -2
+            pow_n_1,  # signed min
+            pow_n_1 - 1,  # signed max
+            pow_n_1 + 1,  # signed min + 1
+            1 << (bw // 2),
+            (1 << (bw // 2)) - 1,
+        }
+    )
+
+
+def case_line(spec, args):
+    return f"{spec.mnemonic} {spec.bitwidth} " + " ".join(f"0x{a:x}" for a in args)
+
+
+# ----------------------------------------
+# Case generators (yield tuples of args)
+# ----------------------------------------
+
+
+def gen_random(spec, n, rng):
+    """Yield n random arg-tuples drawn uniformly over [0, 2^bw)."""
+    bw = spec.bitwidth
+    mask = (1 << bw) - 1
+    if spec.mnemonic == "SRSHR":
+        # SRSHR's first argument is the immediate shift amount, restricted to [1, bw].
+        for _ in range(n):
+            yield (rng.randint(1, bw), rng.randint(0, mask))
+    else:
+        for _ in range(n):
+            yield tuple(rng.randint(0, mask) for _ in range(spec.arity))
+
+
+def gen_full(spec):
+    """Yield every arg-tuple in the input space (only feasible for 8-bit ops)."""
+    bw = spec.bitwidth
+    mask = (1 << bw) - 1
+    if spec.mnemonic == "SRSHR":
+        # Outer loop over the shift immediate, inner over the lane value.
+        for k in range(1, bw + 1):
+            for x in range(mask + 1):
+                yield (k, x)
+        return
+    rng = range(mask + 1)
+    if spec.arity == 2:
+        for a in rng:
+            for b in rng:
+                yield (a, b)
+    elif spec.arity == 3:
+        for a in rng:
+            for b in rng:
+                for c in rng:
+                    yield (a, b, c)
+
+
+def gen_edge(spec):
+    """Yield the cartesian product of edge values (zero, all-ones, signed extremes, ...)."""
+    bw = spec.bitwidth
+    edges = edge_values(bw)
+    if spec.mnemonic == "SRSHR":
+        # Sample three representative shifts: minimum, midpoint, maximum.
+        for k in (1, max(1, bw // 2), bw):
+            for x in edges:
+                yield (k, x)
+        return
+    if spec.arity == 2:
+        for a in edges:
+            for b in edges:
+                yield (a, b)
+    elif spec.arity == 3:
+        for a in edges:
+            for b in edges:
+                for c in edges:
+                    yield (a, b, c)
+
+
+# ----------------
+# Streaming driver
+# ----------------
+
+
+def feed_and_compare(spec, cases, model_proc, hw_proc, stop_after=5, batch=4096):
+    """Pipe cases into both procs, read results in lockstep, count divergences.
+
+    Args:
+        spec: Spec for the operation under test (mnemonic, bitwidth, arity);
+            used to format each case line and to label diagnostics.
+        cases: iterable of arg-tuples to feed into both processes.
+        model_proc: subprocess.Popen running model_exec --stream.
+        hw_proc: subprocess.Popen running hw_exec --stream.
+        stop_after: maximum number of divergences to print verbatim before
+            suppressing further per-case output (the total count is still
+            returned).
+        batch: number of cases written before reading responses; trades memory
+            for syscall overhead.
+
+    Returns:
+        (total, fails) where total is the number of cases compared and fails
+        is the number where model_exec and hw_exec produced different output.
+    """
+    total = 0
+    fails = 0
+    iterator = iter(cases)
+
+    while True:
+        block = list(itertools.islice(iterator, batch))
+        if not block:
+            break
+
+        text = "".join(case_line(spec, t) + "\n" for t in block)
+        model_proc.stdin.write(text)
+        model_proc.stdin.flush()
+        hw_proc.stdin.write(text)
+        hw_proc.stdin.flush()
+
+        for args in block:
+            m_line = model_proc.stdout.readline()
+            h_line = hw_proc.stdout.readline()
+            if not m_line or not h_line:
+                # One side closed stdout before answering: surface a clear
+                # error rather than spinning. Both binaries are designed to
+                # exit on any malformed input, so this points at a real bug.
+                raise RuntimeError(
+                    f"streaming child closed stdout while expecting a result "
+                    f"for {case_line(spec, args)} "
+                    f"(model_eof={not m_line}, hw_eof={not h_line})"
+                )
+            m = m_line.rstrip("\n")
+            h = h_line.rstrip("\n")
+            total += 1
+            if m != h:
+                fails += 1
+                if fails <= stop_after:
+                    print(f"DIVERGE  {case_line(spec, args)}")
+                    print(f"  model_exec -> {m}")
+                    print(f"  hw_exec    -> {h}")
+                if fails == stop_after + 1:
+                    print(
+                        f"  ... suppressing further divergences for "
+                        f"{spec.mnemonic} bw={spec.bitwidth}"
+                    )
+    return total, fails
+
+
+def open_stream(binary):
+    return subprocess.Popen(
+        [str(binary), "--stream"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1 << 16,
+    )
+
+
+def shutdown(*procs):
+    for p in procs:
+        try:
+            p.stdin.close()
+        except Exception:
+            pass
+        p.wait(timeout=10)
+
+
+# --------------------------------------------------------------------
+# Top-level driver: build the case stream for each spec, run it through
+# `feed_and_compare`, and aggregate counts.
+# --------------------------------------------------------------------
+
+
+def filter_specs(args):
+    """Return the SPECS matching the user's --mnemonic / --bitwidth filters."""
+    out = []
+    for s in SPECS:
+        if args.mnemonic and s.mnemonic != args.mnemonic:
+            continue
+        if args.bitwidth and s.bitwidth != args.bitwidth:
+            continue
+        out.append(s)
+    return out
+
+
+def run_mode(args, mode):
+    """Run the conformance comparison for a single subcommand.
+
+    Args:
+        args: parsed argparse Namespace; must carry `model`, `hw`, `seed`,
+            `mnemonic`, `bitwidth`, and the mode-specific knobs (`runs`,
+            `all_runs`).
+        mode: one of {"random", "full", "edge", "all"}; "all" expands to
+            "full" for 8-bit ops and "random+edge" for the rest.
+
+    Returns:
+        Process exit code: 0 on perfect agreement, 1 if any divergences,
+        2 if no specs matched the filters.
+    """
+    specs = filter_specs(args)
+    if not specs:
+        print("no matching specs", file=sys.stderr)
+        return 2
+
+    # `seed` is only carried by the modes that actually consume randomness;
+    # default to 0 elsewhere so this function can stay mode-agnostic.
+    rng = random.Random(getattr(args, "seed", 0))
+    grand_total = 0
+    grand_fails = 0
+    t0 = time.time()
+
+    for spec in specs:
+        m_proc = open_stream(args.model)
+        h_proc = open_stream(args.hw)
+        try:
+            cases_list = []
+            label_parts = []
+
+            effective_mode = mode
+            if mode == "all":
+                if spec.bitwidth == 8:
+                    effective_mode = "full"
+                else:
+                    effective_mode = "random+edge"
+
+            if effective_mode == "random":
+                cases_list.append(gen_random(spec, args.runs, rng))
+                label_parts.append(f"random={args.runs}")
+            elif effective_mode == "edge":
+                cases_list.append(gen_edge(spec))
+                label_parts.append("edge")
+            elif effective_mode == "full":
+                cases_list.append(gen_full(spec))
+                label_parts.append("full")
+            elif effective_mode == "random+edge":
+                cases_list.append(gen_edge(spec))
+                cases_list.append(gen_random(spec, args.all_runs, rng))
+                label_parts.append(f"edge+random={args.all_runs}")
+            else:
+                raise AssertionError(mode)
+
+            spec_t = time.time()
+            total, fails = feed_and_compare(
+                spec, itertools.chain(*cases_list), m_proc, h_proc
+            )
+            dt = time.time() - spec_t
+            grand_total += total
+            grand_fails += fails
+            tag = OK_TAG if fails == 0 else fail_tag(fails)
+            print(
+                f"{tag:7s}  {spec.mnemonic:9s} bw={spec.bitwidth:3d}  "
+                f"cases={total:>10d}  {','.join(label_parts):20s}  {dt:6.2f}s"
+            )
+        finally:
+            shutdown(m_proc, h_proc)
+
+    dt = time.time() - t0
+    print(f"\nTotal: {grand_total} cases, {grand_fails} divergences  ({dt:.2f}s)")
+    return 0 if grand_fails == 0 else 1
+
+
+def _main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=str(MODEL_EXEC))
+    p.add_argument("--hw", default=str(HW_EXEC))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def add_filters(sp):
+        sp.add_argument("--mnemonic")
+        sp.add_argument("--bitwidth", type=int)
+
+    sp_random = sub.add_parser("random", help="random sampling")
+    add_filters(sp_random)
+    sp_random.add_argument("-n", "--runs", type=int, default=1000)
+    sp_random.add_argument("--seed", type=int, default=0)
+
+    sp_full = sub.add_parser(
+        "full", help="exhaustive enumeration (8-bit only feasible)"
+    )
+    add_filters(sp_full)
+
+    sp_edge = sub.add_parser("edge", help="edge-value cartesian product")
+    add_filters(sp_edge)
+
+    sp_all = sub.add_parser(
+        "all", help="full for 8-bit, random+edge (1M each) for the rest"
+    )
+    add_filters(sp_all)
+    sp_all.add_argument("--seed", type=int, default=0)
+    sp_all.add_argument(
+        "--all-runs",
+        type=int,
+        default=1_000_000,
+        help="random samples per non-8-bit op [default: 1,000,000]",
+    )
+
+    args = p.parse_args()
+
+    for path, name in [(args.model, "model_exec"), (args.hw, "hw_exec")]:
+        if not pathlib.Path(path).exists():
+            print(f"error: {name} not found at {path}", file=sys.stderr)
+            return 2
+
+    return run_mode(args, args.cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/proofs/isabelle/neon_ntt/model/hw/Makefile
+++ b/proofs/isabelle/neon_ntt/model/hw/Makefile
@@ -1,0 +1,36 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+CC      ?= cc
+
+# Mirror the pedantic flag set used by the main project (test/mk/config.mk),
+# minus the inline-asm-incompatible -Wpedantic.
+CFLAGS ?= \
+  -O2 \
+  -std=c99 \
+  -march=armv8.1-a \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -Wshadow \
+  -Wpointer-arith \
+  -Wredundant-decls \
+  -Wconversion \
+  -Wsign-conversion \
+  -Wmissing-prototypes \
+  -Wstrict-prototypes \
+  -Wformat=2 \
+  -Wformat-security \
+  -Wundef \
+  -Wcast-qual \
+  -Wnull-dereference \
+  -D_FORTIFY_SOURCE=2
+
+.PHONY: all clean
+all: hw_exec
+
+hw_exec: hw_exec.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f hw_exec

--- a/proofs/isabelle/neon_ntt/model/hw/hw_exec.c
+++ b/proofs/isabelle/neon_ntt/model/hw/hw_exec.c
@@ -1,0 +1,1130 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/*
+ * hw_exec -- run a single AArch64 instruction via inline asm and print
+ * its unsigned result, mirroring the model_exec CLI:
+ *
+ *   hw_exec MNEMONIC BITWIDTH ARG0 [ARG1 ...]
+ *
+ * Inputs accept hex (0x...) or signed decimal. Output is 0x-prefixed
+ * unsigned hex padded to BITWIDTH/4 nibbles.
+ *
+ * NEON ops at 8/16/32-bit element sizes use the corresponding Q-register
+ * arrangement; lane 0 is the result. MULH/UMULH only exist as 64-bit
+ * scalar instructions on AArch64, so they're handled with `smulh`/`umulh`
+ * on Xn registers.
+ *
+ * Supported MNEMONIC / BITWIDTH / arity matrix:
+ *
+ *   MNEMONIC   BITWIDTH      arity   args
+ *   --------   --------      -----   --------------------------
+ *   MUL         8 / 16 / 32    2     a, b
+ *   MLA         8 / 16 / 32    3     acc, a, b
+ *   MLS         8 / 16 / 32    3     acc, a, b
+ *   SHSUB       8 / 16 / 32    2     a, b
+ *   SRSHR       8 / 16 / 32    2     k (shift in [1,bw]), a
+ *   SQDMULH         16 / 32    2     a, b
+ *   SQRDMULH        16 / 32    2     a, b
+ *   SQRDMLAH        16 / 32    3     acc, a, b
+ *   MULH                  64   2     a, b   (scalar smulh on Xn)
+ *   UMULH                 64   2     a, b   (scalar umulh on Xn)
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(__aarch64__)
+#error "hw_exec must be built on AArch64"
+#endif
+
+/* Maximum length of a single input case (line in stream mode, joined argv
+   in one-shot mode). Long enough for the worst case allowed by the CLI
+   surface: a mnemonic + bw + three 64-bit hex values with separators. */
+#define LINE_BUF_SIZE 1024
+#define MAX_TOKENS 8
+#define OUT_BUF_SIZE 1024
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noreturn))
+#endif
+static void die(const char *msg)
+{
+  fprintf(stderr, "%s\n", msg);
+  exit(1);
+}
+
+/*
+ * Convert a single character to its digit value in `base`. Returns the digit
+ * on success or -1 on failure (non-digit, or digit out of range for base).
+ */
+static int digit_value(char c, int base)
+{
+  int v;
+  if (c >= '0' && c <= '9')
+  {
+    v = c - '0';
+  }
+  else if (c >= 'a' && c <= 'z')
+  {
+    v = 10 + (c - 'a');
+  }
+  else if (c >= 'A' && c <= 'Z')
+  {
+    v = 10 + (c - 'A');
+  }
+  else
+  {
+    return -1;
+  }
+  if (v >= base)
+  {
+    return -1;
+  }
+  return v;
+}
+
+/*
+ * Parse a non-negative int in [0, INT_MAX] from an untrusted string.
+ * Returns 0 on success, nonzero on parse error or out-of-range. Accepts only
+ * decimal digits (no sign, no whitespace, no trailing junk).
+ */
+static int parse_int(const char *s, int *out)
+{
+  unsigned int acc = 0;
+  unsigned int limit = (unsigned int)INT_MAX;
+  int d;
+
+  if (s == NULL || *s == '\0')
+  {
+    return 1;
+  }
+  for (; *s != '\0'; s++)
+  {
+    d = digit_value(*s, 10);
+    if (d < 0)
+    {
+      return 1;
+    }
+    if (acc > (limit - (unsigned int)d) / 10u)
+    {
+      return 1;
+    }
+    acc = acc * 10u + (unsigned int)d;
+  }
+  *out = (int)acc;
+  return 0;
+}
+
+/*
+ * Parse a signed integer in decimal or 0x-prefixed hex from an untrusted
+ * string and reduce it mod 2^bw into [0, 2^bw). On parse failure: writes a
+ * diagnostic into *err and returns nonzero. `bw` must be in [1, 64].
+ *
+ * On overflow of the uint64_t accumulator we accept the wrap-around value:
+ * the result is masked to bw bits below regardless, so an over-long literal
+ * is treated as its natural mod-2^bw reduction. We still require strict
+ * digit-only input (no trailing junk, no embedded sign or whitespace).
+ */
+static int parse_arg(const char *s, int bw, uint64_t *out, char *err,
+                     size_t errlen)
+{
+  int neg = 0;
+  int base = 10;
+  uint64_t acc = 0;
+  uint64_t mask;
+  uint64_t v;
+  int d;
+
+  if (bw < 1 || bw > 64)
+  {
+    snprintf(err, errlen, "bitwidth out of range: %d", bw);
+    return 1;
+  }
+
+  if (*s == '-')
+  {
+    neg = 1;
+    s++;
+  }
+  if (*s == '0' && (s[1] == 'x' || s[1] == 'X'))
+  {
+    base = 16;
+    s += 2;
+  }
+  if (*s == '\0')
+  {
+    snprintf(err, errlen, "not an integer: empty");
+    return 1;
+  }
+
+  for (; *s != '\0'; s++)
+  {
+    d = digit_value(*s, base);
+    if (d < 0)
+    {
+      snprintf(err, errlen, "not an integer: %s", s);
+      return 1;
+    }
+    /* Wrap-around on overflow is accepted; the bw-mask below normalises it. */
+    acc = acc * (uint64_t)base + (uint64_t)d;
+  }
+
+  mask = (bw == 64) ? ~(uint64_t)0 : (((uint64_t)1 << bw) - 1);
+  /* Unsigned negation is well-defined: equals (-acc) mod 2^64; mask reduces
+     mod 2^bw. Avoids the UB of `-(int64_t)acc` when acc == 2^63. */
+  v = neg ? ((uint64_t)0 - acc) : acc;
+  *out = v & mask;
+  return 0;
+}
+
+static void fmt_hex(int bw, uint64_t v, char *buf, size_t buflen)
+{
+  int nibbles = (bw + 3) / 4;
+  snprintf(buf, buflen, "0x%0*" PRIx64, nibbles, v);
+}
+
+
+/* ============================================================
+ * NEON 8-bit element ops (16 lanes: .16b on a Q-reg)
+ * ============================================================ */
+
+static uint64_t neon_mul_8(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.16b, %w[a]\n\t"
+      "dup v1.16b, %w[b]\n\t"
+      "mul v2.16b, v0.16b, v1.16b\n\t"
+      "umov %w[out], v2.b[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xff;
+}
+
+static uint64_t neon_mla_8(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.16b, %w[acc]\n\t"
+      "dup v1.16b, %w[a]\n\t"
+      "dup v2.16b, %w[b]\n\t"
+      "mla v0.16b, v1.16b, v2.16b\n\t"
+      "umov %w[out], v0.b[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xff;
+}
+
+static uint64_t neon_mls_8(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.16b, %w[acc]\n\t"
+      "dup v1.16b, %w[a]\n\t"
+      "dup v2.16b, %w[b]\n\t"
+      "mls v0.16b, v1.16b, v2.16b\n\t"
+      "umov %w[out], v0.b[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xff;
+}
+
+static uint64_t neon_shsub_8(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.16b, %w[a]\n\t"
+      "dup v1.16b, %w[b]\n\t"
+      "shsub v2.16b, v0.16b, v1.16b\n\t"
+      "umov %w[out], v2.b[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xff;
+}
+
+/* SRSHR (vector) takes an immediate shift in [1, esize] -- i.e. [1, 8] for
+ * .16b, [1, 16] for .8h, [1, 32] for .4s. A shift of 0 is not architecturally
+ * encodable: the Arm ARM constrains shift to 1 <= shift <= esize, and any
+ * AArch64 assembler rejects #0 outright. We dispatch on k so the immediate
+ * can be stringised at compile time. */
+#define SRSHR_8_ASM(K)             \
+  __asm__ volatile(                \
+      "dup v0.16b, %w[a]\n\t"      \
+      "srshr v1.16b, v0.16b, #" #K \
+      "\n\t"                       \
+      "umov %w[out], v1.b[0]\n\t"  \
+      : [out] "=r"(out)            \
+      : [a] "r"((uint32_t)a)       \
+      : "v0", "v1")
+
+static uint64_t neon_srshr_8(int k, uint64_t a)
+{
+  uint64_t out = 0;
+  switch (k)
+  {
+    case 1:
+      SRSHR_8_ASM(1);
+      break;
+    case 2:
+      SRSHR_8_ASM(2);
+      break;
+    case 3:
+      SRSHR_8_ASM(3);
+      break;
+    case 4:
+      SRSHR_8_ASM(4);
+      break;
+    case 5:
+      SRSHR_8_ASM(5);
+      break;
+    case 6:
+      SRSHR_8_ASM(6);
+      break;
+    case 7:
+      SRSHR_8_ASM(7);
+      break;
+    case 8:
+      SRSHR_8_ASM(8);
+      break;
+    default:
+      die("SRSHR 8: shift must be in [1,8]");
+  }
+  return out & 0xff;
+}
+
+/* ============================================================
+ * NEON 16-bit element ops (8 lanes: .8h)
+ * ============================================================ */
+
+static uint64_t neon_mul_16(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[a]\n\t"
+      "dup v1.8h, %w[b]\n\t"
+      "mul v2.8h, v0.8h, v1.8h\n\t"
+      "umov %w[out], v2.h[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+static uint64_t neon_mla_16(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[acc]\n\t"
+      "dup v1.8h, %w[a]\n\t"
+      "dup v2.8h, %w[b]\n\t"
+      "mla v0.8h, v1.8h, v2.8h\n\t"
+      "umov %w[out], v0.h[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+static uint64_t neon_mls_16(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[acc]\n\t"
+      "dup v1.8h, %w[a]\n\t"
+      "dup v2.8h, %w[b]\n\t"
+      "mls v0.8h, v1.8h, v2.8h\n\t"
+      "umov %w[out], v0.h[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+static uint64_t neon_sqdmulh_16(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[a]\n\t"
+      "dup v1.8h, %w[b]\n\t"
+      "sqdmulh v2.8h, v0.8h, v1.8h\n\t"
+      "umov %w[out], v2.h[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+static uint64_t neon_sqrdmulh_16(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[a]\n\t"
+      "dup v1.8h, %w[b]\n\t"
+      "sqrdmulh v2.8h, v0.8h, v1.8h\n\t"
+      "umov %w[out], v2.h[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+static uint64_t neon_sqrdmlah_16(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[acc]\n\t"
+      "dup v1.8h, %w[a]\n\t"
+      "dup v2.8h, %w[b]\n\t"
+      "sqrdmlah v0.8h, v1.8h, v2.8h\n\t"
+      "umov %w[out], v0.h[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+static uint64_t neon_shsub_16(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.8h, %w[a]\n\t"
+      "dup v1.8h, %w[b]\n\t"
+      "shsub v2.8h, v0.8h, v1.8h\n\t"
+      "umov %w[out], v2.h[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffff;
+}
+
+#define SRSHR_16_ASM(K)           \
+  __asm__ volatile(               \
+      "dup v0.8h, %w[a]\n\t"      \
+      "srshr v1.8h, v0.8h, #" #K  \
+      "\n\t"                      \
+      "umov %w[out], v1.h[0]\n\t" \
+      : [out] "=r"(out)           \
+      : [a] "r"((uint32_t)a)      \
+      : "v0", "v1")
+
+static uint64_t neon_srshr_16(int k, uint64_t a)
+{
+  uint64_t out = 0;
+  switch (k)
+  {
+    case 1:
+      SRSHR_16_ASM(1);
+      break;
+    case 2:
+      SRSHR_16_ASM(2);
+      break;
+    case 3:
+      SRSHR_16_ASM(3);
+      break;
+    case 4:
+      SRSHR_16_ASM(4);
+      break;
+    case 5:
+      SRSHR_16_ASM(5);
+      break;
+    case 6:
+      SRSHR_16_ASM(6);
+      break;
+    case 7:
+      SRSHR_16_ASM(7);
+      break;
+    case 8:
+      SRSHR_16_ASM(8);
+      break;
+    case 9:
+      SRSHR_16_ASM(9);
+      break;
+    case 10:
+      SRSHR_16_ASM(10);
+      break;
+    case 11:
+      SRSHR_16_ASM(11);
+      break;
+    case 12:
+      SRSHR_16_ASM(12);
+      break;
+    case 13:
+      SRSHR_16_ASM(13);
+      break;
+    case 14:
+      SRSHR_16_ASM(14);
+      break;
+    case 15:
+      SRSHR_16_ASM(15);
+      break;
+    case 16:
+      SRSHR_16_ASM(16);
+      break;
+    default:
+      die("SRSHR 16: shift must be in [1,16]");
+  }
+  return out & 0xffff;
+}
+
+/* ============================================================
+ * NEON 32-bit element ops (4 lanes: .4s)
+ * ============================================================ */
+
+static uint64_t neon_mul_32(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[a]\n\t"
+      "dup v1.4s, %w[b]\n\t"
+      "mul v2.4s, v0.4s, v1.4s\n\t"
+      "umov %w[out], v2.s[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+static uint64_t neon_mla_32(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[acc]\n\t"
+      "dup v1.4s, %w[a]\n\t"
+      "dup v2.4s, %w[b]\n\t"
+      "mla v0.4s, v1.4s, v2.4s\n\t"
+      "umov %w[out], v0.s[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+static uint64_t neon_mls_32(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[acc]\n\t"
+      "dup v1.4s, %w[a]\n\t"
+      "dup v2.4s, %w[b]\n\t"
+      "mls v0.4s, v1.4s, v2.4s\n\t"
+      "umov %w[out], v0.s[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+static uint64_t neon_sqdmulh_32(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[a]\n\t"
+      "dup v1.4s, %w[b]\n\t"
+      "sqdmulh v2.4s, v0.4s, v1.4s\n\t"
+      "umov %w[out], v2.s[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+static uint64_t neon_sqrdmulh_32(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[a]\n\t"
+      "dup v1.4s, %w[b]\n\t"
+      "sqrdmulh v2.4s, v0.4s, v1.4s\n\t"
+      "umov %w[out], v2.s[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+static uint64_t neon_sqrdmlah_32(uint64_t acc, uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[acc]\n\t"
+      "dup v1.4s, %w[a]\n\t"
+      "dup v2.4s, %w[b]\n\t"
+      "sqrdmlah v0.4s, v1.4s, v2.4s\n\t"
+      "umov %w[out], v0.s[0]\n\t"
+      : [out] "=r"(out)
+      : [acc] "r"((uint32_t)acc), [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+static uint64_t neon_shsub_32(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile(
+      "dup v0.4s, %w[a]\n\t"
+      "dup v1.4s, %w[b]\n\t"
+      "shsub v2.4s, v0.4s, v1.4s\n\t"
+      "umov %w[out], v2.s[0]\n\t"
+      : [out] "=r"(out)
+      : [a] "r"((uint32_t)a), [b] "r"((uint32_t)b)
+      : "v0", "v1", "v2");
+  return out & 0xffffffff;
+}
+
+#define SRSHR_32_ASM(K)           \
+  __asm__ volatile(               \
+      "dup v0.4s, %w[a]\n\t"      \
+      "srshr v1.4s, v0.4s, #" #K  \
+      "\n\t"                      \
+      "umov %w[out], v1.s[0]\n\t" \
+      : [out] "=r"(out)           \
+      : [a] "r"((uint32_t)a)      \
+      : "v0", "v1")
+
+static uint64_t neon_srshr_32(int k, uint64_t a)
+{
+  uint64_t out = 0;
+  switch (k)
+  {
+    case 1:
+      SRSHR_32_ASM(1);
+      break;
+    case 2:
+      SRSHR_32_ASM(2);
+      break;
+    case 3:
+      SRSHR_32_ASM(3);
+      break;
+    case 4:
+      SRSHR_32_ASM(4);
+      break;
+    case 5:
+      SRSHR_32_ASM(5);
+      break;
+    case 6:
+      SRSHR_32_ASM(6);
+      break;
+    case 7:
+      SRSHR_32_ASM(7);
+      break;
+    case 8:
+      SRSHR_32_ASM(8);
+      break;
+    case 9:
+      SRSHR_32_ASM(9);
+      break;
+    case 10:
+      SRSHR_32_ASM(10);
+      break;
+    case 11:
+      SRSHR_32_ASM(11);
+      break;
+    case 12:
+      SRSHR_32_ASM(12);
+      break;
+    case 13:
+      SRSHR_32_ASM(13);
+      break;
+    case 14:
+      SRSHR_32_ASM(14);
+      break;
+    case 15:
+      SRSHR_32_ASM(15);
+      break;
+    case 16:
+      SRSHR_32_ASM(16);
+      break;
+    case 17:
+      SRSHR_32_ASM(17);
+      break;
+    case 18:
+      SRSHR_32_ASM(18);
+      break;
+    case 19:
+      SRSHR_32_ASM(19);
+      break;
+    case 20:
+      SRSHR_32_ASM(20);
+      break;
+    case 21:
+      SRSHR_32_ASM(21);
+      break;
+    case 22:
+      SRSHR_32_ASM(22);
+      break;
+    case 23:
+      SRSHR_32_ASM(23);
+      break;
+    case 24:
+      SRSHR_32_ASM(24);
+      break;
+    case 25:
+      SRSHR_32_ASM(25);
+      break;
+    case 26:
+      SRSHR_32_ASM(26);
+      break;
+    case 27:
+      SRSHR_32_ASM(27);
+      break;
+    case 28:
+      SRSHR_32_ASM(28);
+      break;
+    case 29:
+      SRSHR_32_ASM(29);
+      break;
+    case 30:
+      SRSHR_32_ASM(30);
+      break;
+    case 31:
+      SRSHR_32_ASM(31);
+      break;
+    case 32:
+      SRSHR_32_ASM(32);
+      break;
+    default:
+      die("SRSHR 32: shift must be in [1,32]");
+  }
+  return out & 0xffffffff;
+}
+
+/* ============================================================
+ * 64-bit scalar SMULH/UMULH (no NEON form)
+ * ============================================================ */
+
+static uint64_t scalar_smulh_64(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile("smulh %[out], %[a], %[b]"
+                   : [out] "=r"(out)
+                   : [a] "r"(a), [b] "r"(b));
+  return out;
+}
+
+static uint64_t scalar_umulh_64(uint64_t a, uint64_t b)
+{
+  uint64_t out;
+  __asm__ volatile("umulh %[out], %[a], %[b]"
+                   : [out] "=r"(out)
+                   : [a] "r"(a), [b] "r"(b));
+  return out;
+}
+
+/* ============================================================
+ * Dispatcher
+ * ============================================================ */
+
+static int streq(const char *a, const char *b) { return strcmp(a, b) == 0; }
+
+/*
+ * Run one case. On success: writes the formatted hex line into out (no
+ * trailing newline) and returns 0. On failure: writes a diagnostic into
+ * out and returns nonzero.
+ */
+static int dispatch(const char *mn, int bw, int nargs, uint64_t a0, uint64_t a1,
+                    uint64_t a2, char *out, size_t outlen)
+{
+  uint64_t r;
+
+  if (streq(mn, "MUL") && nargs == 2)
+  {
+    if (bw == 8)
+    {
+      r = neon_mul_8(a0, a1);
+    }
+    else if (bw == 16)
+    {
+      r = neon_mul_16(a0, a1);
+    }
+    else if (bw == 32)
+    {
+      r = neon_mul_32(a0, a1);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR MUL: bw must be 8/16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "MLA") && nargs == 3)
+  {
+    if (bw == 8)
+    {
+      r = neon_mla_8(a0, a1, a2);
+    }
+    else if (bw == 16)
+    {
+      r = neon_mla_16(a0, a1, a2);
+    }
+    else if (bw == 32)
+    {
+      r = neon_mla_32(a0, a1, a2);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR MLA: bw must be 8/16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "MLS") && nargs == 3)
+  {
+    if (bw == 8)
+    {
+      r = neon_mls_8(a0, a1, a2);
+    }
+    else if (bw == 16)
+    {
+      r = neon_mls_16(a0, a1, a2);
+    }
+    else if (bw == 32)
+    {
+      r = neon_mls_32(a0, a1, a2);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR MLS: bw must be 8/16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "SQDMULH") && nargs == 2)
+  {
+    if (bw == 16)
+    {
+      r = neon_sqdmulh_16(a0, a1);
+    }
+    else if (bw == 32)
+    {
+      r = neon_sqdmulh_32(a0, a1);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR SQDMULH: bw must be 16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "SQRDMULH") && nargs == 2)
+  {
+    if (bw == 16)
+    {
+      r = neon_sqrdmulh_16(a0, a1);
+    }
+    else if (bw == 32)
+    {
+      r = neon_sqrdmulh_32(a0, a1);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR SQRDMULH: bw must be 16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "SQRDMLAH") && nargs == 3)
+  {
+    if (bw == 16)
+    {
+      r = neon_sqrdmlah_16(a0, a1, a2);
+    }
+    else if (bw == 32)
+    {
+      r = neon_sqrdmlah_32(a0, a1, a2);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR SQRDMLAH: bw must be 16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "SHSUB") && nargs == 2)
+  {
+    if (bw == 8)
+    {
+      r = neon_shsub_8(a0, a1);
+    }
+    else if (bw == 16)
+    {
+      r = neon_shsub_16(a0, a1);
+    }
+    else if (bw == 32)
+    {
+      r = neon_shsub_32(a0, a1);
+    }
+    else
+    {
+      snprintf(out, outlen, "ERROR SHSUB: bw must be 8/16/32");
+      return 1;
+    }
+  }
+  else if (streq(mn, "SRSHR") && nargs == 2)
+  {
+    /* First arg is the shift amount k in [1, bw]; second is the lane. Reject
+       out-of-range k here rather than relying on the case-table `default`,
+       which would terminate the process via die() and break stream mode. */
+    if (bw != 8 && bw != 16 && bw != 32)
+    {
+      snprintf(out, outlen, "ERROR SRSHR: bw must be 8/16/32");
+      return 1;
+    }
+    if (a0 < 1 || a0 > (uint64_t)bw)
+    {
+      snprintf(out, outlen, "ERROR SRSHR: shift must be in [1,%d]", bw);
+      return 1;
+    }
+    if (bw == 8)
+    {
+      r = neon_srshr_8((int)a0, a1);
+    }
+    else if (bw == 16)
+    {
+      r = neon_srshr_16((int)a0, a1);
+    }
+    else
+    {
+      r = neon_srshr_32((int)a0, a1);
+    }
+  }
+  else if (streq(mn, "MULH") && nargs == 2)
+  {
+    if (bw != 64)
+    {
+      snprintf(out, outlen, "ERROR MULH: bw must be 64");
+      return 1;
+    }
+    r = scalar_smulh_64(a0, a1);
+  }
+  else if (streq(mn, "UMULH") && nargs == 2)
+  {
+    if (bw != 64)
+    {
+      snprintf(out, outlen, "ERROR UMULH: bw must be 64");
+      return 1;
+    }
+    r = scalar_umulh_64(a0, a1);
+  }
+  else
+  {
+    snprintf(out, outlen, "ERROR unsupported: %s %d arity=%d", mn, bw, nargs);
+    return 1;
+  }
+
+  fmt_hex(bw, r, out, outlen);
+  return 0;
+}
+
+/*
+ * Parse a whitespace-separated tokenized line: MNEMONIC BITWIDTH ARG...
+ * Mutates `line`. Returns number of tokens; -1 on too many.
+ */
+#define IS_SEP(c) ((c) == ' ' || (c) == '\t' || (c) == '\r' || (c) == '\n')
+
+static int tokenize(char *line, char **toks, int max_toks)
+{
+  int n = 0;
+  char *p = line;
+
+  while (*p)
+  {
+    while (IS_SEP(*p))
+    {
+      p++;
+    }
+    if (!*p)
+    {
+      break;
+    }
+    if (n >= max_toks)
+    {
+      return -1;
+    }
+    toks[n++] = p;
+    while (*p && !IS_SEP(*p))
+    {
+      p++;
+    }
+    if (*p)
+    {
+      *p++ = '\0';
+    }
+  }
+  return n;
+}
+
+#undef IS_SEP
+
+static int run_one_from_tokens(char **toks, int n, char *out, size_t outlen)
+{
+  const char *mn;
+  int bw;
+  int nargs;
+  uint64_t a[3] = {0, 0, 0};
+  char err[128];
+  int i;
+
+  if (n < 3)
+  {
+    snprintf(out, outlen, "ERROR expected: MNEMONIC BITWIDTH ARG...");
+    return 1;
+  }
+  mn = toks[0];
+  if (parse_int(toks[1], &bw) != 0)
+  {
+    snprintf(out, outlen, "ERROR bitwidth not an integer: %s", toks[1]);
+    return 1;
+  }
+  nargs = n - 2;
+  if (nargs > 3)
+  {
+    snprintf(out, outlen, "ERROR too many args");
+    return 1;
+  }
+
+  for (i = 0; i < nargs; i++)
+  {
+    if (parse_arg(toks[2 + i], bw, &a[i], err, sizeof err) != 0)
+    {
+      snprintf(out, outlen, "ERROR %s", err);
+      return 1;
+    }
+  }
+  return dispatch(mn, bw, nargs, a[0], a[1], a[2], out, outlen);
+}
+
+/*
+ * Print the offending input and exit. Any malformed input is treated as
+ * fatal: the streaming conformance protocol is one-line-in / one-line-out,
+ * so silently skipping or emitting a placeholder would cause the driver to
+ * fall out of lockstep. The one-shot CLI applies the same policy.
+ *
+ * `original` is the un-tokenised input line, kept around because tokenize()
+ * destructively NUL-terminates inside it. In one-shot mode there is no such
+ * line (argv strings are untouched), so callers pass NULL and we print
+ * "<argv>" instead.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noreturn))
+#endif
+static void die_with_input(const char *reason, const char *original)
+{
+  if (original == NULL)
+  {
+    fprintf(stderr, "hw_exec: %s\n  input: <argv>\n", reason);
+  }
+  else
+  {
+    size_t len = strlen(original);
+    fprintf(stderr, "hw_exec: %s\n  input: %s", reason, original);
+    if (len == 0 || original[len - 1] != '\n')
+    {
+      fputc('\n', stderr);
+    }
+  }
+  exit(1);
+}
+
+/*
+ * Process a tokenised input case: dispatch, write the result to stdout, or
+ * exit on error. `original` may be NULL when called from one-shot mode.
+ */
+static void process_tokens(char **toks, int n, const char *original)
+{
+  char out[OUT_BUF_SIZE];
+
+  if (run_one_from_tokens(toks, n, out, sizeof out) != 0)
+  {
+    /* `out` now holds the diagnostic written by run_one_from_tokens. */
+    die_with_input(out, original);
+  }
+  fputs(out, stdout);
+  fputc('\n', stdout);
+  fflush(stdout);
+}
+
+/*
+ * Read one case from stdin into `line`, copy it to `original` for
+ * diagnostics, and return the number of tokens. Returns 0 on blank line, -1
+ * on EOF. Aborts on a too-long line or too-many-tokens line, since either
+ * indicates a protocol violation we cannot recover from. `line` and
+ * `original` must point at buffers of size at least LINE_BUF_SIZE.
+ */
+static int read_one_line(char *line, char *original, char **toks, int max_toks)
+{
+  int n;
+
+  if (!fgets(line, LINE_BUF_SIZE, stdin))
+  {
+    return -1;
+  }
+  if (strchr(line, '\n') == NULL && !feof(stdin))
+  {
+    die_with_input("line too long", line);
+  }
+  memcpy(original, line, LINE_BUF_SIZE);
+
+  n = tokenize(line, toks, max_toks);
+  if (n < 0)
+  {
+    die_with_input("too many tokens", original);
+  }
+  return n;
+}
+
+/*
+ * Drive the harness over its input. In stream mode we loop over stdin until
+ * EOF; in one-shot mode we run a single case taken directly from argv and
+ * return. The two modes share tokenisation, dispatch, output, and error
+ * handling.
+ */
+static void run(int stream_mode, int argc, char **argv)
+{
+  if (stream_mode)
+  {
+    char line[LINE_BUF_SIZE];
+    char original[LINE_BUF_SIZE];
+    char *toks[MAX_TOKENS];
+    int n;
+
+    for (;;)
+    {
+      n = read_one_line(line, original, toks, MAX_TOKENS);
+      if (n < 0)
+      {
+        return; /* EOF */
+      }
+      if (n == 0)
+      {
+        continue; /* blank line: no case, no output */
+      }
+      process_tokens(toks, n, original);
+    }
+  }
+  else
+  {
+    /* One-shot: argv[1..argc-1] are the tokens. */
+    process_tokens(argv + 1, argc - 1, NULL);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  if (argc == 2 && streq(argv[1], "--stream"))
+  {
+    run(1, 0, NULL);
+    return 0;
+  }
+  if (argc < 4)
+  {
+    die("usage: hw_exec MNEMONIC BITWIDTH ARG... | hw_exec --stream");
+  }
+  run(0, argc, argv);
+  return 0;
+}

--- a/proofs/isabelle/neon_ntt/model/sml/Makefile
+++ b/proofs/isabelle/neon_ntt/model/sml/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# Build the SML reference model_exec wrapper by:
+#   1) running `isabelle build NeonNTT` (which produces model.ML via export_code),
+#   2) extracting model.ML to export/...,
+#   3) emitting a thin shell wrapper that invokes Isabelle's bundled `poly`
+#      with --use main.sml (which itself `use`s the generated model.ML).
+#
+# Override ISABELLE_DIR if your Isabelle install lives elsewhere:
+#   make ISABELLE_DIR=/path/to/Isabelle2025-2.app
+# Everything else is queried from Isabelle.
+#
+# We deliberately avoid `polyc` here: it would require linking against
+# Isabelle's bundled libgmp, whose shipped install_name on macOS points at
+# the (long-deleted) build-host path. `poly` itself has the right rpath
+# baked in, so invoking it directly side-steps the whole mess.
+
+ISABELLE_DIR ?= /Applications/Isabelle2025-2.app
+ISABELLE     := $(ISABELLE_DIR)/bin/isabelle
+
+POLYML_HOME    := $(shell $(ISABELLE) getenv -b POLYML_HOME)
+APPLE_PLATFORM := $(shell $(ISABELLE) getenv -b ISABELLE_APPLE_PLATFORM64)
+PLATFORM64     := $(shell $(ISABELLE) getenv -b ISABELLE_PLATFORM64)
+ML_PLATFORM    := $(if $(APPLE_PLATFORM),$(APPLE_PLATFORM),$(PLATFORM64))
+POLY           := $(POLYML_HOME)/$(ML_PLATFORM)/poly
+
+NEON_NTT_DIR := $(realpath ../..)
+HERE         := $(realpath .)
+
+GENERATED := export/NeonNTT.Word_Ops_Export/code/model.ML
+
+.PHONY: all clean build_isabelle
+
+all: model_exec
+
+build_isabelle:
+	cd $(NEON_NTT_DIR) && $(ISABELLE) build -d . NeonNTT
+
+$(GENERATED): build_isabelle
+	rm -rf export
+	cd $(NEON_NTT_DIR) && $(ISABELLE) export -d . -O $(HERE)/export -x '*:code/*' NeonNTT
+
+model_exec: $(GENERATED) main.sml Makefile
+	@# Wrapper script: cd to this dir (so main.sml's relative `use` of
+	@# export/.../model.ML resolves), then invoke poly. The `--` separator
+	@# isolates user argv from poly's own flags; main.sml's user_args ()
+	@# strips everything before the `--`.
+	@printf '%s\n' \
+	  '#!/bin/sh' \
+	  'cd "$(HERE)" || exit 1' \
+	  'exec "$(POLY)" -q --use main.sml --eval "val () = main ()" --error-exit -- "$$@"' \
+	  > $@
+	@chmod +x $@
+
+clean:
+	rm -rf export model_exec build

--- a/proofs/isabelle/neon_ntt/model/sml/main.sml
+++ b/proofs/isabelle/neon_ntt/model/sml/main.sml
@@ -1,0 +1,149 @@
+(* Copyright (c) The mldsa-native project authors
+   SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT *)
+
+(* SML CLI harness wrapping the exported Isabelle model.
+
+   Two modes:
+   * One-shot:  model_exec MNEMONIC BITWIDTH ARG0 [ARG1 ...]
+                  -> prints one hex result, exits.
+   * Streaming: model_exec --stream
+                  reads one space-separated case per line on stdin
+                  ("MNEMONIC BITWIDTH ARG0 [ARG1 ...]"), writes the hex
+                  result on stdout per line (or "ERROR <msg>" without
+                  exiting). Output is line-buffered.
+
+   Inputs accept hex (0x...) or decimal (incl. negative). Inputs are
+   reduced mod 2^bw to unsigned. Output is 0x-prefixed lowercase hex
+   padded to bw/4 nibbles. *)
+
+use "export/NeonNTT.Word_Ops_Export/code/model.ML";
+
+fun die msg =
+  (TextIO.output (TextIO.stdErr, msg ^ "\n");
+   OS.Process.exit OS.Process.failure)
+
+(* Parse signed integer in decimal or 0x-prefixed hex *)
+exception ParseFail of string
+fun parse_int_opt s =
+  let
+    val (neg, body) =
+      if size s > 0 andalso String.sub (s, 0) = #"-"
+      then (true, String.extract (s, 1, NONE))
+      else (false, s)
+    val (radix, digits) =
+      if size body >= 2
+         andalso String.sub (body, 0) = #"0"
+         andalso (String.sub (body, 1) = #"x" orelse String.sub (body, 1) = #"X")
+      then (StringCvt.HEX, String.extract (body, 2, NONE))
+      else (StringCvt.DEC, body)
+  in
+    case StringCvt.scanString (IntInf.scan radix) digits of
+      SOME v => SOME (if neg then IntInf.~ v else v)
+    | NONE   => NONE
+  end
+
+fun parse_int s =
+  case parse_int_opt s of
+    SOME v => v
+  | NONE   => raise ParseFail ("not an integer: " ^ s)
+
+(* Validate a parsed bitwidth: must fit in a small int and be in [1, 64].
+   Without this, a malicious caller could request bw = 2^60, causing the
+   `1 << bw` below to allocate or trap. *)
+fun parse_bw bw_str =
+  let
+    val v = parse_int bw_str
+  in
+    if IntInf.< (v, 1) orelse IntInf.> (v, 64)
+    then raise ParseFail ("bitwidth out of range [1,64]: " ^ bw_str)
+    else IntInf.toInt v
+  end
+
+(* Reduce x mod 2^bw to the unsigned range [0, 2^bw). bw is a small int. *)
+fun mod_unsigned bw x =
+  let
+    val m = IntInf.<< (1, Word.fromInt bw)
+    val r = IntInf.mod (x, m)
+  in if IntInf.< (r, 0) then IntInf.+ (r, m) else r end
+
+(* Pad unsigned hex string to bw/4 nibbles, lowercase, 0x-prefixed. *)
+fun fmt_hex bw x =
+  let
+    val nibbles = (bw + 3) div 4
+    val raw = IntInf.fmt StringCvt.HEX x
+    val lower = String.translate (fn c => str (Char.toLower c)) raw
+    val pad = nibbles - size lower
+    val padded = if pad > 0 then String.implode (List.tabulate (pad, fn _ => #"0")) ^ lower else lower
+  in "0x" ^ padded end
+
+(* Run one case from a token list. Returns the formatted hex line, or
+   raises ParseFail with a message. *)
+fun run_case (mn :: bw_str :: arg_strs) =
+      let
+        val bw_int = parse_bw bw_str
+        val bw = IntInf.fromInt bw_int
+        val xs = map parse_int arg_strs
+        val xs_u = map (mod_unsigned bw_int) xs
+      in
+        case Model.model_exec mn bw xs_u of
+          SOME r => fmt_hex bw_int r
+        | NONE   => raise ParseFail ("unsupported: " ^ mn ^ " " ^ IntInf.toString bw
+                                     ^ " arity=" ^ Int.toString (length xs))
+      end
+  | run_case _ = raise ParseFail "expected: MNEMONIC BITWIDTH ARG..."
+
+fun tokens s =
+  String.tokens (fn c => c = #" " orelse c = #"\t" orelse c = #"\r") s
+
+fun stream_loop () =
+  case TextIO.inputLine TextIO.stdIn of
+    NONE => ()
+  | SOME line =>
+      let
+        val toks = tokens line
+      in
+        if toks = [] then stream_loop ()
+        else
+          let
+            val result =
+              SOME (run_case toks)
+              handle ParseFail m =>
+                       (TextIO.output (TextIO.stdErr,
+                                       "model_exec: " ^ m ^ "\n  input: " ^ line);
+                        OS.Process.exit OS.Process.failure)
+                   | exn =>
+                       (TextIO.output (TextIO.stdErr,
+                                       "model_exec: exception: " ^ exnMessage exn
+                                       ^ "\n  input: " ^ line);
+                        OS.Process.exit OS.Process.failure)
+          in
+            case result of
+              SOME s =>
+                (print s; print "\n"; TextIO.flushOut TextIO.stdOut;
+                 stream_loop ())
+            | NONE => ()  (* unreachable: handlers above call exit *)
+          end
+      end
+
+(* Split off args after the first "--", if present. Lets us be invoked
+   either directly (compiled binary) or via `poly --use ... -- USER_ARGS`. *)
+fun user_args () =
+  let
+    fun split [] acc = (rev acc, [])
+      | split ("--" :: rest) acc = (rev acc, rest)
+      | split (x :: xs) acc = split xs (x :: acc)
+    val all = CommandLine.arguments ()
+    val (_, after) = split all []
+  in
+    if after = [] andalso List.exists (fn x => x = "--") all = false
+    then all  (* no `--` at all: assume direct invocation *)
+    else after
+  end
+
+fun main () =
+  case user_args () of
+    ["--stream"] => stream_loop ()
+  | (mn :: bw_str :: args) =>
+      (print (run_case (mn :: bw_str :: args) ^ "\n")
+       handle ParseFail m => die m)
+  | _ => die "usage: model_exec MNEMONIC BITWIDTH ARG... | model_exec --stream"


### PR DESCRIPTION
This commit adds additional formal documentation of the approach to
modular arithmetic used in various assembly kernels in mldsa-native
and mlkem-native.

Specifically, it adds source and final PDF document for an Isabelle/HOL
formalization of the original "Neon NTT" paper [1] of Becker, Hwang,
Kannwischer, Yang, and Yang.

The documentation was obtained as human-directed auto-formalization
using Claude Opus 4.7 + the AutoCorrode I/Q + I/R AI integration
infrastructure for Isabelle.

The commit also adds a conformance testing harness to empirically
validate that the ad-hoc instructions models used in the formalization
match concrete execution on an AArch64 host.

CI is extended to re-build the PDF and build+run the conformance testing.

[1]:
  - Becker, Hwang, Kannwischer, Yang, Yang
  - Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1
  - [https://eprint.iacr.org/2021/986](https://eprint.iacr.org/2021/986)