### PR TITLE
CI: Run RISC-V64 RVV tests as per-VLEN matrix entries

### DIFF
--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -30,6 +30,9 @@ inputs:
   compile_mode:
     description: all | native | cross-x86_64 | cross-aarch64 | cross-riscv64 | cross-riscv32
     default: "native"
+  exec_wrapper:
+    description: QEMU exec wrapper override for cross runs (per-platform default when empty)
+    default: ""
   opt:
     description: all | opt | no_opt
     default: "all"
@@ -108,7 +111,7 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_X86_64"
           ldflags: ${{ inputs.ldflags }}
           cross_prefix: x86_64-unknown-linux-gnu-
-          exec_wrapper: qemu-x86_64
+          exec_wrapper: "${{ inputs.exec_wrapper != '' && inputs.exec_wrapper || 'qemu-x86_64' }}"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -134,7 +137,7 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_AARCH64"
           ldflags: ${{ inputs.ldflags }}
           cross_prefix: aarch64-unknown-linux-gnu-
-          exec_wrapper: qemu-aarch64
+          exec_wrapper: "${{ inputs.exec_wrapper != '' && inputs.exec_wrapper || 'qemu-aarch64' }}"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -160,7 +163,7 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_PPC64LE"
           ldflags: ${{ inputs.ldflags }}
           cross_prefix: powerpc64le-unknown-linux-gnu-
-          exec_wrapper: qemu-ppc64le
+          exec_wrapper: "${{ inputs.exec_wrapper != '' && inputs.exec_wrapper || 'qemu-ppc64le' }}"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -186,7 +189,7 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_AARCH64_EB"
           ldflags: "${{ inputs.ldflags }} -static"
           cross_prefix: aarch64_be-none-linux-gnu-
-          exec_wrapper: qemu-aarch64_be
+          exec_wrapper: "${{ inputs.exec_wrapper != '' && inputs.exec_wrapper || 'qemu-aarch64_be' }}"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -200,7 +203,7 @@ runs:
           rng_fail: ${{ inputs.rng_fail }}
           extra_args: ${{ inputs.extra_args }}
           extra_env: ${{ inputs.extra_env }}
-      - name: Cross riscv64 Tests (RVV, VLEN=128)
+      - name: Cross riscv64 Tests (RVV)
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
         uses: ./.github/actions/functest
         with:
@@ -212,82 +215,7 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
           ldflags: ${{ inputs.ldflags }}
           cross_prefix: riscv64-unknown-linux-gnu-
-          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=128"
-          opt: ${{ inputs.opt }}
-          func: ${{ inputs.func }}
-          kat: ${{ inputs.kat }}
-          unit: ${{ inputs.unit }}
-          acvp: ${{ inputs.acvp }}
-          wycheproof: ${{ inputs.wycheproof }}
-          examples: ${{ inputs.examples }}
-          check_namespace: ${{ inputs.check_namespace }}
-          stack: ${{ inputs.stack }}
-          alloc: ${{ inputs.alloc }}
-          rng_fail: ${{ inputs.rng_fail }}
-          extra_args: ${{ inputs.extra_args }}
-          extra_env: ${{ inputs.extra_env }}
-      - name: Cross riscv64 Tests (RVV, VLEN=256)
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
-        uses: ./.github/actions/functest
-        with:
-          nix-shell: ${{ inputs.nix-shell }}
-          nix-cache: ${{ inputs.nix-cache }}
-          nix-verbose: ${{ inputs.nix-verbose }}
-          gh_token: ${{ inputs.gh_token }}
-          custom_shell: ${{ inputs.custom_shell }}
-          cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
-          cross_prefix: riscv64-unknown-linux-gnu-
-          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=256"
-          opt: ${{ inputs.opt }}
-          func: ${{ inputs.func }}
-          kat: ${{ inputs.kat }}
-          unit: ${{ inputs.unit }}
-          acvp: ${{ inputs.acvp }}
-          wycheproof: ${{ inputs.wycheproof }}
-          examples: ${{ inputs.examples }}
-          check_namespace: ${{ inputs.check_namespace }}
-          stack: ${{ inputs.stack }}
-          alloc: ${{ inputs.alloc }}
-          rng_fail: ${{ inputs.rng_fail }}
-          extra_args: ${{ inputs.extra_args }}
-          extra_env: ${{ inputs.extra_env }}
-      - name: Cross riscv64 Tests (RVV, VLEN=512)
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
-        uses: ./.github/actions/functest
-        with:
-          nix-shell: ${{ inputs.nix-shell }}
-          nix-cache: ${{ inputs.nix-cache }}
-          nix-verbose: ${{ inputs.nix-verbose }}
-          gh_token: ${{ inputs.gh_token }}
-          custom_shell: ${{ inputs.custom_shell }}
-          cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
-          cross_prefix: riscv64-unknown-linux-gnu-
-          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=512"
-          opt: ${{ inputs.opt }}
-          func: ${{ inputs.func }}
-          kat: ${{ inputs.kat }}
-          unit: ${{ inputs.unit }}
-          acvp: ${{ inputs.acvp }}
-          wycheproof: ${{ inputs.wycheproof }}
-          examples: ${{ inputs.examples }}
-          check_namespace: ${{ inputs.check_namespace }}
-          stack: ${{ inputs.stack }}
-          alloc: ${{ inputs.alloc }}
-          rng_fail: ${{ inputs.rng_fail }}
-          extra_args: ${{ inputs.extra_args }}
-          extra_env: ${{ inputs.extra_env }}
-      - name: Cross riscv64 Tests (RVV, VLEN=1024)
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
-        uses: ./.github/actions/functest
-        with:
-          nix-shell: ${{ inputs.nix-shell }}
-          nix-cache: ${{ inputs.nix-cache }}
-          nix-verbose: ${{ inputs.nix-verbose }}
-          gh_token: ${{ inputs.gh_token }}
-          custom_shell: ${{ inputs.custom_shell }}
-          cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV64"
-          cross_prefix: riscv64-unknown-linux-gnu-
-          exec_wrapper: "qemu-riscv64 -cpu rv64,v=true,vlen=1024"
+          exec_wrapper: "${{ inputs.exec_wrapper != '' && inputs.exec_wrapper || 'qemu-riscv64 -cpu rv64,v=true,vlen=128' }}"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -313,7 +241,7 @@ runs:
           cflags: "${{ inputs.cflags }} -DMLD_FORCE_RISCV32"
           ldflags: ${{ inputs.ldflags }}
           cross_prefix: riscv32-unknown-linux-gnu-
