### PR TITLE
CI: Split mingw-w64 tests into per-PR and daily sets 

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -192,8 +192,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: re-enable 5.4.0 or other old version
-        mingw-version: [11.2.0, 12.2.0, 13.2.0, 14.2.0, 15.2.0]
+        # Oldest available + 3 latest; intermediate versions run in legacy-compilers.
+        mingw-version: [5.4.0, 13.2.0, 14.2.0, 15.2.0]
     name: Quickcheck (Mingw-w64 ${{ matrix.mingw-version }})
     runs-on: windows-latest
     steps:

--- a/.github/workflows/legacy-compilers.yml
+++ b/.github/workflows/legacy-compilers.yml
@@ -476,6 +476,41 @@ jobs:
           nix-shell: ${{ matrix.compiler.shell }}
           cflags: "-std=c23 ${{ matrix.cflags }}"
 
+  compiler_tests_windows_mingw:
+    name: Compiler tests (Mingw-w64 ${{ matrix.mingw-version }}, x86_64)
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'legacy-compiler-tests'))
+    strategy:
+      fail-fast: false
+      matrix:
+        mingw-version:
+         - "5.4.0"
+         - "6.4.0"
+         - "7.5.0"
+         - "8.5.0"
+         - "9.4.0"
+         - "10.3.0"
+         - "11.2.0"
+         - "12.2.0"
+         - "13.2.0"
+         - "14.2.0"
+         - "15.2.0"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install MinGW-w64
+        run: choco install mingw --version=${{ matrix.mingw-version }} -y
+        shell: cmd
+      - name: make quickcheck
+        shell: bash
+        run: |
+          CC=gcc OPT=0 make quickcheck
+          CC=gcc make clean >/dev/null
+          CC=gcc OPT=1 make quickcheck
+
   check-ct-varlat-legacy:
     name: Constant-time test ${{ matrix.compiler.family }}-${{ matrix.compiler.version }} ${{ matrix.system }}
     if: >-


### PR DESCRIPTION
Previously every PR tested a fixed set of mingw-w64 versions.                   
                                                                                
Mirror the gcc/clang/zig setup: base.yml now tests only the oldest working      
version (5.4.0) plus the three most recent majors (13.2.0, 14.2.0, 15.2.0)      
on every PR, while legacy-compilers.yml tests each major version (5.4.0         
through 15.2.0) daily.                                                          
                                                                                
- Resolves #650.