### PR TITLE
Add clang-tidy to lint with pedantic config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# clang-tidy configuration for mldsa-native
+#
+# We enable whole C-relevant families and disable individual checks with
+# rationale provided inline below.
+Checks:
+  - bugprone-*
+  - cert-*
+  - clang-analyzer-*
+  - concurrency-*
+  - misc-*
+  - performance-*
+  - portability-*
+  - readability-*
+  # Spec/maths use 1-letter names (a, b, r, f, t, k).
+  - -readability-identifier-length
+  # Spec constants; already vetted by scripts/check-magic.
+  - -readability-magic-numbers
+  # Multi-var decls (e.g. `unsigned i, j;`) are deliberate; style only.
+  - -readability-isolate-declaration
+  # Repo uniformly uses lowercase suffixes (1u); this check wants uppercase (1U).
+  - -readability-uppercase-literal-suffix
+  # Repo uses `#if defined(X)` uniformly for composability.
+  - -readability-use-concise-preprocessor-directives
+  # Public symbols are namespaced by macro; the check can't see through it.
+  - -readability-identifier-naming
+  # Only index/bit-packing maths (r[11*j+0]); precedence is the intended reading.
+  - -readability-math-missing-parentheses
+  # Symmetric if/else branches mirror case distinctions in the maths and are
+  # deliberate, even where the first branch returns or breaks.
+  - -readability-else-after-return
+  # All spec/API-fixed signatures (adjacent same-/convertible-type args).
+  - -bugprone-easily-swappable-parameters
+  # All spec-bounded const/index offsets; no real overflow.
+  - -bugprone-implicit-widening-of-multiplication-result
+  # Relies on transitive includes via common.h and single-CU builds.
+  - -misc-include-cleaner
+
+# Report diagnostics in our own headers (under mldsa/src), but never in
+# system or third-party headers.
+HeaderFilterRegex: 'mldsa/src/.*'
+
+# Be strict where we run at all: every enabled check that fires is an error.
+# The CI job is blocking, so this keeps local runs honest with CI.
+WarningsAsErrors: '*'
+
+FormatStyle: file

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -8,7 +8,7 @@ description: Lint
 inputs:
   nix-shell:
     description: Run in the specified Nix environment if exists
-    default: "linter"
+    default: "ci"
   nix-cache:
     description: Determine whether to enable nix cache
     default: "false"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/lint
         with:
-          nix-shell: linter
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           cross-prefix: "aarch64-unknown-linux-gnu-"
   quickcheck:

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -173,7 +173,6 @@ jobs:
         if: ${{ inputs.lint }}
         uses: ./.github/actions/lint
         with:
-          nix-shell: linter
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
           nix-verbose: ${{ inputs.verbose }}
       - name: Functional Tests

--- a/flake.nix
+++ b/flake.nix
@@ -191,9 +191,6 @@
           # TODO: AVR shell not yet available for mldsa-native
           # devShells.cross-avr = util.mkShell (import ./nix/avr { inherit pkgs; });
 
-          devShells.linter = util.mkShellNoCC {
-            packages = builtins.attrValues { inherit (config.packages) linters; };
-          };
           devShells.clang19 = util.mkShellWithCC' pkgs.clang_19;
           devShells.clang20 = util.mkShellWithCC' pkgs.clang_20;
           devShells.clang21 = util.mkShellWithCC' pkgs.clang_21;

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -125,18 +125,18 @@
 /****************************** Error codes ***********************************/
 
 /* Generic failure condition */
-#define MLD_ERR_FAIL -1
+#define MLD_ERR_FAIL (-1)
 /* An allocation failed. This can only happen if MLD_CONFIG_CUSTOM_ALLOC_FREE
  * is defined and the provided MLD_CUSTOM_ALLOC can fail. */
-#define MLD_ERR_OUT_OF_MEMORY -2
+#define MLD_ERR_OUT_OF_MEMORY (-2)
 /* An rng failure occured. Might be due to insufficient entropy or
  * system misconfiguration. */
-#define MLD_ERR_RNG_FAIL -3
+#define MLD_ERR_RNG_FAIL (-3)
 /* The signing rejection-sampling loop exceeded
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS iterations without producing a valid
  * signature. With a FIPS 204 Appendix C compliant bound (>= 814) this
  * has probability < 2^-256. */
-#define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED -4
+#define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED (-4)
 
 /****************************** Function API **********************************/
 

