### PR TITLE
Document signing secret-key validity precondition

### DIFF
--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -246,6 +246,10 @@ int MLD_API_NAMESPACE(keypair)(
  *
  * @spec{Implements @[FIPS204, Algorithm 7, ML-DSA.Sign_internal].}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use crypto_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig        Output signature.
  * @param[out] siglen     Pointer to output length of signature.
  * @param[in]  m          Pointer to message to be signed (when
@@ -258,7 +262,7 @@ int MLD_API_NAMESPACE(keypair)(
  * @param      prelen     Length of prefix string. Ignored when
  *                        externalmu != 0.
  * @param[in]  rnd        Random seed.
- * @param[in]  sk         Bit-packed secret key.
+ * @param[in]  sk         Bit-packed secret key; assumed to be valid.
  * @param      externalmu 0: m/mlen is the raw message; mu = H(tr, pre, m) is
  *                        computed internally.
  *                        non-zero: m points to a precomputed mu of
@@ -298,13 +302,17 @@ int MLD_API_NAMESPACE(signature_internal)(
  *
  * @spec{Implements @[FIPS204, Algorithm 2, ML-DSA.Sign].}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use crypto_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  m       Pointer to message to be signed.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string. May be NULL if ctxlen == 0.
  * @param      ctxlen  Length of context string. Should be <= 255.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
  *                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
@@ -340,10 +348,14 @@ int MLD_API_NAMESPACE(signature)(
  *
  * @spec{Implements @[FIPS204, Algorithm 2, ML-DSA.Sign external mu variant].}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use crypto_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  mu      Precomputed message representative.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
  *                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
@@ -516,6 +528,10 @@ int MLD_API_NAMESPACE(verify_extmu)(
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use signature_pre_hash_shake256.
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use crypto_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  ph      Pointer to pre-hashed message.
@@ -523,7 +539,7 @@ int MLD_API_NAMESPACE(verify_extmu)(
  * @param[in]  ctx     Pointer to context string.
  * @param      ctxlen  Length of context string.
  * @param[in]  rnd     Random seed.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      hashalg Hash algorithm constant (one of MLD_PREHASH_*).
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
@@ -607,6 +623,10 @@ int MLD_API_NAMESPACE(verify_pre_hash_internal)(
  * @spec{Implements @[FIPS204, Algorithm 4, HashML-DSA.Sign] with SHAKE256 as
  * the pre-hash.}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use crypto_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  m       Pointer to message to be hashed and signed.
@@ -614,7 +634,7 @@ int MLD_API_NAMESPACE(verify_pre_hash_internal)(
  * @param[in]  ctx     Pointer to context string.
  * @param      ctxlen  Length of context string.
  * @param[in]  rnd     Random seed.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
  *                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE.

--- a/mldsa/src/sign.h
+++ b/mldsa/src/sign.h
@@ -180,6 +180,10 @@ __contract__(
  *
  * @spec{Implements @[FIPS204, Algorithm 7, ML-DSA.Sign_internal].}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use mld_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig        Output signature.
  * @param[out] siglen     Pointer to output length of signature.
  * @param[in]  m          Pointer to message to be signed (when
@@ -192,7 +196,7 @@ __contract__(
  * @param      prelen     Length of prefix string. Ignored when
  *                        externalmu != 0.
  * @param[in]  rnd        Random seed.
- * @param[in]  sk         Bit-packed secret key.
+ * @param[in]  sk         Bit-packed secret key; assumed to be valid.
  * @param      externalmu 0: m/mlen is the raw message; mu = H(tr, pre, m) is
  *                        computed internally.
  *                        non-zero: m points to a precomputed mu of
@@ -246,13 +250,17 @@ __contract__(
  *
  * @spec{Implements @[FIPS204, Algorithm 2, ML-DSA.Sign].}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use mld_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  m       Pointer to message to be signed.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string. May be NULL if ctxlen == 0.
  * @param      ctxlen  Length of context string. Should be <= 255.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
  *                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
@@ -298,10 +306,14 @@ __contract__(
  *
  * @spec{Implements @[FIPS204, Algorithm 2, ML-DSA.Sign external mu variant].}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use mld_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  mu      Precomputed message representative.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
  *                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
@@ -479,6 +491,10 @@ __contract__(
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use mld_sign_signature_pre_hash_shake256.
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use mld_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  ph      Pointer to pre-hashed message.
@@ -486,7 +502,7 @@ __contract__(
  * @param[in]  ctx     Pointer to context string.
  * @param      ctxlen  Length of context string.
  * @param[in]  rnd     Random seed.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      hashalg Hash algorithm constant (one of MLD_PREHASH_*).
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
@@ -584,6 +600,10 @@ __contract__(
  * @spec{Implements @[FIPS204, Algorithm 4, HashML-DSA.Sign] with SHAKE256 as
  * the pre-hash.}
  *
+ * @warning This function does not perform secret key validation.
+ *          Callers importing serialized keys can use mld_sign_pk_from_sk
+ *          to validate them before signing.
+ *
  * @param[out] sig     Output signature.
  * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  m       Pointer to message to be hashed and signed.
@@ -591,7 +611,7 @@ __contract__(
  * @param[in]  ctx     Pointer to context string.
  * @param      ctxlen  Length of context string.
  * @param[in]  rnd     Random seed.
- * @param[in]  sk      Bit-packed secret key.
+ * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
  *                     MLD_CONFIG_CONTEXT_PARAMETER is defined; type set by
  *                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE.

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -167,7 +167,10 @@ class TestResult(Enum):
 def check_sign_result(tc, out):
     if tc["result"] == "invalid":
         flags = tc.get("flags", [])
-        # InvalidPrivateKey: signing does not validate sk; tested via pk_from_sk
+        # FIPS 204 does not require signing to validate serialized private keys.
+        # Checking only s1/s2 would be incomplete: full validation also checks
+        # t0 and tr and is exposed through pk_from_sk. These InvalidPrivateKey
+        # vectors are skipped for signing and still tested through pkFromSk.
         if "InvalidPrivateKey" in flags:
             return TestResult.SKIPPED
         # If new invalid-flag classes appear, fail loudly so we can handle them.


### PR DESCRIPTION
## Summary
- Document that signing APIs require a valid secret key.
- Point callers to `pk_from_sk` when they need to validate a serialized secret key before signing.
- Add a Wycheproof client comment explaining why `InvalidPrivateKey` signing vectors are skipped while `pkFromSk` still tests those keys.

## Validation
- `clang-format -i mldsa/src/sign.h mldsa/mldsa_native.h`: passed
- `ruff format test/wycheproof/wycheproof_client.py`: passed
- `ruff check test/wycheproof/wycheproof_client.py`: passed
- `python3 -m py_compile test/wycheproof/wycheproof_client.py`: passed
- `git diff --check -- mldsa/src/sign.h mldsa/mldsa_native.h test/wycheproof/wycheproof_client.py`: passed
- `make run_func -j4`: passed
- `make wycheproof -j4`: passed
- `python3 test/wycheproof/wycheproof_client.py --data-dir <fresh-temp-dir>`: passed
- Not run: `./scripts/format` because `nixpkgs-fmt` is not installed in this local environment
- Not run: `./scripts/lint` because `shfmt` is not installed in this local environment

Fixes #1216


---

This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.