-          exec_wrapper: qemu-riscv32
+          exec_wrapper: "${{ inputs.exec_wrapper != '' && inputs.exec_wrapper || 'qemu-riscv32' }}"
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,25 @@ jobs:
            arch: riscv64
            mode: cross-riscv64
            nix_shell: cross-riscv64
+           vlen: 128
+         - runner: ubuntu-24.04-arm
+           name: 'ubuntu-latest (aarch64)'
+           arch: riscv64
+           mode: cross-riscv64
+           nix_shell: cross-riscv64
+           vlen: 256
+         - runner: ubuntu-24.04-arm
+           name: 'ubuntu-latest (aarch64)'
+           arch: riscv64
+           mode: cross-riscv64
+           nix_shell: cross-riscv64
+           vlen: 512
+         - runner: ubuntu-24.04-arm
+           name: 'ubuntu-latest (aarch64)'
+           arch: riscv64
+           mode: cross-riscv64
+           nix_shell: cross-riscv64
+           vlen: 1024
          - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (aarch64)'
            arch: riscv32
@@ -88,14 +107,6 @@ jobs:
              target: {
                runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (aarch64)',
-               arch: riscv64,
-               mode: cross-riscv64,
-               nix_shell: cross-riscv64
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-24.04-arm,
-               name: 'ubuntu-latest (aarch64)',
                arch: riscv32,
                mode: cross-riscv32,
                nix_shell: cross-riscv32
@@ -132,17 +143,20 @@ jobs:
                mode: cross-aarch64_be,
                nix_shell: cross-aarch64_be
              }}
-    name: Functional tests (${{ matrix.target.arch }}${{ matrix.target.mode != 'native' && ', cross' || ''}})
+    name: Functional tests (${{ matrix.target.arch }}${{ matrix.target.mode != 'native' && ', cross' || ''}}${{ matrix.target.vlen && format(', VLEN={0}', matrix.target.vlen) || '' }})
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: build + test (no-opt)
         uses: ./.github/actions/multi-functest
+        # no-opt exercises only the C fallback, so RVV VLEN is irrelevant; run once for riscv64
+        if: ${{ matrix.target.arch != 'riscv64' || matrix.target.vlen == 128 }}
         with:
           nix-shell: ${{ matrix.target.nix_shell }}
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
+          exec_wrapper: ${{ matrix.target.vlen && format('qemu-riscv64 -cpu rv64,v=true,vlen={0}', matrix.target.vlen) || '' }}
           opt: 'no_opt'
       - name: build + test (+debug+memsan+ubsan, native)
         uses: ./.github/actions/multi-functest
@@ -162,6 +176,7 @@ jobs:
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
+          exec_wrapper: ${{ matrix.target.vlen && format('qemu-riscv64 -cpu rv64,v=true,vlen={0}', matrix.target.vlen) || '' }}
           opt: 'opt'
       - name: build + test (cross, opt, +debug)
         uses: ./.github/actions/multi-functest
@@ -172,6 +187,7 @@ jobs:
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
+          exec_wrapper: ${{ matrix.target.vlen && format('qemu-riscv64 -cpu rv64,v=true,vlen={0}', matrix.target.vlen) || '' }}
           cflags: "-DMLDSA_DEBUG"
           opt: 'opt'
   backend_tests:


### PR DESCRIPTION
CI: Run RISC-V64 RVV tests as per-VLEN matrix entries

The cross-riscv64 leg ran all four RVV vector lengths (VLEN 128/256/512/1024) serially in a single matrix cell on top of the no-opt, opt and opt+debug variants, bottlenecking CI. Lift VLEN into the job matrix so the lengths run in parallel, and add an `exec_wrapper` input to the multi-functest action to drive the per-VLEN QEMU override. The no-opt step only exercises the C fallback, so it runs once for riscv64.

- Resolves #1185
- Ports https://github.com/pq-code-package/mlkem-native/pull/1732 (commit 3)