--- a/mldsa/src/cbmc.h
+++ b/mldsa/src/cbmc.h
@@ -9,17 +9,28 @@
 /***************************************************
  * Basic replacements for __CPROVER_XXX contracts
  ***************************************************/
+/*
+ * The `__contract__` / `__loop__` annotation macros use a
+ * leading-double-underscore spelling in line with other CBMC macros.
+ * clang-tidy flags these as reserved identifiers; we suppress the diagnostic
+ * at each definition site (NOLINT) rather than disabling the check globally,
+ * so it stays active for the rest of the tree.
+ */
 #ifndef CBMC
 
-#define __contract__(x)
-#define __loop__(x)
+/* clang-format off */
+#define __contract__(x) /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+#define __loop__(x) /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+/* clang-format on */
 #define cassert(x)
 
 #else /* !CBMC */
 
 
-#define __contract__(x) x
-#define __loop__(x) x
+/* clang-format off */
+#define __contract__(x) x /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+#define __loop__(x) x /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+/* clang-format on */
 
 /* Conditionally expand to __VA_ARGS__ depending on MLD_CONFIG_REDUCE_RAM. */
 #if defined(MLD_CONFIG_REDUCE_RAM)

--- a/mldsa/src/common.h
+++ b/mldsa/src/common.h
@@ -262,14 +262,18 @@
 #if !defined(MLD_CONFIG_CUSTOM_ALLOC_FREE)
 /* Default: stack allocation */
 
+/* This is a declaration macro, not an expression macro: T is a type and v is
+ * a declarator, neither of which can be wrapped in parentheses. The
+ * bugprone-macro-parentheses diagnostic is therefore a false positive here. */
 #define MLD_ALLOC(v, T, N, context) \
   MLD_ALIGN T mld_alloc_##v[N];     \
-  T *v = mld_alloc_##v
+  T *v = mld_alloc_##v /* NOLINT(bugprone-macro-parentheses) */
 
