### PR TITLE
Reject MLD_PREHASH_NONE in prehash APIs

### DIFF
--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -637,6 +637,7 @@ int MLD_API_NAMESPACE(open)(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
+ * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use crypto_sign_signature_pre_hash_shake256.
@@ -689,6 +690,7 @@ int MLD_API_NAMESPACE(signature_pre_hash_internal)(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
+ * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use crypto_sign_verify_pre_hash_shake256.

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -637,7 +637,7 @@ int MLD_API_NAMESPACE(open)(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
- * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
+ *   MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use crypto_sign_signature_pre_hash_shake256.
@@ -690,7 +690,7 @@ int MLD_API_NAMESPACE(signature_pre_hash_internal)(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
- * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
+ *   MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use crypto_sign_verify_pre_hash_shake256.

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -1411,6 +1411,12 @@ int mld_sign_signature_pre_hash_internal(
   size_t pre_len;
   int ret;
 
+  if (hashalg == MLD_PREHASH_NONE)
+  {
+    ret = MLD_ERR_FAIL;
+    goto cleanup;
+  }
+
   pre_len = mld_prepare_domain_separation_prefix(pre, ph, phlen, ctx, ctxlen,
                                                  hashalg);
   if (pre_len == 0)
@@ -1452,6 +1458,12 @@ int mld_sign_verify_pre_hash_internal(
   MLD_ALIGN uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
   size_t pre_len;
   int ret;
+
+  if (hashalg == MLD_PREHASH_NONE)
+  {
+    ret = MLD_ERR_FAIL;
+    goto cleanup;
+  }
 
   pre_len = mld_prepare_domain_separation_prefix(pre, ph, phlen, ctx, ctxlen,
                                                  hashalg);

--- a/mldsa/src/sign.h
+++ b/mldsa/src/sign.h
@@ -558,6 +558,7 @@ __contract__(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
+ * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_signature_pre_hash_shake256.
@@ -619,6 +620,7 @@ __contract__(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
+ * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_verify_pre_hash_shake256.

--- a/mldsa/src/sign.h
+++ b/mldsa/src/sign.h
@@ -558,7 +558,7 @@ __contract__(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
- * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
+ *   MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_signature_pre_hash_shake256.
@@ -620,7 +620,7 @@ __contract__(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
- * MLD_PREHASH_NONE is rejected by this HashML-DSA API.
+ *   MLD_PREHASH_NONE is rejected by this HashML-DSA API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_verify_pre_hash_shake256.

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -19,6 +19,10 @@
   MLD_API_NAMESPACE(signature_pre_hash_shake256)
 #define crypto_sign_verify_pre_hash_shake256 \
   MLD_API_NAMESPACE(verify_pre_hash_shake256)
+#define crypto_sign_signature_pre_hash_internal \
+  MLD_API_NAMESPACE(signature_pre_hash_internal)
+#define crypto_sign_verify_pre_hash_internal \
+  MLD_API_NAMESPACE(verify_pre_hash_internal)
 #define crypto_sign_pk_from_sk MLD_API_NAMESPACE(pk_from_sk)
 
 #ifndef NTESTS
@@ -176,6 +180,62 @@ static int test_sign_pre_hash(void)
                                                         ctx, CTXLEN, rnd, sk));
   CHECK(crypto_sign_verify_pre_hash_shake256(sig, siglen, m, MLEN, ctx, CTXLEN,
                                              pk) == 0);
+
+  return 0;
+}
+
+static int test_sign_prehash_none_rejected(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t sig[CRYPTO_BYTES];
+  uint8_t ph1[MLDSA_CRHBYTES];
+  uint8_t ph2[MLDSA_CRHBYTES];
+  uint8_t ctx[CTXLEN];
+  uint8_t rnd[MLDSA_RNDBYTES];
+  size_t siglen = CRYPTO_BYTES;
+  int rc;
+
+  CHECK(crypto_sign_keypair(pk, sk) == 0);
+  CHECK(randombytes(ctx, sizeof(ctx)) == 0);
+  MLD_CT_TESTING_SECRET(ctx, sizeof(ctx));
+  CHECK(randombytes(ph1, sizeof(ph1)) == 0);
+  MLD_CT_TESTING_SECRET(ph1, sizeof(ph1));
+  CHECK(randombytes(ph2, sizeof(ph2)) == 0);
+  MLD_CT_TESTING_SECRET(ph2, sizeof(ph2));
+  CHECK(randombytes(rnd, sizeof(rnd)) == 0);
+  MLD_CT_TESTING_SECRET(rnd, sizeof(rnd));
+  CHECK(randombytes(sig, sizeof(sig)) == 0);
+  MLD_CT_TESTING_SECRET(sig, sizeof(sig));
+
+  rc = crypto_sign_signature_pre_hash_internal(sig, &siglen, ph1, sizeof(ph1),
+                                               ctx, sizeof(ctx), rnd, sk,
+                                               MLD_PREHASH_NONE);
+  MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(rc));
+  MLD_CT_TESTING_DECLASSIFY(&siglen, sizeof(siglen));
+  CHECK(rc == MLD_ERR_FAIL);
+  CHECK(siglen == 0);
+
+  siglen = CRYPTO_BYTES;
+  rc = crypto_sign_signature_pre_hash_internal(sig, &siglen, ph2, sizeof(ph2),
+                                               ctx, sizeof(ctx), rnd, sk,
+                                               MLD_PREHASH_NONE);
+  MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(rc));
+  MLD_CT_TESTING_DECLASSIFY(&siglen, sizeof(siglen));
+  CHECK(rc == MLD_ERR_FAIL);
+  CHECK(siglen == 0);
+
+  rc = crypto_sign_verify_pre_hash_internal(sig, CRYPTO_BYTES, ph1, sizeof(ph1),
+                                            ctx, sizeof(ctx), pk,
+                                            MLD_PREHASH_NONE);
+  MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(rc));
+  CHECK(rc == MLD_ERR_FAIL);
+
+  rc = crypto_sign_verify_pre_hash_internal(sig, CRYPTO_BYTES, ph2, sizeof(ph2),
+                                            ctx, sizeof(ctx), pk,
+                                            MLD_PREHASH_NONE);
+  MLD_CT_TESTING_DECLASSIFY(&rc, sizeof(rc));
+  CHECK(rc == MLD_ERR_FAIL);
 
   return 0;
 }
@@ -514,6 +574,7 @@ int main(void)
     r |= test_wrong_ctx();
     r |= test_sign_extmu();
     r |= test_sign_pre_hash();
+    r |= test_sign_prehash_none_rejected();
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \
           !MLD_CONFIG_NO_VERIFY_API */
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)


### PR DESCRIPTION
## Summary
- Reject `MLD_PREHASH_NONE` in the unstable pre-hash signing and verification APIs.
- Document that `MLD_PREHASH_NONE` is not supported by these HashML-DSA entry points.
- Add functional coverage for the rejected pre-hash algorithm.

## Validation
- `clang-format -i mldsa/src/sign.c mldsa/src/sign.h mldsa/mldsa_native.h test/src/test_mldsa.c`: passed
- `git diff --check -- mldsa/src/sign.c mldsa/src/sign.h mldsa/mldsa_native.h test/src/test_mldsa.c`: passed
- `make run_func -j4`: passed
- Not run: `./scripts/format` because `nixpkgs-fmt` is not installed in this local environment
- Not run: `./scripts/lint` because `shfmt` is not installed in this local environment

Fixes #1215


---

This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.
