### PR TITLE
Update prover choice and/or tactic for long-running proofs

### DIFF
--- a/proofs/cbmc/ct_memcmp/Makefile
+++ b/proofs/cbmc/ct_memcmp/Makefile
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = mld_ct_memcmp
 

--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = mld_invntt_layer
 

--- a/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
+++ b/proofs/cbmc/polyvecl_pointwise_acc_montgomery_c/Makefile
@@ -31,7 +31,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = mld_polyvecl_pointwise_acc_montgomery_c
 

--- a/proofs/cbmc/rej_uniform_native/Makefile
+++ b/proofs/cbmc/rej_uniform_native/Makefile
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = mld_rej_uniform_native_native
 

--- a/proofs/cbmc/rej_uniform_native_aarch64/Makefile
+++ b/proofs/cbmc/rej_uniform_native_aarch64/Makefile
@@ -28,7 +28,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = rej_uniform_native_aarch64
 


### PR DESCRIPTION
These choices appear to favour the SMT encoding of CBMC 6.10.0

**Before - full proof of MLDSA-87 on r8g**
```
Real 7m49s
User 50m27s

with

polyvecl_pointwise_acc_montgomery_c 448s
invntt_layer                        149s
ct_memcmp                           122s
rej_uniform_native                  133s
rej_uniform_native_aarch64           81s
```

**After - full proof of MLDSA-87 on r8g**
```
Real 4m4s
User 38m33s

with

polyvecl_pointwise_acc_montgomery_c 209s
invntt_layer                         62s
ct_memcmp                             2s
rej_uniform_native                    2s
rej_uniform_native_aarch64            3s
```
