### PR TITLE
CI: Run x86_64 functional tests on an emulated non-AVX2 CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,136 +14,88 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        external:
-         - ${{ github.repository_owner != 'pq-code-package' }}
         target:
          - runner: macos-latest
-           name: 'MacOS (aarch64)'
+           name: 'macOS (aarch64)'
            arch: mac
            mode: native
            nix_shell: ci
          - runner: macos-15-intel
-           name: 'MacOS (x86_64)'
+           name: 'macOS (x86_64)'
            arch: mac
            mode: native
            nix_shell: ci
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'aarch64'
            arch: aarch64
            mode: native
            nix_shell: ci
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'x86_64, cross'
            arch: x86_64
            mode: cross-x86_64
            nix_shell: cross-x86_64
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'x86_64, cross, no AVX2'
+           arch: x86_64
+           mode: cross-x86_64
+           nix_shell: cross-x86_64
+           exec_wrapper: 'qemu-x86_64 -cpu Snowridge'
+           extra_args: '--no-auto'
+         - runner: ubuntu-24.04-arm
+           name: 'riscv64, cross, VLEN=128'
            arch: riscv64
            mode: cross-riscv64
            nix_shell: cross-riscv64
            vlen: 128
+           exec_wrapper: 'qemu-riscv64 -cpu rv64,v=true,vlen=128'
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'riscv64, cross, VLEN=256'
            arch: riscv64
            mode: cross-riscv64
            nix_shell: cross-riscv64
            vlen: 256
+           exec_wrapper: 'qemu-riscv64 -cpu rv64,v=true,vlen=256'
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'riscv64, cross, VLEN=512'
            arch: riscv64
            mode: cross-riscv64
            nix_shell: cross-riscv64
            vlen: 512
+           exec_wrapper: 'qemu-riscv64 -cpu rv64,v=true,vlen=512'
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'riscv64, cross, VLEN=1024'
            arch: riscv64
            mode: cross-riscv64
            nix_shell: cross-riscv64
            vlen: 1024
+           exec_wrapper: 'qemu-riscv64 -cpu rv64,v=true,vlen=1024'
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (aarch64)'
+           name: 'riscv32, cross'
            arch: riscv32
            mode: cross-riscv32
            nix_shell: cross-riscv32
          - runner: ubuntu-24.04-arm
-           name: 'ubuntu-latest (ppc64le)'
+           name: 'ppc64le, cross'
            arch: ppc64le
            mode: cross-ppc64le
            nix_shell: cross-ppc64le
          - runner: ubuntu-latest
-           name: 'ubuntu-latest (x86_64)'
+           name: 'x86_64'
            arch: x86_64
            mode: native
            nix_shell: ci
          - runner: ubuntu-latest
-           name: 'ubuntu-latest (x86_64)'
+           name: 'aarch64, cross'
            arch: aarch64
            mode: cross-aarch64
            nix_shell: cross-aarch64
          - runner: ubuntu-latest
-           name: 'ubuntu-latest (x86_64)'
+           name: 'aarch64_be, cross'
            arch: aarch64_be
            mode: cross-aarch64_be
            nix_shell: cross-aarch64_be
-        exclude:
-          - {external: true,
-             target: {
-               runner: ubuntu-24.04-arm,
-               name: 'ubuntu-latest (aarch64)',
-               arch: aarch64,
-               mode: native,
-               nix_shell: ci
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-24.04-arm,
-               name: 'ubuntu-latest (aarch64)',
-               arch: x86_64,
-               mode: cross-x86_64,
-               nix_shell: cross-x86_64
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-24.04-arm,
-               name: 'ubuntu-latest (aarch64)',
-               arch: riscv32,
-               mode: cross-riscv32,
-               nix_shell: cross-riscv32
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-24.04-arm,
-               name: 'ubuntu-latest (ppc64le)',
-               arch: ppc64le,
-               mode: cross-ppc64le,
-               nix_shell: cross-ppc64le
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-latest,
-               name: 'ubuntu-latest (x86_64)',
-               arch: x86_64,
-               mode: native,
-               nix_shell: ci
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-latest,
-               name: 'ubuntu-latest (x86_64)',
-               arch: aarch64,
-               mode: cross-aarch64,
-               nix_shell: cross-aarch64
-             }}
-          - {external: true,
-             target: {
-               runner: ubuntu-latest,
-               name: 'ubuntu-latest (x86_64)',
-               arch: aarch64_be,
-               mode: cross-aarch64_be,
-               nix_shell: cross-aarch64_be
-             }}
-    name: Functional tests (${{ matrix.target.arch }}${{ matrix.target.mode != 'native' && ', cross' || ''}}${{ matrix.target.vlen && format(', VLEN={0}', matrix.target.vlen) || '' }})
+    name: Functional tests (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -156,7 +108,8 @@ jobs:
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
-          exec_wrapper: ${{ matrix.target.vlen && format('qemu-riscv64 -cpu rv64,v=true,vlen={0}', matrix.target.vlen) || '' }}
+          extra_args: ${{ matrix.target.extra_args || '' }}
+          exec_wrapper: ${{ matrix.target.exec_wrapper || '' }}
           opt: 'no_opt'
       - name: build + test (+debug+memsan+ubsan, native)
         uses: ./.github/actions/multi-functest
@@ -176,7 +129,8 @@ jobs:
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
-          exec_wrapper: ${{ matrix.target.vlen && format('qemu-riscv64 -cpu rv64,v=true,vlen={0}', matrix.target.vlen) || '' }}
+          extra_args: ${{ matrix.target.extra_args || '' }}
+          exec_wrapper: ${{ matrix.target.exec_wrapper || '' }}
           opt: 'opt'
       - name: build + test (cross, opt, +debug)
         uses: ./.github/actions/multi-functest
@@ -187,7 +141,8 @@ jobs:
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
-          exec_wrapper: ${{ matrix.target.vlen && format('qemu-riscv64 -cpu rv64,v=true,vlen={0}', matrix.target.vlen) || '' }}
+          extra_args: ${{ matrix.target.extra_args || '' }}
+          exec_wrapper: ${{ matrix.target.exec_wrapper || '' }}
           cflags: "-DMLDSA_DEBUG"
           opt: 'opt'
   backend_tests:


### PR DESCRIPTION
CI: Run x86_64 functional tests on an emulated non-AVX2 CPU

Add a `qemu-x86_64 -cpu Snowridge` matrix entry that runs the func/KAT
tests with `--no-auto` so the makefile's default `-mavx2`/`-mbmi2` is
suppressed and the runtime feature-detection C fallback is exercised.
Refactor the `build_kat` matrix to give each target a descriptive name
and carry its own `exec_wrapper`, dropping the `external`/`exclude`
machinery in favor of a flat target list.

- Resolves #1193
- Ports https://github.com/pq-code-package/mlkem-native/pull/1753