### PR TITLE
mldsa_native.h: Fix MLD_TOTAL_ALLOC worst-case for legacy builds

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -18,6 +18,9 @@
     },
     {
       "pattern": "^http://nvlpubs\\.nist\\.gov"
+    },
+    {
+      "pattern": "^https://eprint\\.iacr\\.org"
     }
   ]
 }

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -187,7 +187,7 @@
 #define MLD_API_NAMESPACE(sym) \
   MLD_API_CONCAT_UNDERSCORE(MLD_CONFIG_API_NAMESPACE_PREFIX, sym)
 
-#if defined(__GNUC__) || defined(clang)
+#if defined(__GNUC__) || defined(__clang__)
 #define MLD_API_MUST_CHECK_RETURN_VALUE __attribute__((warn_unused_result))
 #else
 #define MLD_API_MUST_CHECK_RETURN_VALUE
@@ -917,7 +917,6 @@ int MLD_API_NAMESPACE(pk_from_sk)(
 #undef MLD_API_NAMESPACE
 #undef MLD_API_MUST_CHECK_RETURN_VALUE
 #undef MLD_API_QUALIFIER
-#undef MLD_API_LEGACY_CONFIG
 
 #endif /* MLD_CONFIG_API_NO_SUPERCOP */
 #endif /* !MLD_CONFIG_API_CONSTANTS_ONLY */
@@ -1008,5 +1007,7 @@ int MLD_API_NAMESPACE(pk_from_sk)(
 #define MLD_TOTAL_ALLOC_87                                             \
   MLD_MAX4_(MLD_TOTAL_ALLOC_87_KEYPAIR, MLD_TOTAL_ALLOC_87_PK_FROM_SK, \
             MLD_TOTAL_ALLOC_87_SIGN, MLD_TOTAL_ALLOC_87_VERIFY)
+
+#undef MLD_API_LEGACY_CONFIG
 
 #endif /* !MLD_H */


### PR DESCRIPTION
mldsa_native.h: Fix MLD_TOTAL_ALLOC worst-case for legacy builds

In legacy config with MLD_CONFIG_API_NO_SUPERCOP (mandated for
multi-level legacy builds), MLD_API_LEGACY_CONFIG was undefined before
the Memory Usage section, so MLD_TOTAL_ALLOC_*_KEYPAIR fell back to the
no-PCT value instead of the documented PCT worst case. Move the cleanup
to the end of the header, after its last use. 

Also fix the warn_unused_result
guard to use __clang__ (no compiler predefines bare `clang`), and ignore
eprint.iacr.org in the markdown link checker since it now 403s automated
requests.

- Resolves #1178
- Ports https://github.com/pq-code-package/mlkem-native/pull/1743