### PR TITLE
CI: Apply clang 22 macOS sanitizer fix to build_kat too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,11 @@ jobs:
            name: 'macOS (aarch64)'
            arch: mac
            mode: native
-           nix_shell: ci
+           # macos-latest is now the macOS 26 (Tahoe) image, whose clang 21
+           # ASan runtime deadlocks at process startup (see backend_tests).
+           # Build this target with clang 22, which carries the compiler-rt
+           # fix (llvm/llvm-project#191039, backport #192082).
+           nix_shell: clang22
          - runner: macos-15-intel
            name: 'macOS (x86_64)'
            arch: mac
@@ -115,6 +119,7 @@ jobs:
         uses: ./.github/actions/multi-functest
         if: ${{ matrix.target.mode == 'native' }}
         with:
+          nix-shell: ${{ matrix.target.nix_shell }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
           cflags: "-DMLDSA_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"


### PR DESCRIPTION
Same macOS 26 ASan startup deadlock as the preceding backend_tests fix. Set the macos-latest target's nix_shell to 'clang22', and pass nix-shell to build_kat's sanitizer step uniformly with the other steps (it omitted it and fell back to the action default). Other targets are unchanged.