### PR TITLE
CI: Move RISC-V runner jobs out of base into a dedicated workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,3 +10,5 @@ self-hosted-runner:
     # PQCP runners
     - pqcp-arm64
     - pqcp-x64
+    # RISE RISC-V runner
+    - ubuntu-24.04-riscv

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -34,6 +34,13 @@ jobs:
       id-token: 'write'
     uses: ./.github/workflows/nix.yml
     secrets: inherit
+  riscv:
+    name: RISC-V
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/riscv.yml
   ci:
     name: Extended
     permissions:

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -35,9 +35,6 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
-         # via https://riseproject-dev.github.io/riscv-runner/
-         - runner: ubuntu-24.04-riscv
-           name: 'riscv'
          - runner: macos-latest
            name: 'macos (aarch64)'
          - runner: macos-15-intel
@@ -72,9 +69,6 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
-         # via https://riseproject-dev.github.io/riscv-runner/
-         - runner: ubuntu-24.04-riscv
-           name: 'riscv'
         acvp-version: [v1.1.0.40, v1.1.0.41, v1.1.0.42]
         exclude:
           - {external: true,

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -1,0 +1,39 @@
+# Copyright (c) The mlkem-native project authors
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: RISC-V
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+jobs:
+  quickcheck:
+    name: Quickcheck (riscv)
+    # via https://riseproject-dev.github.io/riscv-runner/
+    runs-on: ubuntu-24.04-riscv
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: make quickcheck
+        run: |
+          OPT=0 make quickcheck
+          make clean >/dev/null
+          OPT=1 make quickcheck
+      - uses: ./.github/actions/setup-os
+      - name: tests func
+        run: |
+          ./scripts/tests func --check-namespace
+  quickcheck-acvp:
+    name: Quickcheck ACVP (riscv, ${{ matrix.acvp-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        acvp-version: [v1.1.0.40, v1.1.0.41, v1.1.0.42]
+    # via https://riseproject-dev.github.io/riscv-runner/
+    runs-on: ubuntu-24.04-riscv
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run ACVP test
+        run: |
+          ./scripts/tests acvp --version ${{ matrix.acvp-version }}


### PR DESCRIPTION
 - Ported from https://github.com/pq-code-package/mlkem-native/pull/1708