### PR TITLE
sys: Prefix capability enum values with architecture

### DIFF
--- a/dev/fips202/aarch64/x1_v84a.h
+++ b/dev/fips202/aarch64/x1_v84a.h
@@ -22,7 +22,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x1_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/aarch64/x2_v84a.h
+++ b/dev/fips202/aarch64/x2_v84a.h
@@ -23,7 +23,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
@@ -22,7 +22,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/x86_64/keccak_f1600_x4_avx2.h
+++ b/dev/fips202/x86_64/keccak_f1600_x4_avx2.h
@@ -20,7 +20,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -38,7 +38,7 @@
 
 static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
 {
-  if (mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     mld_nttunpack_avx2_asm(data);
   }
@@ -47,7 +47,7 @@ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -59,7 +59,7 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -73,7 +73,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              unsigned buflen)
 {
   /* AVX2 implementation assumes specific buffer lengths */
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
@@ -92,7 +92,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
 {
   unsigned int outlen;
   /* AVX2 implementation assumes specific buffer lengths */
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
@@ -121,7 +121,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 {
   unsigned int outlen;
   /* AVX2 implementation assumes specific buffer lengths */
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
@@ -149,7 +149,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -163,7 +163,7 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -177,7 +177,7 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -191,7 +191,7 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -205,7 +205,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -219,7 +219,7 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -231,7 +231,7 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -246,7 +246,7 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -263,7 +263,7 @@ MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -279,7 +279,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -294,7 +294,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -309,7 +309,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/integration/aws-lc/post_import.patch
+++ b/integration/aws-lc/post_import.patch
@@ -1,0 +1,14 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+diff --git a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h b/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
+--- a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
++++ b/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
+@@ -42,7 +42,7 @@
+ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
+ {
+ #if defined(MLD_SYS_X86_64)
+-  if (cap == MLD_SYS_CAP_AVX2)
++  if (cap == MLD_SYS_CAP_X86_64_AVX2)
+   {
+     return CRYPTO_is_AVX2_capable();
+   }

--- a/mldsa/src/fips202/native/aarch64/x1_v84a.h
+++ b/mldsa/src/fips202/native/aarch64/x1_v84a.h
@@ -22,7 +22,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x1_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/fips202/native/aarch64/x2_v84a.h
+++ b/mldsa/src/fips202/native/aarch64/x2_v84a.h
@@ -23,7 +23,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/fips202/native/aarch64/x4_v8a_v84a_scalar.h
+++ b/mldsa/src/fips202/native/aarch64/x4_v8a_v84a_scalar.h
@@ -22,7 +22,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/fips202/native/x86_64/keccak_f1600_x4_avx2.h
+++ b/mldsa/src/fips202/native/x86_64/keccak_f1600_x4_avx2.h
@@ -20,7 +20,7 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/native/x86_64/meta.h
+++ b/mldsa/src/native/x86_64/meta.h
@@ -38,7 +38,7 @@
 
 static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
 {
-  if (mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     mld_nttunpack_avx2_asm(data);
   }
@@ -47,7 +47,7 @@ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -59,7 +59,7 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -73,7 +73,7 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              unsigned buflen)
 {
   /* AVX2 implementation assumes specific buffer lengths */
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
@@ -92,7 +92,7 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
 {
   unsigned int outlen;
   /* AVX2 implementation assumes specific buffer lengths */
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA2_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
@@ -121,7 +121,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 {
   unsigned int outlen;
   /* AVX2 implementation assumes specific buffer lengths */
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2) || len != MLDSA_N ||
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2) || len != MLDSA_N ||
       buflen != MLD_AVX2_REJ_UNIFORM_ETA4_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
@@ -149,7 +149,7 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -163,7 +163,7 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -177,7 +177,7 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -191,7 +191,7 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -205,7 +205,7 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -219,7 +219,7 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -231,7 +231,7 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -246,7 +246,7 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -263,7 +263,7 @@ MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -279,7 +279,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -294,7 +294,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -309,7 +309,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/sys.h
+++ b/mldsa/src/sys.h
@@ -264,11 +264,11 @@
 typedef enum
 {
   /* x86_64 */
-  MLD_SYS_CAP_AVX2,
+  MLD_SYS_CAP_X86_64_AVX2,
   /* AArch64 */
-  MLD_SYS_CAP_SHA3,
+  MLD_SYS_CAP_AARCH64_SHA3,
   /* Armv8.1-M */
-  MLD_SYS_CAP_MVE
+  MLD_SYS_CAP_ARMV81M_MVE
 } mld_sys_cap;
 
 #if !defined(MLD_CONFIG_CUSTOM_CAPABILITY_FUNC)

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2309,10 +2309,9 @@ def check_macro_typos_in_file(filename, macro_check):
 
 def get_syscaps():
     return [
-        "MLD_SYS_CAP_AVX2",
-        "MLD_SYS_CAP_SHA3",
-        "MLD_SYS_CAP_MVE",
-        "MLD_SYS_CAP_DUMMY",
+        "MLD_SYS_CAP_X86_64_AVX2",
+        "MLD_SYS_CAP_AARCH64_SHA3",
+        "MLD_SYS_CAP_ARMV81M_MVE",
     ]
 
 
@@ -2369,8 +2368,8 @@ def check_macro_typos():
             if rest.startswith("\\") or m in ["MLD_XXX", "MLD_SOURCE_XXX"]:
                 return True
 
-        # 5. AWS-LC importer patch
-        if is_autogen or filename == "integration/awslc/awslc.patch":
+        # 5. AWS-LC post-import patch
+        if is_autogen or filename == "integration/aws-lc/post_import.patch":
             return True
 
         if (
@@ -4168,7 +4167,7 @@ ABI_CAPS = {
     "AVX2": {
         "asm_subdir": "x86_64",
         "guard": "__AVX2__",
-        "syscap": "MLD_SYS_CAP_AVX2",
+        "syscap": "MLD_SYS_CAP_X86_64_AVX2",
         "description": "AVX2",
         "cflags": ["-mavx2", "-mbmi2"],
         "aux_files": [],
@@ -4176,7 +4175,7 @@ ABI_CAPS = {
     "SHA3": {
         "asm_subdir": "aarch64",
         "guard": "__ARM_FEATURE_SHA3",
-        "syscap": "MLD_SYS_CAP_SHA3",
+        "syscap": "MLD_SYS_CAP_AARCH64_SHA3",
         "description": "Armv8.4-A SHA3 (eor3, rax1, xar, bcax)",
         "cflags": ["-march=armv8.4-a+sha3"],
         "aux_files": [],
@@ -4184,7 +4183,7 @@ ABI_CAPS = {
     "MVE": {
         "asm_subdir": "armv81m",
         "guard": "__ARM_FEATURE_MVE",
-        "syscap": "MLD_SYS_CAP_MVE",
+        "syscap": "MLD_SYS_CAP_ARMV81M_MVE",
         "description": "Armv8.1-M MVE",
         "cflags": ["-march=armv8.1-m.main+mve", "-mthumb"],
         "aux_files": [
@@ -4889,8 +4888,8 @@ def _main():
             lambda: gen_test_vectors(args.test_vectors_msg, args.test_vectors_ctx),
             args.test_vectors,
         ),
-        ("Check macro typos", check_macro_typos),
         ("Generate ABI checker tests", gen_abicheck),
+        ("Check macro typos", check_macro_typos),
         ("Generate preprocessor comments", gen_preprocessor_comments),
         # Formatting should be the last step
         ("Format files", lambda: format_files(args.dry_run)),

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x1_v84a_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x1_v84a_aarch64_asm.c
@@ -31,7 +31,7 @@ int check_keccak_f1600_x1_v84a_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x0[200]; /* Keccak state (25 x uint64_t) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     fprintf(stderr,
             "ABI check keccak_f1600_x1_v84a_aarch64_asm: host lacks Armv8.4-A "

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x2_v84a_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x2_v84a_aarch64_asm.c
@@ -32,7 +32,7 @@ int check_keccak_f1600_x2_v84a_aarch64_asm(void)
       buf_x0[400]; /* Two sequential Keccak states (state0[25], state1[25]) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     fprintf(stderr,
             "ABI check keccak_f1600_x2_v84a_aarch64_asm: host lacks Armv8.4-A "

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.c
@@ -32,7 +32,7 @@ int check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm(void)
                                     state1[25], state2[25], state3[25]) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     fprintf(stderr,
             "ABI check keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm: "

--- a/test/abicheck/armv81m/checks/check_keccak_f1600_x4_mve_asm.c
+++ b/test/abicheck/armv81m/checks/check_keccak_f1600_x4_mve_asm.c
@@ -34,7 +34,7 @@ int check_keccak_f1600_x4_mve_asm(void)
   MLD_ALIGN uint8_t buf_r2[192]; /* Keccak round constants in bit-interleaved
                                     form (24 pairs of 32-bit words) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_MVE))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_ARMV81M_MVE))
   {
     fprintf(stderr,
             "ABI check keccak_f1600_x4_mve_asm: host lacks Armv8.1-M MVE, "

--- a/test/abicheck/x86_64/checks/check_invntt_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_invntt_avx2_asm.c
@@ -32,7 +32,7 @@ int check_invntt_avx2_asm(void)
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Input/output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_rsi[2496]; /* Precomputed constants (624 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr, "ABI check invntt_avx2_asm: host lacks AVX2, skipping\n");
     return MLD_ABICHECK_SKIPPED;

--- a/test/abicheck/x86_64/checks/check_keccak_f1600_x4_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_keccak_f1600_x4_avx2_asm.c
@@ -37,7 +37,7 @@ int check_keccak_f1600_x4_avx2_asm(void)
   MLD_ALIGN uint8_t buf_rdx[32];  /* Rotation constant rho8 (4 x uint64_t) */
   MLD_ALIGN uint8_t buf_rsi[192]; /* Round constants (24 x uint64_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check keccak_f1600_x4_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_ntt_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_ntt_avx2_asm.c
@@ -32,7 +32,7 @@ int check_ntt_avx2_asm(void)
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Input/output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_rsi[2496]; /* Precomputed constants (624 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr, "ABI check ntt_avx2_asm: host lacks AVX2, skipping\n");
     return MLD_ABICHECK_SKIPPED;

--- a/test/abicheck/x86_64/checks/check_nttunpack_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_nttunpack_avx2_asm.c
@@ -31,7 +31,7 @@ int check_nttunpack_avx2_asm(void)
   int violations;
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Input/output polynomial (256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check nttunpack_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_pointwise_acc_l4_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_acc_l4_avx2_asm.c
@@ -38,7 +38,7 @@ int check_pointwise_acc_l4_avx2_asm(void)
   MLD_ALIGN uint8_t
       buf_rsi[4096]; /* Input polynomial vector a (4 x 256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check pointwise_acc_l4_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_pointwise_acc_l5_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_acc_l5_avx2_asm.c
@@ -38,7 +38,7 @@ int check_pointwise_acc_l5_avx2_asm(void)
   MLD_ALIGN uint8_t
       buf_rsi[5120]; /* Input polynomial vector a (5 x 256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check pointwise_acc_l5_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_pointwise_acc_l7_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_acc_l7_avx2_asm.c
@@ -38,7 +38,7 @@ int check_pointwise_acc_l7_avx2_asm(void)
   MLD_ALIGN uint8_t
       buf_rsi[7168]; /* Input polynomial vector a (7 x 256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check pointwise_acc_l7_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_pointwise_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_avx2_asm.c
@@ -33,7 +33,7 @@ int check_pointwise_avx2_asm(void)
   MLD_ALIGN uint8_t buf_rdx[2496]; /* Precomputed constants (624 x int32_t) */
   MLD_ALIGN uint8_t buf_rsi[1024]; /* Input polynomial (256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check pointwise_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_poly_caddq_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_caddq_avx2_asm.c
@@ -31,7 +31,7 @@ int check_poly_caddq_avx2_asm(void)
   int violations;
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Input/output polynomial (256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check poly_caddq_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_poly_chknorm_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_chknorm_avx2_asm.c
@@ -31,7 +31,7 @@ int check_poly_chknorm_avx2_asm(void)
   int violations;
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Input polynomial (256 x int32_t) */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check poly_chknorm_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_polyz_unpack_17_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_polyz_unpack_17_avx2_asm.c
@@ -32,7 +32,7 @@ int check_polyz_unpack_17_avx2_asm(void)
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_rsi[576];  /* Packed input bytes */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check polyz_unpack_17_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/abicheck/x86_64/checks/check_polyz_unpack_19_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_polyz_unpack_19_avx2_asm.c
@@ -32,7 +32,7 @@ int check_polyz_unpack_19_avx2_asm(void)
   MLD_ALIGN uint8_t buf_rdi[1024]; /* Output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_rsi[640];  /* Packed input bytes */
 
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
   {
     fprintf(stderr,
             "ABI check polyz_unpack_19_avx2_asm: host lacks AVX2, skipping\n");

--- a/test/configs/configs.yml
+++ b/test/configs/configs.yml
@@ -223,7 +223,7 @@ configs:
 
           static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
           {
-            if (cap == MLD_SYS_CAP_AVX2)
+            if (cap == MLD_SYS_CAP_X86_64_AVX2)
             {
               uint32_t eax, ebx, ecx, edx;
 
@@ -270,7 +270,7 @@ configs:
 
           static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
           {
-            if (cap == MLD_SYS_CAP_SHA3)
+            if (cap == MLD_SYS_CAP_AARCH64_SHA3)
             {
               uint64_t id_aa64pfr1_el1;
 

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -484,7 +484,7 @@
 
 static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 {
-  if (cap == MLD_SYS_CAP_AVX2)
+  if (cap == MLD_SYS_CAP_X86_64_AVX2)
   {
     uint32_t eax, ebx, ecx, edx;
 

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -483,7 +483,7 @@
 
 static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 {
-  if (cap == MLD_SYS_CAP_SHA3)
+  if (cap == MLD_SYS_CAP_AARCH64_SHA3)
   {
     uint64_t id_aa64pfr1_el1;
 


### PR DESCRIPTION
Disambiguate the mld_sys_cap values by architecture:
MLD_SYS_CAP_{AVX2,SHA3,MVE} become
MLD_SYS_CAP_{X86_64_AVX2,AARCH64_SHA3,ARMV81M_MVE}.

Generate the ABI checker tests before the macro-typo check in autogen
so the renamed values in the generated check files pass validation,
and drop the unused MLD_SYS_CAP_DUMMY allowlist entry.

- Resolves #1203 
- Depends on #1195 