### PR TITLE
HOL-Light: Consolidate AArch64 poly_use_hint_32 _CORRECT theorems

### DIFF
--- a/proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml
@@ -400,176 +400,15 @@ let ELEMENT_CORRECT_WORD = prove(
   AP_TERM_TAC THEN MP_TAC(SPECL [`a:int32`; `h:int32`] ELEMENT_CORRECT) THEN ASM_REWRITE_TAC[] THEN DISCH_THEN(fun th -> REWRITE_TAC[th]));;
 
 (* ========================================================================= *)
-(* Correctness proof, code-aligned spec (intermediate)                       *)
-(* ========================================================================= *)
-
-let POLY_USE_HINT_32_AARCH64_ASM_CORRECT_CODE = prove
- (`!a h x y pc.
-    nonoverlapping (word pc, LENGTH poly_use_hint_32_aarch64_asm_mc) (a, 1024) /\
-    nonoverlapping (a, 1024) (h, 1024)
-    ==> ensures arm
-          (\s. aligned_bytes_loaded s (word pc) poly_use_hint_32_aarch64_asm_mc /\
-               read PC s = word pc /\
-               C_ARGUMENTS [a; h] s /\
-               (!i. i < 256 ==> val(x i) < 8380417) /\
-               (!i. i < 256 ==> val(y i) <= 1) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s = x i) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add h (word(4 * i)))) s = y i))
-          (\s. read PC s = word(pc + LENGTH poly_use_hint_32_aarch64_asm_mc - 4) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s =
-                 word(mldsa_use_hint_32_code (val(x i)) (val(y i)))))
-          (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
-           MAYCHANGE [memory :> bytes(a, 1024)])`,
-
-  (* Setup *)
-  MAP_EVERY X_GEN_TAC
-    [`a:int64`; `h:int64`;
-     `x:num->int32`; `y:num->int32`; `pc:num`] THEN
-  REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
-              NONOVERLAPPING_CLAUSES; ALL;
-              fst POLY_USE_HINT_32_AARCH64_ASM_EXEC] THEN
-  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
-  GLOBALIZE_PRECONDITION_TAC THEN
-  CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
-  CONV_TAC NUM_REDUCE_CONV THEN
-  REPEAT STRIP_TAC THEN
-  REWRITE_TAC[SOME_FLAGS; MODIFIABLE_SIMD_REGS] THEN
-
-  (* Initialize and merge memory *)
-  ENSURES_INIT_TAC "s0" THEN
-  MEMORY_128_FROM_32_TAC "a" 0 64 THEN
-  ASM_REWRITE_TAC[WORD_ADD_0] THEN CONV_TAC WORD_REDUCE_CONV THEN
-  STRIP_TAC THEN
-  MEMORY_128_FROM_32_TAC "h" 0 64 THEN
-  ASM_REWRITE_TAC[WORD_ADD_0] THEN CONV_TAC WORD_REDUCE_CONV THEN
-  STRIP_TAC THEN
-  DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes32 a) s = x`] THEN
-
-  (* Simulate 878 instructions (excluding RET) *)
-  MAP_EVERY (fun n -> ARM_STEPS_TAC POLY_USE_HINT_32_AARCH64_ASM_EXEC [n] THEN
-                      SIMD_SIMPLIFY_TAC[])
-        (1--878) THEN
-  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
-
-  (* Split bytes128 -> bytes32 for output memory *)
-  REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
-    CONV_RULE (SIMD_SIMPLIFY_CONV []) o
-    CONV_RULE(READ_MEMORY_SPLIT_CONV 2) o
-    check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
-
-  (* Expand output cases, substitute *)
-  CONV_TAC(TOP_DEPTH_CONV EXPAND_CASES_CONV) THEN
-  CONV_TAC(DEPTH_CONV NUM_MULT_CONV THENC DEPTH_CONV NUM_ADD_CONV) THEN
-  REWRITE_TAC[WORD_ADD_0] THEN
-  ASM_REWRITE_TAC[WORD_ADD_0] THEN ASM_REWRITE_TAC[] THEN
-
-  (* Push word_subword through SIMD ops to per-element form *)
-  REWRITE_TAC[WORD_SUBWORD_AND; WORD_SUBWORD_OR] THEN
-  let WSN_TAC = REWRITE_TAC(map (fun n -> prove(
-    subst [mk_small_numeral n, `n:num`]
-      `!x:int128. word_subword(word_not x) (n,32):int32 = word_not(word_subword x (n,32))`,
-    GEN_TAC THEN MATCH_MP_TAC WORD_SUBWORD_NOT THEN
-    REWRITE_TAC[DIMINDEX_32; DIMINDEX_128] THEN ARITH_TAC)) [0;32;64;96]) in
-  WSN_TAC THEN
-  CONV_TAC(DEPTH_CONV WORD_SIMPLE_SUBWORD_CONV) THEN
-  CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN
-  (* Match expanded ival/iword form *)
-  let EC_DEEP =
-    CONV_RULE(DEPTH_CONV WORD_NUM_RED_CONV)
-     (CONV_RULE(DEPTH_CONV(INT_RED_CONV ORELSEC NUM_RED_CONV))
-       (CONV_RULE(TOP_DEPTH_CONV let_CONV)
-         (REWRITE_RULE[mldsa_use_hint_32_asm; word_2smulh; word_ishr_round;
-                        DIMINDEX_32] ELEMENT_CORRECT_WORD))) in
-  let EC_FINAL = ONCE_REWRITE_RULE[WORD_AND_SYM]
-    (ONCE_REWRITE_RULE[WORD_OR_SYM] EC_DEEP) in
-  REPEAT CONJ_TAC THEN
-  MATCH_MP_TAC EC_FINAL THEN
-  CONJ_TAC THEN FIRST_X_ASSUM MATCH_MP_TAC THEN ARITH_TAC);;
-
-
-(* ========================================================================= *)
-(* Subroutine form (intermediate, code-aligned)                              *)
-(* ========================================================================= *)
-
-let POLY_USE_HINT_32_AARCH64_ASM_CORRECT_BOUND_CODE = prove
- (`!a h x y pc.
-    nonoverlapping (word pc, LENGTH poly_use_hint_32_aarch64_asm_mc) (a, 1024) /\
-    nonoverlapping (a, 1024) (h, 1024)
-    ==> ensures arm
-          (\s. aligned_bytes_loaded s (word pc) poly_use_hint_32_aarch64_asm_mc /\
-               read PC s = word pc /\
-               C_ARGUMENTS [a; h] s /\
-               (!i. i < 256 ==> val(x i) < 8380417) /\
-               (!i. i < 256 ==> val(y i) <= 1) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s = x i) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add h (word(4 * i)))) s = y i))
-          (\s. read PC s = word(pc + LENGTH poly_use_hint_32_aarch64_asm_mc - 4) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s =
-                   word(mldsa_use_hint_32_code (val(x i)) (val(y i)))) /\
-               (!i. i < 256 ==>
-                 val(read(memory :> bytes32(word_add a (word(4 * i)))) s) < 16))
-          (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
-           MAYCHANGE [memory :> bytes(a, 1024)])`,
-  REPEAT GEN_TAC THEN DISCH_TAC THEN
-  MATCH_MP_TAC ENSURES_STRENGTHEN_POST THEN
-  EXISTS_TAC
-   `\s. read PC s = word(pc + LENGTH poly_use_hint_32_aarch64_asm_mc - 4) /\
-        (!i. i < 256 ==>
-          read(memory :> bytes32(word_add a (word(4 * i)))) s =
-            word(mldsa_use_hint_32_code (val(x i:int32)) (val(y i:int32))))` THEN
-  CONJ_TAC THENL
-  [MATCH_MP_TAC POLY_USE_HINT_32_AARCH64_ASM_CORRECT_CODE THEN ASM_REWRITE_TAC[];
-   REWRITE_TAC[] THEN REPEAT STRIP_TAC THEN ASM_REWRITE_TAC[] THEN
-   FIRST_X_ASSUM(MP_TAC o SPEC `i:num`) THEN ASM_REWRITE_TAC[] THEN
-   DISCH_THEN SUBST1_TAC THEN REWRITE_TAC[VAL_WORD; DIMINDEX_32] THEN
-   CONV_TAC NUM_REDUCE_CONV THEN
-   MATCH_MP_TAC(ARITH_RULE `x < 16 ==> x MOD 4294967296 < 16`) THEN
-   REWRITE_TAC[mldsa_use_hint_32_code] THEN
-   CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
-   REPEAT(COND_CASES_TAC THEN ASM_REWRITE_TAC[]) THEN ASM_ARITH_TAC]);;
-
-(* Intermediate subroutine correctness against the code-aligned spec.
-   Bridged to the public FIPS 204-aligned theorem below via
-   MLDSA_USE_HINT_32_EQUIV. *)
-let POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT_CODE = prove
- (`!a h x y pc returnaddress.
-    nonoverlapping (word pc, LENGTH poly_use_hint_32_aarch64_asm_mc) (a, 1024) /\
-    nonoverlapping (a, 1024) (h, 1024)
-    ==> ensures arm
-          (\s. aligned_bytes_loaded s (word pc) poly_use_hint_32_aarch64_asm_mc /\
-               read PC s = word pc /\
-               read X30 s = returnaddress /\
-               C_ARGUMENTS [a; h] s /\
-               (!i. i < 256 ==> val(x i) < 8380417) /\
-               (!i. i < 256 ==> val(y i) <= 1) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s = x i) /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add h (word(4 * i)))) s = y i))
-          (\s. read PC s = returnaddress /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s =
-                   word(mldsa_use_hint_32_code (val(x i)) (val(y i)))) /\
-               (!i. i < 256 ==>
-                 val(read(memory :> bytes32(word_add a (word(4 * i)))) s) < 16))
-          (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
-           MAYCHANGE [memory :> bytes(a, 1024)])`,
-  REWRITE_TAC[fst POLY_USE_HINT_32_AARCH64_ASM_EXEC] THEN
-  CONV_TAC NUM_REDUCE_CONV THEN
-  ARM_ADD_RETURN_NOSTACK_TAC POLY_USE_HINT_32_AARCH64_ASM_EXEC
-    (CONV_RULE(ONCE_DEPTH_CONV NUM_REDUCE_CONV)
-      (REWRITE_RULE[fst POLY_USE_HINT_32_AARCH64_ASM_EXEC]
-         POLY_USE_HINT_32_AARCH64_ASM_CORRECT_BOUND_CODE)));;
-
-
-(* ========================================================================= *)
 (* FIPS 204 = code-aligned equivalence                                       *)
+(* ========================================================================= *)
+(*                                                                           *)
+(* Bridges mldsa_use_hint_32 (FIPS 204 Algorithm 40, used in the public      *)
+(* postcondition) to mldsa_use_hint_32_code (the Barrett-style numeric form  *)
+(* the assembly actually computes). The main correctness proof states its    *)
+(* postcondition in FIPS 204 terms and rewrites with this equivalence in the *)
+(* strengthening branch to expose the code-aligned form for symbolic         *)
+(* execution.                                                                *)
 (* ========================================================================= *)
 
 let LINEARIZE_DIV_MOD_TAC =
@@ -860,50 +699,162 @@ let MLDSA_USE_HINT_32_EQUIV = prove(
   ASM_MESON_TAC[]);;
 
 (* ========================================================================= *)
-(* Public subroutine correctness (FIPS 204-aligned)                          *)
+(* Correctness (FIPS 204-aligned)                                            *)
 (* ========================================================================= *)
 
 (* Postcondition is stated in terms of mldsa_use_hint_32 from FIPS 204
-   (Algorithm 40), with the output bound < 16 as a corollary.
-   Derived from POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT_CODE by
-   rewriting mldsa_use_hint_32_code -> mldsa_use_hint_32 via
-   MLDSA_USE_HINT_32_EQUIV. *)
+   (Algorithm 40), with the output bound < 16 as a corollary. The bounds
+   on val(x i) / val(y i) appear as antecedents inside the postcondition
+   (decompose-style): the assembly executes regardless of input ranges,
+   and only the FIPS-equivalence + output bound require the input bounds. *)
+let POLY_USE_HINT_32_AARCH64_ASM_CORRECT = prove
+ (`!a h x y pc.
+    nonoverlapping (word pc, LENGTH poly_use_hint_32_aarch64_asm_mc) (a, 1024) /\
+    nonoverlapping (a, 1024) (h, 1024)
+    ==> ensures arm
+          (\s. aligned_bytes_loaded s (word pc) poly_use_hint_32_aarch64_asm_mc /\
+               read PC s = word pc /\
+               C_ARGUMENTS [a; h] s /\
+               (!i. i < 256 ==>
+                 read(memory :> bytes32(word_add a (word(4 * i)))) s = x i) /\
+               (!i. i < 256 ==>
+                 read(memory :> bytes32(word_add h (word(4 * i)))) s = y i))
+          (\s. read PC s = word(pc + LENGTH poly_use_hint_32_aarch64_asm_mc - 4) /\
+               ((!i. i < 256 ==> val(x i:int32) < 8380417) /\
+                (!i. i < 256 ==> val(y i:int32) <= 1)
+                ==> (!i. i < 256 ==>
+                      read(memory :> bytes32(word_add a (word(4 * i)))) s =
+                        word(mldsa_use_hint_32 (val(y i)) (val(x i)))) /\
+                    (!i. i < 256 ==>
+                      val(read(memory :> bytes32
+                        (word_add a (word(4 * i)))) s) < 16)))
+          (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+           MAYCHANGE [memory :> bytes(a, 1024)])`,
+
+  MAP_EVERY X_GEN_TAC
+    [`a:int64`; `h:int64`;
+     `x:num->int32`; `y:num->int32`; `pc:num`] THEN
+  REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
+              NONOVERLAPPING_CLAUSES; ALL;
+              fst POLY_USE_HINT_32_AARCH64_ASM_EXEC] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  GLOBALIZE_PRECONDITION_TAC THEN
+  CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
+  CONV_TAC NUM_REDUCE_CONV THEN
+  REPEAT STRIP_TAC THEN
+  REWRITE_TAC[SOME_FLAGS; MODIFIABLE_SIMD_REGS] THEN
+
+  (* Initialize and merge memory (input bounds NOT used yet). *)
+  ENSURES_INIT_TAC "s0" THEN
+  MEMORY_128_FROM_32_TAC "a" 0 64 THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN CONV_TAC WORD_REDUCE_CONV THEN
+  STRIP_TAC THEN
+  MEMORY_128_FROM_32_TAC "h" 0 64 THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN CONV_TAC WORD_REDUCE_CONV THEN
+  STRIP_TAC THEN
+  DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes32 a) s = x`] THEN
+
+  (* Simulate 878 instructions (the assembly is bound-independent). *)
+  MAP_EVERY (fun n -> ARM_STEPS_TAC POLY_USE_HINT_32_AARCH64_ASM_EXEC [n] THEN
+                      SIMD_SIMPLIFY_TAC[])
+        (1--878) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+
+  (* Pick up the postcondition's input-bound antecedents
+     (val(x i) < 8380417 /\ val(y i) <= 1) as assumptions. *)
+  DISCH_THEN(CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  (* Split bytes128 -> bytes32 for output memory. *)
+  REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
+    CONV_RULE (SIMD_SIMPLIFY_CONV []) o
+    CONV_RULE(READ_MEMORY_SPLIT_CONV 2) o
+    check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
+
+  (* Expand output cases, substitute. *)
+  CONV_TAC(TOP_DEPTH_CONV EXPAND_CASES_CONV) THEN
+  CONV_TAC(DEPTH_CONV NUM_MULT_CONV THENC DEPTH_CONV NUM_ADD_CONV) THEN
+  REWRITE_TAC[WORD_ADD_0] THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN ASM_REWRITE_TAC[] THEN
+
+  (* Push word_subword through SIMD ops to per-element form. *)
+  REWRITE_TAC[WORD_SUBWORD_AND; WORD_SUBWORD_OR] THEN
+  let WSN_TAC = REWRITE_TAC(map (fun n -> prove(
+    subst [mk_small_numeral n, `n:num`]
+      `!x:int128. word_subword(word_not x) (n,32):int32 = word_not(word_subword x (n,32))`,
+    GEN_TAC THEN MATCH_MP_TAC WORD_SUBWORD_NOT THEN
+    REWRITE_TAC[DIMINDEX_32; DIMINDEX_128] THEN ARITH_TAC)) [0;32;64;96]) in
+  WSN_TAC THEN
+  CONV_TAC(DEPTH_CONV WORD_SIMPLE_SUBWORD_CONV) THEN
+  CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN
+
+  (* Build the per-element FIPS-eq lemma EC_FINAL by composing
+     ELEMENT_CORRECT_WORD with the asm definition unfold. *)
+  let EC_DEEP =
+    CONV_RULE(DEPTH_CONV WORD_NUM_RED_CONV)
+     (CONV_RULE(DEPTH_CONV(INT_RED_CONV ORELSEC NUM_RED_CONV))
+       (CONV_RULE(TOP_DEPTH_CONV let_CONV)
+         (REWRITE_RULE[mldsa_use_hint_32_asm; word_2smulh; word_ishr_round;
+                        DIMINDEX_32] ELEMENT_CORRECT_WORD))) in
+  let EC_FINAL = ONCE_REWRITE_RULE[WORD_AND_SYM]
+    (ONCE_REWRITE_RULE[WORD_OR_SYM] EC_DEEP) in
+
+  (* Pre-rewrite mldsa_use_hint_32 -> _code via the equivalence at all
+     occurrences. Then split into per-element leaves: FIPS-eq via EC_FINAL,
+     val<16 via direct MOD reduction on mldsa_use_hint_32_code. Index-bound
+     side conditions left over from IMP_REWRITE_TAC close via ARITH. *)
+  REPEAT (IMP_REWRITE_TAC[MLDSA_USE_HINT_32_EQUIV]) THEN
+  REPEAT CONJ_TAC THEN
+  (FIRST [
+    MATCH_MP_TAC EC_FINAL THEN CONJ_TAC THEN
+      FIRST_X_ASSUM MATCH_MP_TAC THEN ARITH_TAC;
+    REWRITE_TAC[VAL_WORD; DIMINDEX_32] THEN
+      CONV_TAC NUM_REDUCE_CONV THEN
+      MATCH_MP_TAC(ARITH_RULE `x < 16 ==> x MOD 4294967296 < 16`) THEN
+      REWRITE_TAC[mldsa_use_hint_32_code] THEN
+      CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
+      REPEAT(COND_CASES_TAC THEN ASM_REWRITE_TAC[]) THEN
+      REWRITE_TAC[MOD_LT_EQ; ARITH_EQ];
+    ARITH_TAC]));;
+
+
+(* ========================================================================= *)
+(* Public subroutine correctness (FIPS 204-aligned)                          *)
+(* ========================================================================= *)
+
+(* Subroutine form: derives directly from POLY_USE_HINT_32_AARCH64_ASM_CORRECT
+   by adding the X30 -> RET return wiring via ARM_ADD_RETURN_NOSTACK_TAC. The
+   bound antecedents inside the postcondition pass through unchanged
+   (decompose pattern). *)
 let POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT = prove
  (`!a h x y pc returnaddress.
     nonoverlapping (word pc, LENGTH poly_use_hint_32_aarch64_asm_mc) (a, 1024) /\
-    nonoverlapping (a, 1024) (h, 1024) /\
-    (!i. i < 256 ==> val((x:num->int32) i) < 8380417) /\
-    (!i. i < 256 ==> val((y:num->int32) i) <= 1)
+    nonoverlapping (a, 1024) (h, 1024)
     ==> ensures arm
           (\s. aligned_bytes_loaded s (word pc) poly_use_hint_32_aarch64_asm_mc /\
                read PC s = word pc /\
                read X30 s = returnaddress /\
                C_ARGUMENTS [a; h] s /\
-               (!i. i < 256 ==> val(x i) < 8380417) /\
-               (!i. i < 256 ==> val(y i) <= 1) /\
                (!i. i < 256 ==>
                  read(memory :> bytes32(word_add a (word(4 * i)))) s = x i) /\
                (!i. i < 256 ==>
                  read(memory :> bytes32(word_add h (word(4 * i)))) s = y i))
           (\s. read PC s = returnaddress /\
-               (!i. i < 256 ==>
-                 read(memory :> bytes32(word_add a (word(4 * i)))) s =
-                   word(mldsa_use_hint_32 (val(y i)) (val(x i)))) /\
-               (!i. i < 256 ==>
-                 val(read(memory :> bytes32(word_add a (word(4 * i)))) s) < 16))
+               ((!i. i < 256 ==> val(x i:int32) < 8380417) /\
+                (!i. i < 256 ==> val(y i:int32) <= 1)
+                ==> (!i. i < 256 ==>
+                      read(memory :> bytes32(word_add a (word(4 * i)))) s =
+                        word(mldsa_use_hint_32 (val(y i)) (val(x i)))) /\
+                    (!i. i < 256 ==>
+                      val(read(memory :> bytes32
+                        (word_add a (word(4 * i)))) s) < 16)))
           (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
            MAYCHANGE [memory :> bytes(a, 1024)])`,
-  REPEAT GEN_TAC THEN
-  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
-  SUBGOAL_THEN
-    `!i. i < 256 ==>
-         mldsa_use_hint_32 (val((y:num->int32) i)) (val((x:num->int32) i)) =
-         mldsa_use_hint_32_code (val(x i)) (val(y i))`
-    (fun th -> SIMP_TAC[th]) THENL
-  [REPEAT STRIP_TAC THEN MATCH_MP_TAC MLDSA_USE_HINT_32_EQUIV THEN
-   CONJ_TAC THEN FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_REWRITE_TAC[];
-   MATCH_MP_TAC POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT_CODE THEN
-   ASM_REWRITE_TAC[]]);;
+  REWRITE_TAC[fst POLY_USE_HINT_32_AARCH64_ASM_EXEC] THEN
+  CONV_TAC NUM_REDUCE_CONV THEN
+  ARM_ADD_RETURN_NOSTACK_TAC POLY_USE_HINT_32_AARCH64_ASM_EXEC
+    (CONV_RULE(ONCE_DEPTH_CONV NUM_REDUCE_CONV)
+      (REWRITE_RULE[fst POLY_USE_HINT_32_AARCH64_ASM_EXEC]
+         POLY_USE_HINT_32_AARCH64_ASM_CORRECT)));;
 
 
 (* ========================================================================= *)
