### PR TITLE
Use z3_smt_only for proof of poly_ntt_c()

### DIFF
--- a/proofs/cbmc/poly_ntt_c/Makefile
+++ b/proofs/cbmc/poly_ntt_c/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_smt_only --z3
 
 FUNCTION_NAME = mld_poly_ntt_c
 


### PR DESCRIPTION
Fixes #1156 

This stabilizes proof time for all parameter sets, with and without MLD_CONFIG_REDUCE_RAM, and on all platforms.