-/* TODO: This leads to a circular dependency between common and ct.h
- * It just works out before we're at the end of the file, but it's still
- * prone to issues in the future. */
-#include "ct.h"
+/* The MLD_FREE macro body references mld_zeroize(), which is declared in
+ * ct.h. We deliberately do NOT include ct.h here: doing so would create a
+ * circular dependency (ct.h includes common.h), and common.h itself never
+ * calls mld_zeroize() -- only the macro expansion does. Each translation
+ * unit that uses MLD_FREE therefore includes ct.h directly. */
 #define MLD_FREE(v, T, N, context)                     \
   do                                                   \
   {                                                    \
@@ -305,18 +309,18 @@
 /****************************** Error codes ***********************************/
 
 /* Generic failure condition */
-#define MLD_ERR_FAIL -1
+#define MLD_ERR_FAIL (-1)
 /* An allocation failed. This can only happen if MLD_CONFIG_CUSTOM_ALLOC_FREE
  * is defined and the provided MLD_CUSTOM_ALLOC can fail. */
-#define MLD_ERR_OUT_OF_MEMORY -2
+#define MLD_ERR_OUT_OF_MEMORY (-2)
 /* An rng failure occured. Might be due to insufficient entropy or
  * system misconfiguration. */
-#define MLD_ERR_RNG_FAIL -3
+#define MLD_ERR_RNG_FAIL (-3)
 /* The signing rejection-sampling loop exceeded
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS iterations without producing a valid
  * signature. With a FIPS 204 Appendix C compliant bound (>= 814) this
  * has probability < 2^-256. */
-#define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED -4
+#define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED (-4)
 
 /* Disjunction over the full set of MLD_ERR_XXX failure codes.
  *

--- a/mldsa/src/fips202/keccakf1600.c
+++ b/mldsa/src/fips202/keccakf1600.c
@@ -33,7 +33,7 @@
 #if !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
 
 #define MLD_KECCAK_NROUNDS 24
-#define MLD_KECCAK_ROL(a, offset) ((a << offset) ^ (a >> (64 - offset)))
+#define MLD_KECCAK_ROL(a, offset) (((a) << (offset)) ^ ((a) >> (64 - (offset))))
 
 MLD_INTERNAL_API
 void mld_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,

--- a/mldsa/src/reduce.h
+++ b/mldsa/src/reduce.h
@@ -11,7 +11,7 @@
 #include "debug.h"
 
 /* check-magic: -4186625 == pow(2,32,MLDSA_Q) */
-#define MLD_MONT -4186625
+#define MLD_MONT (-4186625)
 
 /* Upper bound for domain of mld_reduce32() */
 #define MLD_REDUCE32_DOMAIN_MAX (INT32_MAX - (1 << 22))

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -636,6 +636,7 @@ __contract__(
  *           an allocation via MLD_CUSTOM_ALLOC returned NULL.
  */
 MLD_MUST_CHECK_RETURN_VALUE
+/* NOLINTNEXTLINE(readability-function-cognitive-complexity) */
 static int mld_attempt_signature_generation(
     uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *mu,
     const uint8_t rhoprime[MLDSA_CRHBYTES], uint16_t nonce, mld_polymat *mat,
@@ -1502,8 +1503,9 @@ static int mld_validate_hash_length(int hashalg, size_t len)
       return (len == 256 / 8) ? 0 : -1;
     case MLD_PREHASH_SHAKE_256:
       return (len == 512 / 8) ? 0 : -1;
+    default:
+      return -1;
   }
-  return -1;
 }
 
 size_t mld_prepare_domain_separation_prefix(

--- a/scripts/lint
+++ b/scripts/lint
@@ -195,6 +195,64 @@ lint-c-files()
 checkerr "Lint C" "$(lint-c-files)"
 gh_group_end
 
+lint-clang-tidy()
+{
+  if ! command -v clang-tidy >/dev/null; then
+    gh_error_simple "clang-tidy missing" "clang-tidy is not installed"
+    error "Lint clang-tidy"
+    SUCCESS=false
+    gh_summary_failure "Lint clang-tidy"
+    return 0
+  fi
+
+  # Files to analyse, by language. Add directories here to widen coverage;
+  # native backends are deliberately excluded (they need per-arch flags).
+  # Pathspecs use :(glob) so '*' does not cross '/' (top-level of each dir).
+  local c_files=(":(glob)mldsa/src/*.c" ":(glob)mldsa/src/fips202/*.c")
+  local h_files=(":(glob)mldsa/src/*.h" ":(glob)mldsa/src/fips202/*.h")
+
+  local nproc success=true
+  nproc=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+
+  # Run clang-tidy over a set of files. $1 is a label for diagnostics, $2 is a
+  # space-separated list of git pathspecs, and the rest are passed verbatim to
+  # clang-tidy's compiler invocation (after `--`). Note: not invoked via a pipe
+  # so that `success=false` propagates to the enclosing function.
+  run-clang-tidy()
+  {
+    local label="$1" pathspecs="$2" out
+    shift 2
+    if ! out=$(git ls-files -- $pathspecs |
+      xargs -P "$nproc" -I {} \
+        clang-tidy --quiet {} -- -I"$ROOT"/mldsa -std=c90 "$@" 2>&1); then
+      echo "$out"
+      gh_error_simple "clang-tidy error" "clang-tidy reported findings ($label)"
+      success=false
+    fi
+  }
+
+  for params in 44 65 87; do
+    # Headers are passed with `-x c` so clang-tidy treats them as C, not C++.
+    run-clang-tidy "ML-DSA-$params .c" "${c_files[*]}" \
+      -DMLD_CONFIG_PARAMETER_SET="$params"
+    run-clang-tidy "ML-DSA-$params .h" "${h_files[*]}" \
+      -x c -DMLD_CONFIG_PARAMETER_SET="$params"
+  done
+
+  if $success; then
+    info "Lint clang-tidy"
+    gh_summary_success "Lint clang-tidy"
+  else
+    error "Lint clang-tidy"
+    SUCCESS=false
+    gh_summary_failure "Lint clang-tidy"
+  fi
+}
+
+gh_group_start "Static analysis with clang-tidy"
+lint-clang-tidy
+gh_group_end
+
 check-eol-dry-run()
 {
   for file in $(git ls-files -- ":/" ":/!:*.png"); do


### PR DESCRIPTION
Run clang-tidy as part of scripts/lint. clang-tidy needs a C compiler to resolve system headers, so the lint CI job moves from the compiler-less 'linter' shell to 'ci' (linters + native toolchain); the now-unused 'linter' devShell is removed.

Pre-suppress style checks hostile to this codebase; fix or suppress the substantive findings, including breaking the common.h <-> ct.h include cycle.

Ports pq-code-package/mlkem-native#1737.