### PR TITLE
Fail HOL-Light tests on unsupported arch

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -1049,12 +1049,14 @@ class Tests:
         self.check_fail()
 
     def hol_light(self):
-        if platform.machine().lower() in ["arm64", "aarch64"]:
+        machine = platform.machine().lower()
+        if machine in ["arm64", "aarch64"]:
             arch = "aarch64"
-        elif platform.machine().lower() in ["x86_64"]:
+        elif machine in ["x86_64"]:
             arch = "x86_64"
         else:
-            return
+            self.fail(f"HOL-Light unsupported architecture: {machine}")
+            self.check_fail()
 
         def list_proofs(arch):
             cmd_str = ["./proofs/hol_light/" + arch + "/list_proofs.sh"]


### PR DESCRIPTION
## Summary
- Make the HOL-Light test command fail on unsupported host architectures instead of reporting success.
- Keep supported architecture mapping explicit before selecting proof functions.

## Validation
- `ruff format scripts/tests`: passed
- `ruff check scripts/tests`: passed
- `python3 -m py_compile scripts/tests`: passed
- `git diff --check -- scripts/tests`: passed
- `python3 scripts/tests hol_light --list-functions`: passed
- Unsupported-architecture probe with `platform.machine()` mocked to `riscv64`: failed as expected with `HOL-Light unsupported architecture: riscv64`
- Not run: `./scripts/format` because `nixpkgs-fmt` is not installed in this local environment
- Not run: `./scripts/lint` because `shfmt` is not installed in this local environment

Fixes #1214


---

This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.

