### PR TITLE
Reject MLD_PREHASH_NONE in prehash APIs

### DIFF
--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -513,6 +513,8 @@ int MLD_API_NAMESPACE(verify_extmu)(
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
  *
+ * MLD_PREHASH_NONE is rejected by this API.
+ *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use signature_pre_hash_shake256.
  *
@@ -564,6 +566,8 @@ int MLD_API_NAMESPACE(signature_pre_hash_internal)(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
+ *
+ * MLD_PREHASH_NONE is rejected by this API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use verify_pre_hash_shake256.

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -1336,6 +1336,12 @@ int mld_sign_signature_pre_hash_internal(
   size_t pre_len;
   int ret;
 
+  if (hashalg == MLD_PREHASH_NONE)
+  {
+    ret = MLD_ERR_FAIL;
+    goto cleanup;
+  }
+
   pre_len = mld_prepare_domain_separation_prefix(pre, ph, phlen, ctx, ctxlen,
                                                  hashalg);
   if (pre_len == 0)
@@ -1377,6 +1383,12 @@ int mld_sign_verify_pre_hash_internal(
   MLD_ALIGN uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
   size_t pre_len;
   int ret;
+
+  if (hashalg == MLD_PREHASH_NONE)
+  {
+    ret = MLD_ERR_FAIL;
+    goto cleanup;
+  }
 
   pre_len = mld_prepare_domain_separation_prefix(pre, ph, phlen, ctx, ctxlen,
                                                  hashalg);

--- a/mldsa/src/sign.h
+++ b/mldsa/src/sign.h
@@ -476,6 +476,8 @@ __contract__(
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
  *
+ * MLD_PREHASH_NONE is rejected by this API.
+ *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_signature_pre_hash_shake256.
  *
@@ -536,6 +538,8 @@ __contract__(
  *   MLD_PREHASH_SHA2_512, MLD_PREHASH_SHA2_512_224, MLD_PREHASH_SHA2_512_256,
  *   MLD_PREHASH_SHA3_224, MLD_PREHASH_SHA3_256, MLD_PREHASH_SHA3_384,
  *   MLD_PREHASH_SHA3_512, MLD_PREHASH_SHAKE_128, MLD_PREHASH_SHAKE_256.
+ *
+ * MLD_PREHASH_NONE is rejected by this API.
  *
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_verify_pre_hash_shake256.

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -152,6 +152,13 @@ static int test_sign_pre_hash(void)
   CHECK(mld_sign_verify_pre_hash_shake256(sig, siglen, m, MLEN, ctx, CTXLEN,
                                           pk) == 0);
 
+  /* MLD_PREHASH_NONE must be rejected by the internal prehash APIs. */
+  CHECK(mld_sign_verify_pre_hash_internal(sig, siglen, m, MLEN, ctx, CTXLEN, pk,
+                                          MLD_PREHASH_NONE) == MLD_ERR_FAIL);
+  CHECK(mld_sign_signature_pre_hash_internal(sig, &siglen, m, MLEN, ctx, CTXLEN,
+                                             rnd, sk,
+                                             MLD_PREHASH_NONE) == MLD_ERR_FAIL);
+
   return 0;
 }
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \


### PR DESCRIPTION
## Summary
- Reject `MLD_PREHASH_NONE` in the unstable pre-hash signing and verification APIs.
- Document that `MLD_PREHASH_NONE` is not supported by these HashML-DSA entry points.
- Add functional coverage for the rejected pre-hash algorithm.

## Validation
- `clang-format -i mldsa/src/sign.c mldsa/src/sign.h mldsa/mldsa_native.h test/src/test_mldsa.c`: passed
- `git diff --check -- mldsa/src/sign.c mldsa/src/sign.h mldsa/mldsa_native.h test/src/test_mldsa.c`: passed
- `make run_func -j4`: passed
- Not run: `./scripts/format` because `nixpkgs-fmt` is not installed in this local environment
- Not run: `./scripts/lint` because `shfmt` is not installed in this local environment

Fixes #1215


---

This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.

