### PR TITLE
dev: Document ABI and callee-saved register handling at function entry

### DIFF
--- a/dev/aarch64_clean/src/intt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/intt_aarch64_asm.S
@@ -228,6 +228,18 @@
         .global MLD_ASM_NAMESPACE(intt_aarch64_asm)
         .balign 4
 MLD_ASM_FN_SYMBOL(intt_aarch64_asm)
+        // ABI: AArch64 AAPCS. Callee-saved vector registers v8-v15 are
+        // used; their lower 64 bits (d8-d15) are saved/restored on the
+        // stack via push_stack/pop_stack. No callee-saved GPRs are
+        // touched.
+        //
+        // Function signature:
+        //   void mld_intt_aarch64_asm(int32_t *in,
+        //                             const int32_t *r78,
+        //                             const int32_t *r123456)
+        //   x0: pointer to in/out polynomial
+        //   x1: pointer to layer 7-8 twiddles
+        //   x2: pointer to layer 1-6 twiddles
         push_stack
 
         // Load MLDSA_Q = 8380417

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -91,6 +91,15 @@
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(
+    //       int32_t *c, const int32_t *a, const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial vector a (4 polynomials)
+    //   x2: pointer to input polynomial vector b (4 polynomials)
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -91,6 +91,15 @@
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(
+    //       int32_t *c, const int32_t *a, const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial vector a (5 polynomials)
+    //   x2: pointer to input polynomial vector b (5 polynomials)
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -91,6 +91,15 @@
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(
+    //       int32_t *c, const int32_t *a, const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial vector a (7 polynomials)
+    //   x2: pointer to input polynomial vector b (7 polynomials)
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_clean/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/ntt_aarch64_asm.S
@@ -197,6 +197,18 @@
         .global MLD_ASM_NAMESPACE(ntt_aarch64_asm)
         .balign 4
 MLD_ASM_FN_SYMBOL(ntt_aarch64_asm)
+        // ABI: AArch64 AAPCS. Callee-saved vector registers v8-v15 are
+        // used; their lower 64 bits (d8-d15) are saved/restored on the
+        // stack via push_stack/pop_stack. No callee-saved GPRs are
+        // touched.
+        //
+        // Function signature:
+        //   void mld_ntt_aarch64_asm(int32_t *in,
+        //                            const int32_t *r012345,
+        //                            const int32_t *r67)
+        //   x0: pointer to in/out polynomial
+        //   x1: pointer to layer 0-5 twiddles
+        //   x2: pointer to layer 6-7 twiddles
         push_stack
 
         // Load MLDSA_Q = 8380417

--- a/dev/aarch64_clean/src/pointwise_montgomery_aarch64_asm.S
+++ b/dev/aarch64_clean/src/pointwise_montgomery_aarch64_asm.S
@@ -74,6 +74,16 @@
 .global MLD_ASM_NAMESPACE(poly_pointwise_montgomery_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_pointwise_montgomery_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *c,
+    //                                                  const int32_t *a,
+    //                                                  const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial a
+    //   x2: pointer to input polynomial b
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_clean/src/poly_caddq_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_caddq_aarch64_asm.S
@@ -15,8 +15,11 @@
 .global MLD_ASM_NAMESPACE(poly_caddq_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_caddq_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
         // Function signature: void mld_poly_caddq_aarch64_asm(int32_t *a)
-        // x0: pointer to polynomial coefficients
+        //   x0: pointer to polynomial coefficients
 
         // Register assignments
         a_ptr           .req x0

--- a/dev/aarch64_clean/src/poly_chknorm_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_chknorm_aarch64_asm.S
@@ -27,6 +27,14 @@
 .global MLD_ASM_NAMESPACE(poly_chknorm_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_chknorm_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+        //   x0: pointer to input polynomial a
+        //   w1: norm bound B
+        //   w0: return value (1 if any |a[i]| >= B, else 0)
         // Load constants
         dup bound.4s, B
 

--- a/dev/aarch64_clean/src/poly_decompose_32_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_32_aarch64_asm.S
@@ -85,6 +85,13 @@
 .global MLD_ASM_NAMESPACE(poly_decompose_32_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_decompose_32_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+        //   x0: pointer to output polynomial a1
+        //   x1: pointer to input/output polynomial a0
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_clean/src/poly_decompose_88_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_88_aarch64_asm.S
@@ -84,6 +84,13 @@
 .global MLD_ASM_NAMESPACE(poly_decompose_88_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_decompose_88_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+        //   x0: pointer to output polynomial a1
+        //   x1: pointer to input/output polynomial a0
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_clean/src/poly_use_hint_32_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_use_hint_32_aarch64_asm.S
@@ -62,6 +62,13 @@
 .global MLD_ASM_NAMESPACE(poly_use_hint_32_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_use_hint_32_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+        //   x0: pointer to input/output polynomial a
+        //   x1: pointer to input hints h
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_clean/src/poly_use_hint_88_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_use_hint_88_aarch64_asm.S
@@ -64,6 +64,13 @@
 .global MLD_ASM_NAMESPACE(poly_use_hint_88_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_use_hint_88_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+        //   x0: pointer to input/output polynomial a
+        //   x1: pointer to input hints h
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_clean/src/polyz_unpack_17_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_17_aarch64_asm.S
@@ -45,6 +45,16 @@
 .global MLD_ASM_NAMESPACE(polyz_unpack_17_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyz_unpack_17_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_polyz_unpack_17_aarch64_asm(int32_t *r,
+        //                                        const uint8_t *buf,
+        //                                        const void *indices)
+        //   x0: pointer to output polynomial r
+        //   x1: pointer to input byte buffer buf
+        //   x2: pointer to TBL index table
         // Load indices
         ldr q24, [indices]
         ldr q25, [indices, #1*16]

--- a/dev/aarch64_clean/src/polyz_unpack_19_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_19_aarch64_asm.S
@@ -45,6 +45,16 @@
 .global MLD_ASM_NAMESPACE(polyz_unpack_19_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyz_unpack_19_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_polyz_unpack_19_aarch64_asm(int32_t *r,
+        //                                        const uint8_t *buf,
+        //                                        const void *indices)
+        //   x0: pointer to output polynomial r
+        //   x1: pointer to input byte buffer buf
+        //   x2: pointer to TBL index table
         // Load indices
         ldr q24, [indices]
         ldr q25, [indices, #1*16]

--- a/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
@@ -102,6 +102,20 @@
     .global MLD_ASM_NAMESPACE(rej_uniform_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(rej_uniform_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered. push_stack/pop_stack only allocate a scratch
+    // output buffer on the stack, not save/restore registers.
+    //
+    // Function signature:
+    //   unsigned mld_rej_uniform_aarch64_asm(int32_t *r,
+    //                                        const uint8_t *buf,
+    //                                        unsigned buflen,
+    //                                        const void *table)
+    //   x0: pointer to output polynomial r
+    //   x1: pointer to input byte buffer buf
+    //   x2: number of bytes available in buf
+    //   x3: pointer to TBL index table
+    //   x0: return value (number of coefficients sampled)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8

--- a/dev/aarch64_clean/src/rej_uniform_eta2_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_eta2_aarch64_asm.S
@@ -102,6 +102,20 @@
     .global MLD_ASM_NAMESPACE(rej_uniform_eta2_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(rej_uniform_eta2_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered. push_stack/pop_stack only allocate a scratch
+    // output buffer on the stack, not save/restore registers.
+    //
+    // Function signature:
+    //   unsigned mld_rej_uniform_eta2_aarch64_asm(int32_t *r,
+    //                                             const uint8_t *buf,
+    //                                             unsigned buflen,
+    //                                             const void *table)
+    //   x0: pointer to output polynomial r
+    //   x1: pointer to input byte buffer buf
+    //   x2: number of bytes available in buf
+    //   x3: pointer to TBL index table
+    //   x0: return value (number of coefficients sampled)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80

--- a/dev/aarch64_clean/src/rej_uniform_eta4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_eta4_aarch64_asm.S
@@ -98,6 +98,20 @@
     .global MLD_ASM_NAMESPACE(rej_uniform_eta4_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(rej_uniform_eta4_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered. push_stack/pop_stack only allocate a scratch
+    // output buffer on the stack, not save/restore registers.
+    //
+    // Function signature:
+    //   unsigned mld_rej_uniform_eta4_aarch64_asm(int32_t *r,
+    //                                             const uint8_t *buf,
+    //                                             unsigned buflen,
+    //                                             const void *table)
+    //   x0: pointer to output polynomial r
+    //   x1: pointer to input byte buffer buf
+    //   x2: number of bytes available in buf
+    //   x3: pointer to TBL index table
+    //   x0: return value (number of coefficients sampled)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80

--- a/dev/aarch64_opt/src/intt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/intt_aarch64_asm.S
@@ -222,6 +222,18 @@
         .global MLD_ASM_NAMESPACE(intt_aarch64_asm)
         .balign 4
 MLD_ASM_FN_SYMBOL(intt_aarch64_asm)
+        // ABI: AArch64 AAPCS. Callee-saved vector registers v8-v15 are
+        // used; their lower 64 bits (d8-d15) are saved/restored on the
+        // stack via push_stack/pop_stack. No callee-saved GPRs are
+        // touched.
+        //
+        // Function signature:
+        //   void mld_intt_aarch64_asm(int32_t *in,
+        //                             const int32_t *r78,
+        //                             const int32_t *r123456)
+        //   x0: pointer to in/out polynomial
+        //   x1: pointer to layer 7-8 twiddles
+        //   x2: pointer to layer 1-6 twiddles
         push_stack
 
         // Load MLDSA_Q = 8380417

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -91,6 +91,15 @@
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(
+    //       int32_t *c, const int32_t *a, const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial vector a (4 polynomials)
+    //   x2: pointer to input polynomial vector b (4 polynomials)
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -91,6 +91,15 @@
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(
+    //       int32_t *c, const int32_t *a, const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial vector a (5 polynomials)
+    //   x2: pointer to input polynomial vector b (5 polynomials)
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -91,6 +91,15 @@
 .global MLD_ASM_NAMESPACE(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(
+    //       int32_t *c, const int32_t *a, const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial vector a (7 polynomials)
+    //   x2: pointer to input polynomial vector b (7 polynomials)
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_opt/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/ntt_aarch64_asm.S
@@ -191,6 +191,18 @@
         .global MLD_ASM_NAMESPACE(ntt_aarch64_asm)
         .balign 4
 MLD_ASM_FN_SYMBOL(ntt_aarch64_asm)
+        // ABI: AArch64 AAPCS. Callee-saved vector registers v8-v15 are
+        // used; their lower 64 bits (d8-d15) are saved/restored on the
+        // stack via push_stack/pop_stack. No callee-saved GPRs are
+        // touched.
+        //
+        // Function signature:
+        //   void mld_ntt_aarch64_asm(int32_t *in,
+        //                            const int32_t *r012345,
+        //                            const int32_t *r67)
+        //   x0: pointer to in/out polynomial
+        //   x1: pointer to layer 0-5 twiddles
+        //   x2: pointer to layer 6-7 twiddles
         push_stack
 
         // Load MLDSA_Q = 8380417

--- a/dev/aarch64_opt/src/pointwise_montgomery_aarch64_asm.S
+++ b/dev/aarch64_opt/src/pointwise_montgomery_aarch64_asm.S
@@ -74,6 +74,16 @@
 .global MLD_ASM_NAMESPACE(poly_pointwise_montgomery_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_pointwise_montgomery_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered, so none are saved/restored.
+    //
+    // Function signature:
+    //   void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *c,
+    //                                                  const int32_t *a,
+    //                                                  const int32_t *b)
+    //   x0: pointer to output polynomial c
+    //   x1: pointer to input polynomial a
+    //   x2: pointer to input polynomial b
     // Load MLDSA_Q = 8380417
     movz wtmp, #0xe001
     movk wtmp, #0x7f, lsl #16

--- a/dev/aarch64_opt/src/poly_caddq_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_caddq_aarch64_asm.S
@@ -15,8 +15,11 @@
 .global MLD_ASM_NAMESPACE(poly_caddq_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_caddq_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
         // Function signature: void mld_poly_caddq_aarch64_asm(int32_t *a)
-        // x0: pointer to polynomial coefficients
+        //   x0: pointer to polynomial coefficients
 
         // Register assignments
         a_ptr           .req x0

--- a/dev/aarch64_opt/src/poly_chknorm_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_chknorm_aarch64_asm.S
@@ -27,6 +27,14 @@
 .global MLD_ASM_NAMESPACE(poly_chknorm_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_chknorm_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+        //   x0: pointer to input polynomial a
+        //   w1: norm bound B
+        //   w0: return value (1 if any |a[i]| >= B, else 0)
         // Load constants
         dup bound.4s, B
 

--- a/dev/aarch64_opt/src/poly_decompose_32_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_decompose_32_aarch64_asm.S
@@ -56,6 +56,13 @@
 .global MLD_ASM_NAMESPACE(poly_decompose_32_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_decompose_32_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+        //   x0: pointer to output polynomial a1
+        //   x1: pointer to input/output polynomial a0
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_opt/src/poly_decompose_88_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_decompose_88_aarch64_asm.S
@@ -55,6 +55,13 @@
 .global MLD_ASM_NAMESPACE(poly_decompose_88_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_decompose_88_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+        //   x0: pointer to output polynomial a1
+        //   x1: pointer to input/output polynomial a0
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_opt/src/poly_use_hint_32_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_use_hint_32_aarch64_asm.S
@@ -62,6 +62,13 @@
 .global MLD_ASM_NAMESPACE(poly_use_hint_32_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_use_hint_32_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+        //   x0: pointer to input/output polynomial a
+        //   x1: pointer to input hints h
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_opt/src/poly_use_hint_88_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_use_hint_88_aarch64_asm.S
@@ -64,6 +64,13 @@
 .global MLD_ASM_NAMESPACE(poly_use_hint_88_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(poly_use_hint_88_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+        //   x0: pointer to input/output polynomial a
+        //   x1: pointer to input hints h
         // Load constants into SIMD registers
         movz w4, #57345
         movk w4, #127, lsl #16

--- a/dev/aarch64_opt/src/polyz_unpack_17_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_17_aarch64_asm.S
@@ -45,6 +45,16 @@
 .global MLD_ASM_NAMESPACE(polyz_unpack_17_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyz_unpack_17_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_polyz_unpack_17_aarch64_asm(int32_t *r,
+        //                                        const uint8_t *buf,
+        //                                        const void *indices)
+        //   x0: pointer to output polynomial r
+        //   x1: pointer to input byte buffer buf
+        //   x2: pointer to TBL index table
         // Load indices
         ldr q24, [indices]
         ldr q25, [indices, #1*16]

--- a/dev/aarch64_opt/src/polyz_unpack_19_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_19_aarch64_asm.S
@@ -45,6 +45,16 @@
 .global MLD_ASM_NAMESPACE(polyz_unpack_19_aarch64_asm)
 .balign 4
 MLD_ASM_FN_SYMBOL(polyz_unpack_19_aarch64_asm)
+        // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+        // are clobbered, so none are saved/restored.
+        //
+        // Function signature:
+        //   void mld_polyz_unpack_19_aarch64_asm(int32_t *r,
+        //                                        const uint8_t *buf,
+        //                                        const void *indices)
+        //   x0: pointer to output polynomial r
+        //   x1: pointer to input byte buffer buf
+        //   x2: pointer to TBL index table
         // Load indices
         ldr q24, [indices]
         ldr q25, [indices, #1*16]

--- a/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
@@ -102,6 +102,20 @@
     .global MLD_ASM_NAMESPACE(rej_uniform_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(rej_uniform_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered. push_stack/pop_stack only allocate a scratch
+    // output buffer on the stack, not save/restore registers.
+    //
+    // Function signature:
+    //   unsigned mld_rej_uniform_aarch64_asm(int32_t *r,
+    //                                        const uint8_t *buf,
+    //                                        unsigned buflen,
+    //                                        const void *table)
+    //   x0: pointer to output polynomial r
+    //   x1: pointer to input byte buffer buf
+    //   x2: number of bytes available in buf
+    //   x3: pointer to TBL index table
+    //   x0: return value (number of coefficients sampled)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8

--- a/dev/aarch64_opt/src/rej_uniform_eta2_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_eta2_aarch64_asm.S
@@ -102,6 +102,20 @@
     .global MLD_ASM_NAMESPACE(rej_uniform_eta2_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(rej_uniform_eta2_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered. push_stack/pop_stack only allocate a scratch
+    // output buffer on the stack, not save/restore registers.
+    //
+    // Function signature:
+    //   unsigned mld_rej_uniform_eta2_aarch64_asm(int32_t *r,
+    //                                             const uint8_t *buf,
+    //                                             unsigned buflen,
+    //                                             const void *table)
+    //   x0: pointer to output polynomial r
+    //   x1: pointer to input byte buffer buf
+    //   x2: number of bytes available in buf
+    //   x3: pointer to TBL index table
+    //   x0: return value (number of coefficients sampled)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80

--- a/dev/aarch64_opt/src/rej_uniform_eta4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_eta4_aarch64_asm.S
@@ -98,6 +98,20 @@
     .global MLD_ASM_NAMESPACE(rej_uniform_eta4_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(rej_uniform_eta4_aarch64_asm)
+    // ABI: AArch64 AAPCS. No callee-saved registers (x19-x29, v8-v15)
+    // are clobbered. push_stack/pop_stack only allocate a scratch
+    // output buffer on the stack, not save/restore registers.
+    //
+    // Function signature:
+    //   unsigned mld_rej_uniform_eta4_aarch64_asm(int32_t *r,
+    //                                             const uint8_t *buf,
+    //                                             unsigned buflen,
+    //                                             const void *table)
+    //   x0: pointer to output polynomial r
+    //   x1: pointer to input byte buffer buf
+    //   x2: number of bytes available in buf
+    //   x3: pointer to TBL index table
+    //   x0: return value (number of coefficients sampled)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_scalar_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_scalar_aarch64_asm.S
@@ -171,6 +171,16 @@
     .global MLD_ASM_NAMESPACE(keccak_f1600_x1_scalar_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(keccak_f1600_x1_scalar_aarch64_asm)
+    // ABI: AArch64 AAPCS. Callee-saved GPRs x19-x28 plus the frame
+    // pointer x29 and link register x30 are saved/restored on the
+    // stack via save_gprs/restore_gprs. No callee-saved vector
+    // registers (v8-v15) are touched.
+    //
+    // Function signature:
+    //   void mld_keccak_f1600_x1_scalar_aarch64_asm(uint64_t state[25],
+    //                                               const uint64_t rc[24])
+    //   x0: pointer to Keccak state (25 x uint64_t, in/out)
+    //   x1: pointer to round constants (24 x uint64_t)
     alloc_stack
     save_gprs
 

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -346,6 +346,16 @@
     .global MLD_ASM_NAMESPACE(keccak_f1600_x1_v84a_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_aarch64_asm)
+    // ABI: AArch64 AAPCS. Callee-saved vector registers v8-v15 are
+    // used; their lower 64 bits (d8-d15) are saved/restored on the
+    // stack via save_vregs/restore_vregs. No callee-saved GPRs are
+    // touched.
+    //
+    // Function signature:
+    //   void mld_keccak_f1600_x1_v84a_aarch64_asm(uint64_t state[25],
+    //                                             const uint64_t rc[24])
+    //   x0: pointer to Keccak state (25 x uint64_t, in/out)
+    //   x1: pointer to round constants (24 x uint64_t)
     alloc_stack
     save_vregs
     load_input

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -330,6 +330,16 @@
     .balign 4
 
 MLD_ASM_FN_SYMBOL(keccak_f1600_x2_v84a_aarch64_asm)
+    // ABI: AArch64 AAPCS. Callee-saved vector registers v8-v15 are
+    // used; their lower 64 bits (d8-d15) are saved/restored on the
+    // stack via save_vregs/restore_vregs. No callee-saved GPRs are
+    // touched.
+    //
+    // Function signature:
+    //   void mld_keccak_f1600_x2_v84a_aarch64_asm(uint64_t state[50],
+    //                                             const uint64_t rc[24])
+    //   x0: pointer to two sequential Keccak states (50 x uint64_t, in/out)
+    //   x1: pointer to round constants (24 x uint64_t)
     alloc_stack
     save_vregs
     load_input

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -850,6 +850,17 @@
     .global MLD_ASM_NAMESPACE(keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm)
+    // ABI: AArch64 AAPCS. Callee-saved GPRs x19-x28 plus the frame
+    // pointer x29 and link register x30 are saved/restored via
+    // save_gprs/restore_gprs. Callee-saved vector registers v8-v15
+    // are used; their lower 64 bits (d8-d15) are saved/restored via
+    // save_vregs/restore_vregs.
+    //
+    // Function signature:
+    //   void mld_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(
+    //       uint64_t state[100], const uint64_t rc[24])
+    //   x0: pointer to four sequential Keccak states (100 x uint64_t, in/out)
+    //   x1: pointer to round constants (24 x uint64_t)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -868,6 +868,17 @@
     .global MLD_ASM_NAMESPACE(keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm)
     .balign 4
 MLD_ASM_FN_SYMBOL(keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm)
+    // ABI: AArch64 AAPCS. Callee-saved GPRs x19-x28 plus the frame
+    // pointer x29 and link register x30 are saved/restored via
+    // save_gprs/restore_gprs. Callee-saved vector registers v8-v15
+    // are used; their lower 64 bits (d8-d15) are saved/restored via
+    // save_vregs/restore_vregs.
+    //
+    // Function signature:
+    //   void mld_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm(
+    //       uint64_t state[100], const uint64_t rc[24])
+    //   x0: pointer to four sequential Keccak states (100 x uint64_t, in/out)
+    //   x1: pointer to round constants (24 x uint64_t)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/fips202/x86_64/src/keccak_f1600_x4_avx2_asm.S
+++ b/dev/fips202/x86_64/src/keccak_f1600_x4_avx2_asm.S
@@ -13,6 +13,17 @@
 .balign 4
 .global MLD_ASM_NAMESPACE(keccak_f1600_x4_avx2_asm)
 MLD_ASM_FN_SYMBOL(keccak_f1600_x4_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. The caller-saved r11
+// is used to stash the entry rsp before the stack is realigned to
+// 32 bytes, and is restored before ret. All XMM/YMM registers are
+// caller-saved.
+//
+// Function signature:
+//   void mld_keccak_f1600_x4_avx2_asm(uint64_t state[100],
+//                                     const uint64_t rc[24])
+//   rdi: pointer to four sequential Keccak states (100 x uint64_t, in/out)
+//   rsi: pointer to round constants (24 x uint64_t)
 
    // **** Bitstates Allocation Map **** //
    // 0x0(%rsp)     A0    (state0[0), state1[0], state2[0], state3[0]]     Input (%rdi) offsets: 0x00, 0xC8, 0x190, 0x258

--- a/dev/x86_64/src/intt_avx2_asm.S
+++ b/dev/x86_64/src/intt_avx2_asm.S
@@ -369,6 +369,14 @@ vmovdqa         %ymm7,384+32*\off(%rdi)
 .balign 4
 .global MLD_ASM_NAMESPACE(invntt_avx2_asm)
 MLD_ASM_FN_SYMBOL(invntt_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_invntt_avx2_asm(int32_t *a, const __m256i *qdata)
+//   rdi: pointer to input/output polynomial a
+//   rsi: pointer to qdata constants
 
 vmovdqa MLD_AVX2_BACKEND_DATA_OFFSET_8XQ*4(%rsi),%ymm0
 

--- a/dev/x86_64/src/ntt_avx2_asm.S
+++ b/dev/x86_64/src/ntt_avx2_asm.S
@@ -292,6 +292,15 @@ vmovdqa  %ymm11,256*\off+224(%rdi)
 .balign 4
 .global MLD_ASM_NAMESPACE(ntt_avx2_asm)
 MLD_ASM_FN_SYMBOL(ntt_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_ntt_avx2_asm(int32_t *a, const __m256i *qdata)
+//   rdi: pointer to input/output polynomial a
+//   rsi: pointer to qdata constants
+
 vmovdqa  MLD_AVX2_BACKEND_DATA_OFFSET_8XQ*4(%rsi),%ymm0
 
 levels0t1 0

--- a/dev/x86_64/src/nttunpack_avx2_asm.S
+++ b/dev/x86_64/src/nttunpack_avx2_asm.S
@@ -84,6 +84,13 @@ vmovdqa  %ymm11, (\offset + 224)(%rdi)
 .balign 4
 .global MLD_ASM_NAMESPACE(nttunpack_avx2_asm)
 MLD_ASM_FN_SYMBOL(nttunpack_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_nttunpack_avx2_asm(int32_t *a)
+//   rdi: pointer to input/output polynomial a
 
 nttunpack_64_coefficients 0
 nttunpack_64_coefficients 4*64

--- a/dev/x86_64/src/pointwise_acc_l4_avx2_asm.S
+++ b/dev/x86_64/src/pointwise_acc_l4_avx2_asm.S
@@ -75,6 +75,18 @@
         .balign 4
         .global MLD_ASM_NAMESPACE(pointwise_acc_l4_avx2_asm)
 MLD_ASM_FN_SYMBOL(pointwise_acc_l4_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_pointwise_acc_l4_avx2_asm(__m256i *c, const __m256i *a,
+//                                      const __m256i *b,
+//                                      const __m256i *qdata)
+//   rdi: pointer to output polynomial c
+//   rsi: pointer to input polynomial vector a (4 polynomials)
+//   rdx: pointer to input polynomial vector b (4 polynomials)
+//   rcx: pointer to qdata constants
 
 // Load constants
         vmovdqa ymm0, [rcx + (MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV)*4]

--- a/dev/x86_64/src/pointwise_acc_l5_avx2_asm.S
+++ b/dev/x86_64/src/pointwise_acc_l5_avx2_asm.S
@@ -75,6 +75,18 @@
         .balign 4
         .global MLD_ASM_NAMESPACE(pointwise_acc_l5_avx2_asm)
 MLD_ASM_FN_SYMBOL(pointwise_acc_l5_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_pointwise_acc_l5_avx2_asm(__m256i *c, const __m256i *a,
+//                                      const __m256i *b,
+//                                      const __m256i *qdata)
+//   rdi: pointer to output polynomial c
+//   rsi: pointer to input polynomial vector a (5 polynomials)
+//   rdx: pointer to input polynomial vector b (5 polynomials)
+//   rcx: pointer to qdata constants
 
 // Load constants
         vmovdqa ymm0, [rcx + (MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV)*4]

--- a/dev/x86_64/src/pointwise_acc_l7_avx2_asm.S
+++ b/dev/x86_64/src/pointwise_acc_l7_avx2_asm.S
@@ -75,6 +75,18 @@
         .balign 4
         .global MLD_ASM_NAMESPACE(pointwise_acc_l7_avx2_asm)
 MLD_ASM_FN_SYMBOL(pointwise_acc_l7_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_pointwise_acc_l7_avx2_asm(__m256i *c, const __m256i *a,
+//                                      const __m256i *b,
+//                                      const __m256i *qdata)
+//   rdi: pointer to output polynomial c
+//   rsi: pointer to input polynomial vector a (7 polynomials)
+//   rdx: pointer to input polynomial vector b (7 polynomials)
+//   rcx: pointer to qdata constants
 
 // Load constants
         vmovdqa ymm0, [rcx + (MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV)*4]

--- a/dev/x86_64/src/pointwise_avx2_asm.S
+++ b/dev/x86_64/src/pointwise_avx2_asm.S
@@ -41,6 +41,16 @@
         .balign 4
         .global MLD_ASM_NAMESPACE(pointwise_avx2_asm)
 MLD_ASM_FN_SYMBOL(pointwise_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_pointwise_avx2_asm(__m256i *a, const __m256i *b,
+//                               const __m256i *qdata)
+//   rdi: pointer to first input/output polynomial a
+//   rsi: pointer to second input polynomial b
+//   rdx: pointer to qdata constants
 
 // Load constants
         vmovdqa ymm0, [rdx + (MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV)*4]

--- a/dev/x86_64/src/poly_caddq_avx2_asm.S
+++ b/dev/x86_64/src/poly_caddq_avx2_asm.S
@@ -45,6 +45,13 @@ vmovdqa  \reg, \offset(%rdi)
 .global MLD_ASM_NAMESPACE(poly_caddq_avx2_asm)
 .balign 16
 MLD_ASM_FN_SYMBOL(poly_caddq_avx2_asm)
+// ABI: System V AMD64. No callee-saved registers (rbx, rbp, r12-r15)
+// are clobbered, so none are saved/restored. All XMM/YMM registers
+// are caller-saved.
+//
+// Function signature:
+//   void mld_poly_caddq_avx2_asm(int32_t *a)
+//   rdi: pointer to input/output polynomial coefficients
 
 vpxor %xmm2, %xmm2, %xmm2
 mov $8380417, %eax


### PR DESCRIPTION
Add a uniform comment block at the entry of every aarch64 and x86_64 assembly function under dev/, naming the calling convention (AAPCS or System V AMD64), listing which callee-saved registers (if any) are saved/restored, and giving the function signature with per-register argument descriptions.