### PR TITLE
CI: Trim unnecessary fetch-depth from checkout steps

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -52,8 +52,6 @@ jobs:
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,8 +65,6 @@ jobs:
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -133,7 +129,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
@@ -175,8 +172,6 @@ jobs:
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -190,8 +185,6 @@ jobs:
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -238,7 +231,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6

--- a/.github/workflows/isabelle.yml
+++ b/.github/workflows/isabelle.yml
@@ -56,8 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event_name != 'workflow_dispatch'
         with:
-          fetch-depth: 0
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
       - name: Get changed files
         if: github.event_name != 'workflow_dispatch'
         id: changed-files


### PR DESCRIPTION
Only the jobs that use tj-actions/changed-files need git history. Drop fetch-depth: 0 from the checkout steps that don't and document why the changed-files jobs keep full history.