@@ -917,7 +868,7 @@ needs "mldsa_native/aarch64/proofs/subroutine_signatures.ml";;
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false
     (assoc "poly_use_hint_32_aarch64_asm" subroutine_signatures)
-    POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT_CODE
+    POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_CORRECT
     POLY_USE_HINT_32_AARCH64_ASM_EXEC;;
 
 let POLY_USE_HINT_32_AARCH64_ASM_SUBROUTINE_SAFE = time prove


### PR DESCRIPTION
## Summary

Consolidates the `poly_use_hint_32` AArch64 HOL-Light proofs to use the same `_CORRECT` / `_SUBROUTINE_CORRECT` shape as every other proof in the codebase, addressing #1085.

The `_CORRECT_CODE` / `_CORRECT_BOUND_CODE` / `_SUBROUTINE_CORRECT_CODE` intermediates are removed; the public `_CORRECT` is now stated directly in FIPS 204 terms (`mldsa_use_hint_32`) with the `< 16` bound as a corollary, following the pattern outlined in https://github.com/pq-code-package/mldsa-native/pull/1037#issuecomment-4363057304:

- The FIPS 204 / code-aligned equivalence section (`MLDSA_USE_HINT_32_EQUIV`) moves above the correctness proof.
- `_CORRECT` uses `ENSURES_STRENGTHEN_POST` to bridge the FIPS-aligned postcondition to the code-aligned form before symbolic execution; the strengthening branch closes via `IMP_REWRITE_TAC[MLDSA_USE_HINT_32_EQUIV]` and a short bound discharge.
- `_SUBROUTINE_CORRECT` derives directly from `_CORRECT` via `ARM_ADD_RETURN_NOSTACK_TAC`.

The `_88` variant will follow in a separate PR.

Validated end-to-end against the equivalent file in s2n-bignum (`arm/proofs/mldsa_poly_use_hint_32.ml`), where the same refactor proves in 25:10 wall time.

Closes part of #1085. If we are happy with `_32` I can make the same changes to `_88`
