### PR TITLE
SLOTHY: Pin to 0.2.2 to speed up CI re-optimization

### DIFF
--- a/nix/slothy/default.nix
+++ b/nix/slothy/default.nix
@@ -9,14 +9,14 @@
 
 { pkgs }:
 
-pkgs.slothy
+# pkgs.slothy
 
-# pkgs.slothy.overrideAttrs (old: rec {
-#   version = "6d35cc147a0859f53f8bfc0d0f2ea3b947c8c4eb";
-#   src = pkgs.fetchFromGitHub {
-#     owner = "slothy-optimizer";
-#     repo = "slothy";
-#     rev = version;
-#     sha256 = "sha256-TplnMBjNvY7f8RTOwRWcv+cqxcRZ8KHx6toczNC5QGo=";
-#   };
-# })
+pkgs.slothy.overrideAttrs (old: rec {
+  version = "0.2.2";
+  src = pkgs.fetchFromGitHub {
+    owner = "slothy-optimizer";
+    repo = "slothy";
+    rev = version;
+    sha256 = "sha256-pyES6ithBVAFSVdjsM61kp6eeEUxNsLs7jdekpX+YuA=";
+  };
+})


### PR DESCRIPTION
- Resolves #1173