### PR TITLE
Remove siglen from signing and verification APIs

### DIFF
--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -61,6 +61,15 @@ jobs:
           yq e -i 'del(.kems[] | select(.name == "kyber"))' scripts/copy_from_upstream/copy_from_upstream.yml
           yq e -i 'del(.sigs[] | select(.name == "dilithium"))' scripts/copy_from_upstream/copy_from_upstream.yml
           git diff >> "$GITHUB_STEP_SUMMARY";
+      - name: Apply integration patches
+        run: |
+          cd "$LIBOQS_DIR"
+          for patch in "$GITHUB_WORKSPACE"/integration/liboqs/*.patch; do
+            if [ -f "$patch" ]; then
+              echo "Applying $patch"
+              git apply "$patch"
+            fi
+          done
       - name: Configure
         run: |
           cd "$LIBOQS_DIR"

--- a/examples/basic/main.c
+++ b/examples/basic/main.c
@@ -67,14 +67,12 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(mldsa_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -90,10 +88,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/basic_deterministic/main.c
+++ b/examples/basic_deterministic/main.c
@@ -78,7 +78,6 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
   uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* prefix string (0, ctxlen, ctx) */
 
   printf("Signing message... ");
@@ -88,13 +87,12 @@ static int example_sign(void)
   pre[1] = TEST_VECTOR_CTX_LEN;
   memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
 
-  CHECK(mldsa_signature_internal(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
                                  TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
                                  test_vector_rnd, test_vector_sk, 0) == 0);
 
   /* Deterministic signing with explicit randomness -- always compare */
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -110,10 +108,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/basic_lowram/main.c
+++ b/examples/basic_lowram/main.c
@@ -67,14 +67,12 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(mldsa_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -90,10 +88,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -67,14 +67,12 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(mldsa_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -90,10 +88,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/bring_your_own_fips202_static/main.c
+++ b/examples/bring_your_own_fips202_static/main.c
@@ -76,14 +76,12 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(mldsa_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -99,10 +97,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -67,15 +67,13 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(CUSTOM_TINY_SHA3_signature(
-            sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-            (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-            test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(CUSTOM_TINY_SHA3_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN,
+                                   (const uint8_t *)TEST_VECTOR_CTX,
+                                   TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -91,11 +89,10 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(CUSTOM_TINY_SHA3_verify(test_vector_sig, sizeof(test_vector_sig),
-                                (const uint8_t *)TEST_VECTOR_MSG,
-                                TEST_VECTOR_MSG_LEN,
-                                (const uint8_t *)TEST_VECTOR_CTX,
-                                TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
+  CHECK(CUSTOM_TINY_SHA3_verify(
+            test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+            TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+            TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -70,14 +70,12 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(mldsa_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -93,10 +91,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/monolithic_build_multilevel/main.c
+++ b/examples/monolithic_build_multilevel/main.c
@@ -89,14 +89,12 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa44_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_44));
-  CHECK(memcmp(sig, test_vector_sig_44, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -104,14 +102,12 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa65_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_65));
-  CHECK(memcmp(sig, test_vector_sig_65, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -119,14 +115,12 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa87_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_87));
-  CHECK(memcmp(sig, test_vector_sig_87, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -154,10 +148,9 @@ static int example_mldsa87_sign(void)
 static int example_mldsa44_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa44_verify(test_vector_sig_44, sizeof(test_vector_sig_44),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_44) == 0);
+  CHECK(mldsa44_verify(test_vector_sig_44, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_44) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -165,10 +158,9 @@ static int example_mldsa44_verify(void)
 static int example_mldsa65_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa65_verify(test_vector_sig_65, sizeof(test_vector_sig_65),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_65) == 0);
+  CHECK(mldsa65_verify(test_vector_sig_65, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_65) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -176,10 +168,9 @@ static int example_mldsa65_verify(void)
 static int example_mldsa87_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa87_verify(test_vector_sig_87, sizeof(test_vector_sig_87),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_87) == 0);
+  CHECK(mldsa87_verify(test_vector_sig_87, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_87) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/monolithic_build_multilevel_native/main.c
+++ b/examples/monolithic_build_multilevel_native/main.c
@@ -91,14 +91,12 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa44_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_44));
-  CHECK(memcmp(sig, test_vector_sig_44, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -106,14 +104,12 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa65_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_65));
-  CHECK(memcmp(sig, test_vector_sig_65, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -121,14 +117,12 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa87_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_87));
-  CHECK(memcmp(sig, test_vector_sig_87, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -156,10 +150,9 @@ static int example_mldsa87_sign(void)
 static int example_mldsa44_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa44_verify(test_vector_sig_44, sizeof(test_vector_sig_44),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_44) == 0);
+  CHECK(mldsa44_verify(test_vector_sig_44, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_44) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -167,10 +160,9 @@ static int example_mldsa44_verify(void)
 static int example_mldsa65_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa65_verify(test_vector_sig_65, sizeof(test_vector_sig_65),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_65) == 0);
+  CHECK(mldsa65_verify(test_vector_sig_65, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_65) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -178,10 +170,9 @@ static int example_mldsa65_verify(void)
 static int example_mldsa87_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa87_verify(test_vector_sig_87, sizeof(test_vector_sig_87),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_87) == 0);
+  CHECK(mldsa87_verify(test_vector_sig_87, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_87) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/monolithic_build_native/main.c
+++ b/examples/monolithic_build_native/main.c
@@ -70,14 +70,12 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   printf("Signing message... ");
-  CHECK(mldsa_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
-  CHECK(siglen == sizeof(test_vector_sig));
-  CHECK(memcmp(sig, test_vector_sig, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -93,10 +91,9 @@ static int example_sign(void)
 static int example_verify(void)
 {
   printf("Verifying signature... ");
-  CHECK(mldsa_verify(test_vector_sig, sizeof(test_vector_sig),
-                     (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                     (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                     test_vector_pk) == 0);
+  CHECK(mldsa_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                     TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                     TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/multilevel_build/main.c
+++ b/examples/multilevel_build/main.c
@@ -89,14 +89,12 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa44_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_44));
-  CHECK(memcmp(sig, test_vector_sig_44, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -104,14 +102,12 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa65_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_65));
-  CHECK(memcmp(sig, test_vector_sig_65, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -119,14 +115,12 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa87_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_87));
-  CHECK(memcmp(sig, test_vector_sig_87, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -154,10 +148,9 @@ static int example_mldsa87_sign(void)
 static int example_mldsa44_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa44_verify(test_vector_sig_44, sizeof(test_vector_sig_44),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_44) == 0);
+  CHECK(mldsa44_verify(test_vector_sig_44, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_44) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -165,10 +158,9 @@ static int example_mldsa44_verify(void)
 static int example_mldsa65_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa65_verify(test_vector_sig_65, sizeof(test_vector_sig_65),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_65) == 0);
+  CHECK(mldsa65_verify(test_vector_sig_65, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_65) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -176,10 +168,9 @@ static int example_mldsa65_verify(void)
 static int example_mldsa87_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa87_verify(test_vector_sig_87, sizeof(test_vector_sig_87),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_87) == 0);
+  CHECK(mldsa87_verify(test_vector_sig_87, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_87) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/multilevel_build_native/main.c
+++ b/examples/multilevel_build_native/main.c
@@ -89,14 +89,12 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa44_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_44));
-  CHECK(memcmp(sig, test_vector_sig_44, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -104,14 +102,12 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa65_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_65));
-  CHECK(memcmp(sig, test_vector_sig_65, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -119,14 +115,12 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  size_t siglen;
 
   printf("  Signing message... ");
-  CHECK(mldsa87_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+  CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
-  CHECK(siglen == sizeof(test_vector_sig_87));
-  CHECK(memcmp(sig, test_vector_sig_87, siglen) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -154,10 +148,9 @@ static int example_mldsa87_sign(void)
 static int example_mldsa44_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa44_verify(test_vector_sig_44, sizeof(test_vector_sig_44),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_44) == 0);
+  CHECK(mldsa44_verify(test_vector_sig_44, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_44) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -165,10 +158,9 @@ static int example_mldsa44_verify(void)
 static int example_mldsa65_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa65_verify(test_vector_sig_65, sizeof(test_vector_sig_65),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_65) == 0);
+  CHECK(mldsa65_verify(test_vector_sig_65, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_65) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -176,10 +168,9 @@ static int example_mldsa65_verify(void)
 static int example_mldsa87_verify(void)
 {
   printf("  Verifying signature... ");
-  CHECK(mldsa87_verify(test_vector_sig_87, sizeof(test_vector_sig_87),
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk_87) == 0);
+  CHECK(mldsa87_verify(test_vector_sig_87, (const uint8_t *)TEST_VECTOR_MSG,
+                       TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                       TEST_VECTOR_CTX_LEN, test_vector_pk_87) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/integration/aws-lc/post_import.patch
+++ b/integration/aws-lc/post_import.patch
@@ -1,5 +1,12 @@
 # Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Adapt AWS-LC's ML-DSA wrapper to the mldsa-native API, where signing and
+# verification omit the signature-length argument (ML-DSA signatures have a
+# fixed length). For signing, the wrapper sets the output length itself; for
+# verification, it validates the input length before calling, since
+# mldsa-native expects a fixed-length signature.
+
 diff --git a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h b/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
 --- a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
 +++ b/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
@@ -12,3 +19,288 @@ diff --git a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h b/crypto/fipsmodule/
    {
      return CRYPTO_is_AVX2_capable();
    }
+diff --git a/crypto/fipsmodule/ml_dsa/ml_dsa.c b/crypto/fipsmodule/ml_dsa/ml_dsa.c
+index f6b8342..2ac93f7 100644
+--- a/crypto/fipsmodule/ml_dsa/ml_dsa.c
++++ b/crypto/fipsmodule/ml_dsa/ml_dsa.c
+@@ -92,8 +92,9 @@ int ml_dsa_44_sign(const uint8_t *private_key /* IN */,
+   FIPS_service_indicator_lock_state();
+   boringssl_ensure_ml_dsa_self_test();
+ 
+-  int ret = mldsa44_signature(sig, sig_len, message, message_len,
++  int ret = mldsa44_signature(sig, message, message_len,
+                                ctx_string, ctx_string_len, private_key);
++  *sig_len = (ret == 0) ? MLDSA44_SIGNATURE_BYTES : 0;
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -113,7 +114,8 @@ int ml_dsa_extmu_44_sign(const uint8_t *private_key /* IN */,
+ 
+   // mu_len is ignored - extmu always uses MLDSA_CRHBYTES (64 bytes)
+   (void)mu_len;
+-  int ret = mldsa44_signature_extmu(sig, sig_len, mu, private_key);
++  int ret = mldsa44_signature_extmu(sig, mu, private_key);
++  *sig_len = (ret == 0) ? MLDSA44_SIGNATURE_BYTES : 0;
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -144,8 +146,9 @@ int ml_dsa_44_sign_internal_no_self_test(const uint8_t *private_key  /* IN */,
+                                          const uint8_t *pre          /* IN */,
+                                          size_t pre_len              /* IN */,
+                                          const uint8_t *rnd          /* IN */) {
+-  int ret = mldsa44_signature_internal(sig, sig_len, message, message_len,
++  int ret = mldsa44_signature_internal(sig, message, message_len,
+                                         pre, pre_len, rnd, private_key, 0);
++  *sig_len = (ret == 0) ? MLDSA44_SIGNATURE_BYTES : 0;
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -158,8 +161,9 @@ int ml_dsa_extmu_44_sign_internal(const uint8_t *private_key  /* IN */,
+                                   size_t pre_len              /* IN */,
+                                   const uint8_t *rnd          /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa44_signature_internal(sig, sig_len, mu, mu_len,
++  int ret = mldsa44_signature_internal(sig, mu, mu_len,
+                                         pre, pre_len, rnd, private_key, 1);
++  *sig_len = (ret == 0) ? MLDSA44_SIGNATURE_BYTES : 0;
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -173,8 +177,11 @@ int ml_dsa_44_verify(const uint8_t *public_key /* IN */,
+   FIPS_service_indicator_lock_state();
+   boringssl_ensure_ml_dsa_self_test();
+ 
+-  int ret = mldsa44_verify(sig, sig_len, message, message_len,
++  int ret = -1;
++  if (sig_len == MLDSA44_SIGNATURE_BYTES) {
++    ret = mldsa44_verify(sig, message, message_len,
+                             ctx_string, ctx_string_len, public_key);
++  }
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -194,7 +201,10 @@ int ml_dsa_extmu_44_verify(const uint8_t *public_key /* IN */,
+ 
+   // mu_len is ignored - extmu always uses MLDSA_CRHBYTES (64 bytes)
+   (void)mu_len;
+-  int ret = mldsa44_verify_extmu(sig, sig_len, mu, public_key);
++  int ret = -1;
++  if (sig_len == MLDSA44_SIGNATURE_BYTES) {
++    ret = mldsa44_verify_extmu(sig, mu, public_key);
++  }
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -223,8 +233,11 @@ int ml_dsa_44_verify_internal_no_self_test(const uint8_t *public_key /* IN */,
+                                            size_t message_len        /* IN */,
+                                            const uint8_t *pre        /* IN */,
+                                            size_t pre_len            /* IN */) {
+-  int ret = mldsa44_verify_internal(sig, sig_len, message, message_len,
++  int ret = -1;
++  if (sig_len == MLDSA44_SIGNATURE_BYTES) {
++    ret = mldsa44_verify_internal(sig, message, message_len,
+                                      pre, pre_len, public_key, 0);
++  }
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -236,8 +249,11 @@ int ml_dsa_extmu_44_verify_internal(const uint8_t *public_key /* IN */,
+                                     const uint8_t *pre        /* IN */,
+                                     size_t pre_len            /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa44_verify_internal(sig, sig_len, mu, mu_len,
++  int ret = -1;
++  if (sig_len == MLDSA44_SIGNATURE_BYTES) {
++    ret = mldsa44_verify_internal(sig, mu, mu_len,
+                                      pre, pre_len, public_key, 1);
++  }
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -296,8 +312,9 @@ int ml_dsa_65_sign(const uint8_t *private_key /* IN */,
+   FIPS_service_indicator_lock_state();
+   boringssl_ensure_ml_dsa_self_test();
+ 
+-  int ret = mldsa65_signature(sig, sig_len, message, message_len,
++  int ret = mldsa65_signature(sig, message, message_len,
+                                ctx_string, ctx_string_len, private_key);
++  *sig_len = (ret == 0) ? MLDSA65_SIGNATURE_BYTES : 0;
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -317,7 +334,8 @@ int ml_dsa_extmu_65_sign(const uint8_t *private_key /* IN */,
+ 
+   // mu_len is ignored - extmu always uses MLDSA_CRHBYTES (64 bytes)
+   (void)mu_len;
+-  int ret = mldsa65_signature_extmu(sig, sig_len, mu, private_key);
++  int ret = mldsa65_signature_extmu(sig, mu, private_key);
++  *sig_len = (ret == 0) ? MLDSA65_SIGNATURE_BYTES : 0;
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -336,8 +354,9 @@ int ml_dsa_65_sign_internal(const uint8_t *private_key  /* IN */,
+                             size_t pre_len              /* IN */,
+                             const uint8_t *rnd          /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa65_signature_internal(sig, sig_len, message, message_len,
++  int ret = mldsa65_signature_internal(sig, message, message_len,
+                                         pre, pre_len, rnd, private_key, 0);
++  *sig_len = (ret == 0) ? MLDSA65_SIGNATURE_BYTES : 0;
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -350,8 +369,9 @@ int ml_dsa_extmu_65_sign_internal(const uint8_t *private_key  /* IN */,
+                                   size_t pre_len              /* IN */,
+                                   const uint8_t *rnd          /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa65_signature_internal(sig, sig_len, mu, mu_len,
++  int ret = mldsa65_signature_internal(sig, mu, mu_len,
+                                         pre, pre_len, rnd, private_key, 1);
++  *sig_len = (ret == 0) ? MLDSA65_SIGNATURE_BYTES : 0;
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -365,8 +385,11 @@ int ml_dsa_65_verify(const uint8_t *public_key /* IN */,
+   FIPS_service_indicator_lock_state();
+   boringssl_ensure_ml_dsa_self_test();
+ 
+-  int ret = mldsa65_verify(sig, sig_len, message, message_len,
++  int ret = -1;
++  if (sig_len == MLDSA65_SIGNATURE_BYTES) {
++    ret = mldsa65_verify(sig, message, message_len,
+                             ctx_string, ctx_string_len, public_key);
++  }
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -386,7 +409,10 @@ int ml_dsa_extmu_65_verify(const uint8_t *public_key /* IN */,
+ 
+   // mu_len is ignored - extmu always uses MLDSA_CRHBYTES (64 bytes)
+   (void)mu_len;
+-  int ret = mldsa65_verify_extmu(sig, sig_len, mu, public_key);
++  int ret = -1;
++  if (sig_len == MLDSA65_SIGNATURE_BYTES) {
++    ret = mldsa65_verify_extmu(sig, mu, public_key);
++  }
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -404,8 +430,11 @@ int ml_dsa_65_verify_internal(const uint8_t *public_key /* IN */,
+                               const uint8_t *pre        /* IN */,
+                               size_t pre_len            /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa65_verify_internal(sig, sig_len, message, message_len,
++  int ret = -1;
++  if (sig_len == MLDSA65_SIGNATURE_BYTES) {
++    ret = mldsa65_verify_internal(sig, message, message_len,
+                                      pre, pre_len, public_key, 0);
++  }
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -417,8 +446,11 @@ int ml_dsa_extmu_65_verify_internal(const uint8_t *public_key /* IN */,
+                                     const uint8_t *pre        /* IN */,
+                                     size_t pre_len            /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa65_verify_internal(sig, sig_len, mu, mu_len,
++  int ret = -1;
++  if (sig_len == MLDSA65_SIGNATURE_BYTES) {
++    ret = mldsa65_verify_internal(sig, mu, mu_len,
+                                      pre, pre_len, public_key, 1);
++  }
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -476,8 +508,9 @@ int ml_dsa_87_sign(const uint8_t *private_key /* IN */,
+   FIPS_service_indicator_lock_state();
+   boringssl_ensure_ml_dsa_self_test();
+ 
+-  int ret = mldsa87_signature(sig, sig_len, message, message_len,
++  int ret = mldsa87_signature(sig, message, message_len,
+                                ctx_string, ctx_string_len, private_key);
++  *sig_len = (ret == 0) ? MLDSA87_SIGNATURE_BYTES : 0;
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -497,7 +530,8 @@ int ml_dsa_extmu_87_sign(const uint8_t *private_key /* IN */,
+ 
+   // mu_len is ignored - extmu always uses MLDSA_CRHBYTES (64 bytes)
+   (void)mu_len;
+-  int ret = mldsa87_signature_extmu(sig, sig_len, mu, private_key);
++  int ret = mldsa87_signature_extmu(sig, mu, private_key);
++  *sig_len = (ret == 0) ? MLDSA87_SIGNATURE_BYTES : 0;
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -516,8 +550,9 @@ int ml_dsa_87_sign_internal(const uint8_t *private_key  /* IN */,
+                             size_t pre_len              /* IN */,
+                             const uint8_t *rnd          /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa87_signature_internal(sig, sig_len, message, message_len,
++  int ret = mldsa87_signature_internal(sig, message, message_len,
+                                         pre, pre_len, rnd, private_key, 0);
++  *sig_len = (ret == 0) ? MLDSA87_SIGNATURE_BYTES : 0;
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -530,8 +565,9 @@ int ml_dsa_extmu_87_sign_internal(const uint8_t *private_key  /* IN */,
+                                   size_t pre_len              /* IN */,
+                                   const uint8_t *rnd          /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa87_signature_internal(sig, sig_len, mu, mu_len,
++  int ret = mldsa87_signature_internal(sig, mu, mu_len,
+                                         pre, pre_len, rnd, private_key, 1);
++  *sig_len = (ret == 0) ? MLDSA87_SIGNATURE_BYTES : 0;
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -545,8 +581,11 @@ int ml_dsa_87_verify(const uint8_t *public_key /* IN */,
+   FIPS_service_indicator_lock_state();
+   boringssl_ensure_ml_dsa_self_test();
+ 
+-  int ret = mldsa87_verify(sig, sig_len, message, message_len,
++  int ret = -1;
++  if (sig_len == MLDSA87_SIGNATURE_BYTES) {
++    ret = mldsa87_verify(sig, message, message_len,
+                             ctx_string, ctx_string_len, public_key);
++  }
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -566,7 +605,10 @@ int ml_dsa_extmu_87_verify(const uint8_t *public_key /* IN */,
+ 
+   // mu_len is ignored - extmu always uses MLDSA_CRHBYTES (64 bytes)
+   (void)mu_len;
+-  int ret = mldsa87_verify_extmu(sig, sig_len, mu, public_key);
++  int ret = -1;
++  if (sig_len == MLDSA87_SIGNATURE_BYTES) {
++    ret = mldsa87_verify_extmu(sig, mu, public_key);
++  }
+ 
+   FIPS_service_indicator_unlock_state();
+   if (ret == 0) {
+@@ -584,8 +626,11 @@ int ml_dsa_87_verify_internal(const uint8_t *public_key /* IN */,
+                               const uint8_t *pre        /* IN */,
+                               size_t pre_len            /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa87_verify_internal(sig, sig_len, message, message_len,
++  int ret = -1;
++  if (sig_len == MLDSA87_SIGNATURE_BYTES) {
++    ret = mldsa87_verify_internal(sig, message, message_len,
+                                      pre, pre_len, public_key, 0);
++  }
+   return (ret == 0) ? 1 : 0;
+ }
+ 
+@@ -597,7 +642,10 @@ int ml_dsa_extmu_87_verify_internal(const uint8_t *public_key /* IN */,
+                                     const uint8_t *pre        /* IN */,
+                                     size_t pre_len            /* IN */) {
+   boringssl_ensure_ml_dsa_self_test();
+-  int ret = mldsa87_verify_internal(sig, sig_len, mu, mu_len,
++  int ret = -1;
++  if (sig_len == MLDSA87_SIGNATURE_BYTES) {
++    ret = mldsa87_verify_internal(sig, mu, mu_len,
+                                      pre, pre_len, public_key, 1);
++  }
+   return (ret == 0) ? 1 : 0;
+ }

--- a/integration/liboqs/ML-DSA-44_META.yml
+++ b/integration/liboqs/ML-DSA-44_META.yml
@@ -24,38 +24,39 @@ implementations:
 - name: ref
   version: FIPS204
   folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../../integration/liboqs/config_c.h"
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_C_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_C_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA44_C_verify_extmu
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_C_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA44_C_verify_extmu_oqs
   api-with-context-string: true
   sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h
-    mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c
-    mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h
-    mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h
-    mldsa/src/sys.h mldsa/src/zetas.inc
-- name: x86_64
-  version: FIPS204
-  folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../../integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify_extmu
-  api-with-context-string: true
-  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/native/api.h mldsa/src/native/meta.h
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
     mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h
     mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c mldsa/src/polyvec.h
     mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h mldsa/src/reduce.h
     mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h
-    mldsa/src/zetas.inc mldsa/src/native/x86_64
+    mldsa/src/zetas.inc
+- name: x86_64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify_extmu_oqs
+  api-with-context-string: true
+  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
+    mldsa/src/native/api.h mldsa/src/native/meta.h mldsa/src/packing.c mldsa/src/packing.h
+    mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h
+    mldsa/src/polyvec.c mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h
+    mldsa/src/randombytes.h mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c
+    mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h mldsa/src/zetas.inc mldsa/src/native/x86_64
   supported_platforms:
   - architecture: x86_64
     operating_systems:
@@ -68,21 +69,21 @@ implementations:
 - name: aarch64
   version: FIPS204
   folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../../integration/liboqs/config_aarch64.h"
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify_extmu
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify_extmu_oqs
   api-with-context-string: true
   sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/native/api.h mldsa/src/native/meta.h
-    mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h
-    mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c mldsa/src/polyvec.h
-    mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h mldsa/src/reduce.h
-    mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h
-    mldsa/src/zetas.inc mldsa/src/native/aarch64
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
+    mldsa/src/native/api.h mldsa/src/native/meta.h mldsa/src/packing.c mldsa/src/packing.h
+    mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h
+    mldsa/src/polyvec.c mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h
+    mldsa/src/randombytes.h mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c
+    mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h mldsa/src/zetas.inc mldsa/src/native/aarch64
   supported_platforms:
   - architecture: arm_8
     operating_systems:

--- a/integration/liboqs/ML-DSA-65_META.yml
+++ b/integration/liboqs/ML-DSA-65_META.yml
@@ -24,38 +24,39 @@ implementations:
 - name: ref
   version: FIPS204
   folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../../integration/liboqs/config_c.h"
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_C_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_C_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA65_C_verify_extmu
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_C_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA65_C_verify_extmu_oqs
   api-with-context-string: true
   sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h
-    mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c
-    mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h
-    mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h
-    mldsa/src/sys.h mldsa/src/zetas.inc
-- name: x86_64
-  version: FIPS204
-  folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../../integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify_extmu
-  api-with-context-string: true
-  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/native/api.h mldsa/src/native/meta.h
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
     mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h
     mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c mldsa/src/polyvec.h
     mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h mldsa/src/reduce.h
     mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h
-    mldsa/src/zetas.inc mldsa/src/native/x86_64
+    mldsa/src/zetas.inc
+- name: x86_64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify_extmu_oqs
+  api-with-context-string: true
+  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
+    mldsa/src/native/api.h mldsa/src/native/meta.h mldsa/src/packing.c mldsa/src/packing.h
+    mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h
+    mldsa/src/polyvec.c mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h
+    mldsa/src/randombytes.h mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c
+    mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h mldsa/src/zetas.inc mldsa/src/native/x86_64
   supported_platforms:
   - architecture: x86_64
     operating_systems:
@@ -68,21 +69,21 @@ implementations:
 - name: aarch64
   version: FIPS204
   folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="../../integration/liboqs/config_aarch64.h"
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify_extmu
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify_extmu_oqs
   api-with-context-string: true
   sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/native/api.h mldsa/src/native/meta.h
-    mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h
-    mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c mldsa/src/polyvec.h
-    mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h mldsa/src/reduce.h
-    mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h
-    mldsa/src/zetas.inc mldsa/src/native/aarch64
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
+    mldsa/src/native/api.h mldsa/src/native/meta.h mldsa/src/packing.c mldsa/src/packing.h
+    mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h
+    mldsa/src/polyvec.c mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h
+    mldsa/src/randombytes.h mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c
+    mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h mldsa/src/zetas.inc mldsa/src/native/aarch64
   supported_platforms:
   - architecture: arm_8
     operating_systems:

--- a/integration/liboqs/ML-DSA-87_META.yml
+++ b/integration/liboqs/ML-DSA-87_META.yml
@@ -24,38 +24,39 @@ implementations:
 - name: ref
   version: FIPS204
   folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../../integration/liboqs/config_c.h"
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_C_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_C_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA87_C_verify_extmu
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_C_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA87_C_verify_extmu_oqs
   api-with-context-string: true
   sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h
-    mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c
-    mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h
-    mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h
-    mldsa/src/sys.h mldsa/src/zetas.inc
-- name: x86_64
-  version: FIPS204
-  folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../../integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify_extmu
-  api-with-context-string: true
-  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/native/api.h mldsa/src/native/meta.h
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
     mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h
     mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c mldsa/src/polyvec.h
     mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h mldsa/src/reduce.h
     mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h
-    mldsa/src/zetas.inc mldsa/src/native/x86_64
+    mldsa/src/zetas.inc
+- name: x86_64
+  version: FIPS204
+  folder_name: .
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify_extmu_oqs
+  api-with-context-string: true
+  sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
+    mldsa/src/native/api.h mldsa/src/native/meta.h mldsa/src/packing.c mldsa/src/packing.h
+    mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h
+    mldsa/src/polyvec.c mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h
+    mldsa/src/randombytes.h mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c
+    mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h mldsa/src/zetas.inc mldsa/src/native/x86_64
   supported_platforms:
   - architecture: x86_64
     operating_systems:
@@ -68,21 +69,21 @@ implementations:
 - name: aarch64
   version: FIPS204
   folder_name: .
-  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="../../integration/liboqs/config_aarch64.h"
+  compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair
-  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature
-  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify
-  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_extmu
-  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify_extmu
+  signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_oqs
+  signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify_oqs
+  signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_extmu_oqs
+  signature_verify_extmu: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify_extmu_oqs
   api-with-context-string: true
   sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mldsa/src/cbmc.h mldsa/src/common.h mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h
-    mldsa/src/debug.c mldsa/src/debug.h mldsa/src/native/api.h mldsa/src/native/meta.h
-    mldsa/src/packing.c mldsa/src/packing.h mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h
-    mldsa/src/poly_kl.c mldsa/src/poly_kl.h mldsa/src/polyvec.c mldsa/src/polyvec.h
-    mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h mldsa/src/randombytes.h mldsa/src/reduce.h
-    mldsa/src/rounding.h mldsa/src/sign.c mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h
-    mldsa/src/zetas.inc mldsa/src/native/aarch64
+    integration/liboqs/sig_glue.c mldsa/mldsa_native.h mldsa/src/cbmc.h mldsa/src/common.h
+    mldsa/src/context.h mldsa/src/ct.c mldsa/src/ct.h mldsa/src/debug.c mldsa/src/debug.h
+    mldsa/src/native/api.h mldsa/src/native/meta.h mldsa/src/packing.c mldsa/src/packing.h
+    mldsa/src/params.h mldsa/src/poly.c mldsa/src/poly.h mldsa/src/poly_kl.c mldsa/src/poly_kl.h
+    mldsa/src/polyvec.c mldsa/src/polyvec.h mldsa/src/polyvec_lazy.c mldsa/src/polyvec_lazy.h
+    mldsa/src/randombytes.h mldsa/src/reduce.h mldsa/src/rounding.h mldsa/src/sign.c
+    mldsa/src/sign.h mldsa/src/symmetric.h mldsa/src/sys.h mldsa/src/zetas.inc mldsa/src/native/aarch64
   supported_platforms:
   - architecture: arm_8
     operating_systems:

--- a/integration/liboqs/sig_glue.c
+++ b/integration/liboqs/sig_glue.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/*
+ * liboqs glue for mldsa-native.
+ *
+ * liboqs's generated ML-DSA wrapper links against signing and verification
+ * functions that carry a signature-length argument, since OQS signatures are
+ * variable-length in general. mldsa-native's API omits that argument because
+ * ML-DSA signatures have a fixed length. These thin shims re-expose the
+ * length-carrying API expected by liboqs on top of the fixed-length one, and
+ * are referenced from the per-level META.yml files.
+ *
+ * The shims are compiled once per build (parameter set and backend), so the
+ * namespaced symbol names match the names liboqs links against.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "mldsa/mldsa_native.h"
+
+/*
+ * mldsa-native's public symbols are prefixed with MLD_CONFIG_NAMESPACE_PREFIX.
+ * mldsa_native.h builds these names via MLD_API_NAMESPACE(), but #undef's
+ * MLD_API_NAMESPACE_PREFIX at the end of the header, so MLD_API_NAMESPACE()
+ * cannot be reused here. Replicate the concatenation for both the shim symbols
+ * and their callees.
+ */
+#define MLD_OQS_CONCAT_(x, y) x##y
+#define MLD_OQS_CONCAT(x, y) MLD_OQS_CONCAT_(x, y)
+#define MLD_OQS_NS(sym) \
+  MLD_OQS_CONCAT(MLD_OQS_CONCAT(MLD_CONFIG_NAMESPACE_PREFIX, _), sym)
+
+#define mld_oqs_signature MLD_OQS_NS(signature_oqs)
+#define mld_oqs_verify MLD_OQS_NS(verify_oqs)
+#define mld_oqs_signature_extmu MLD_OQS_NS(signature_extmu_oqs)
+#define mld_oqs_verify_extmu MLD_OQS_NS(verify_extmu_oqs)
+
+int mld_oqs_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
+                      size_t mlen, const uint8_t *ctx, size_t ctxlen,
+                      const uint8_t *sk)
+{
+  int ret = MLD_OQS_NS(signature)(sig, m, mlen, ctx, ctxlen, sk);
+  if (ret == 0)
+  {
+    *siglen = MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET);
+  }
+  return ret;
+}
+
+int mld_oqs_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
+                   size_t mlen, const uint8_t *ctx, size_t ctxlen,
+                   const uint8_t *pk)
+{
+  /* mldsa-native's verify assumes a fixed-length signature, so reject any
+   * other length here. */
+  if (siglen != MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET))
+  {
+    return MLD_ERR_FAIL;
+  }
+  return MLD_OQS_NS(verify)(sig, m, mlen, ctx, ctxlen, pk);
+}
+
+int mld_oqs_signature_extmu(uint8_t *sig, size_t *siglen, const uint8_t *mu,
+                            const uint8_t *sk)
+{
+  int ret = MLD_OQS_NS(signature_extmu)(sig, mu, sk);
+  if (ret == 0)
+  {
+    *siglen = MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET);
+  }
+  return ret;
+}
+
+int mld_oqs_verify_extmu(const uint8_t *sig, size_t siglen, const uint8_t *mu,
+                         const uint8_t *pk)
+{
+  if (siglen != MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET))
+  {
+    return MLD_ERR_FAIL;
+  }
+  return MLD_OQS_NS(verify_extmu)(sig, mu, pk);
+}
+
+#undef mld_oqs_signature
+#undef mld_oqs_verify
+#undef mld_oqs_signature_extmu
+#undef mld_oqs_verify_extmu
+#undef MLD_OQS_NS
+#undef MLD_OQS_CONCAT
+#undef MLD_OQS_CONCAT_

--- a/integration/liboqs/vectors_sig.patch
+++ b/integration/liboqs/vectors_sig.patch
@@ -1,0 +1,194 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Adapt liboqs's ML-DSA vector test to the mldsa-native API, where signing and
+# verification omit the signature-length argument (ML-DSA signatures have a
+# fixed length). The signing functions write a full-length signature, so the
+# test keeps the length it set up front; the verification functions take a
+# fixed-length signature, so the test rejects length mismatches itself.
+diff --git a/tests/vectors_sig.c b/tests/vectors_sig.c
+index 2366be340..5e549aa07 100644
+--- a/tests/vectors_sig.c
++++ b/tests/vectors_sig.c
+@@ -22,7 +22,6 @@
+ 
+ #ifdef OQS_ENABLE_SIG_ml_dsa_44
+ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_signature_internal(uint8_t *sig,
+-        size_t *siglen,
+         const uint8_t *m,
+         size_t mlen,
+         const uint8_t *pre,
+@@ -32,7 +31,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_signature_internal(uint8_t *sig,
+         int externalmu);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_signature_pre_hash_internal(uint8_t *sig,
+-        size_t *siglen,
+         const uint8_t *ph,
+         size_t phlen,
+         const uint8_t *ctx,
+@@ -42,7 +40,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_signature_pre_hash_internal(uint8_t *sig,
+         int hashalg);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_verify_internal(const uint8_t *sig,
+-        size_t siglen,
+         const uint8_t *m,
+         size_t mlen,
+         const uint8_t *pre,
+@@ -51,7 +48,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_verify_internal(const uint8_t *sig,
+         int externalmu);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_verify_pre_hash_internal(const uint8_t *sig,
+-        size_t siglen,
+         const uint8_t *ph,
+         size_t phlen,
+         const uint8_t *ctx,
+@@ -62,7 +58,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA44_C_verify_pre_hash_internal(const uint8_t *s
+ 
+ #ifdef OQS_ENABLE_SIG_ml_dsa_65
+ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_signature_internal(uint8_t *sig,
+-        size_t *siglen,
+         const uint8_t *m,
+         size_t mlen,
+         const uint8_t *pre,
+@@ -72,7 +67,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_signature_internal(uint8_t *sig,
+         int externalmu);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_signature_pre_hash_internal(uint8_t *sig,
+-        size_t *siglen,
+         const uint8_t *ph,
+         size_t phlen,
+         const uint8_t *ctx,
+@@ -82,7 +76,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_signature_pre_hash_internal(uint8_t *sig,
+         int hashalg);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_verify_internal(const uint8_t *sig,
+-        size_t siglen,
+         const uint8_t *m,
+         size_t mlen,
+         const uint8_t *pre,
+@@ -91,7 +84,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_verify_internal(const uint8_t *sig,
+         int externalmu);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_verify_pre_hash_internal(const uint8_t *sig,
+-        size_t siglen,
+         const uint8_t *ph,
+         size_t phlen,
+         const uint8_t *ctx,
+@@ -102,7 +94,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA65_C_verify_pre_hash_internal(const uint8_t *s
+ 
+ #ifdef OQS_ENABLE_SIG_ml_dsa_87
+ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_signature_internal(uint8_t *sig,
+-        size_t *siglen,
+         const uint8_t *m,
+         size_t mlen,
+         const uint8_t *pre,
+@@ -112,7 +103,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_signature_internal(uint8_t *sig,
+         int externalmu);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_signature_pre_hash_internal(uint8_t *sig,
+-        size_t *siglen,
+         const uint8_t *ph,
+         size_t phlen,
+         const uint8_t *ctx,
+@@ -122,7 +112,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_signature_pre_hash_internal(uint8_t *sig,
+         int hashalg);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_verify_internal(const uint8_t *sig,
+-        size_t siglen,
+         const uint8_t *m,
+         size_t mlen,
+         const uint8_t *pre,
+@@ -131,7 +120,6 @@ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_verify_internal(const uint8_t *sig,
+         int externalmu);
+ 
+ extern int PQCP_MLDSA_NATIVE_MLDSA87_C_verify_pre_hash_internal(const uint8_t *sig,
+-        size_t siglen,
+         const uint8_t *ph,
+         size_t phlen,
+         const uint8_t *ctx,
+@@ -419,17 +407,19 @@ static int sig_ver_vector(const char *method_name,
+ 		goto err;
+ 	}
+ 
+-	if (!strcmp(method_name, "ML-DSA-44")) {
++	if (is_ml_dsa(method_name) && sigLen != sig->length_signature) {
++		rc = 1; /* fixed-length signature: reject length mismatch */
++	} else if (!strcmp(method_name, "ML-DSA-44")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_44
+-		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_verify_internal(sigVer_sig_bytes, sigLen, sigVer_msg_bytes, msgLen, NULL, 0, sigVer_pk_bytes, extMu);
++		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_verify_internal(sigVer_sig_bytes, sigVer_msg_bytes, msgLen, NULL, 0, sigVer_pk_bytes, extMu);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-65")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_65
+-		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_verify_internal(sigVer_sig_bytes, sigLen, sigVer_msg_bytes, msgLen, NULL, 0, sigVer_pk_bytes, extMu);
++		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_verify_internal(sigVer_sig_bytes, sigVer_msg_bytes, msgLen, NULL, 0, sigVer_pk_bytes, extMu);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-87")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_87
+-		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_verify_internal(sigVer_sig_bytes, sigLen, sigVer_msg_bytes, msgLen, NULL, 0, sigVer_pk_bytes, extMu);
++		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_verify_internal(sigVer_sig_bytes, sigVer_msg_bytes, msgLen, NULL, 0, sigVer_pk_bytes, extMu);
+ #endif
+ 	} else if (!strncmp(method_name, "SLH_DSA", 7)) {
+ #ifdef OQS_ENABLE_SIG_SLH_DSA
+@@ -560,17 +550,19 @@ static int sig_ver_prehash_vector_ext(const char *method_name,
+ 
+ 	fh = stdout;
+ 
+-	if (!strcmp(method_name, "ML-DSA-44")) {
++	if (is_ml_dsa(method_name) && sigLen != sig->length_signature) {
++		rc = 1; /* fixed-length signature: reject length mismatch */
++	} else if (!strcmp(method_name, "ML-DSA-44")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_44
+-		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_verify_pre_hash_internal(sigVer_sig_bytes, sigLen, sigVer_msg_bytes, msgLen, sigVer_ctx, sigVer_ctxLen, sigVer_pk_bytes, hashalg);
++		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_verify_pre_hash_internal(sigVer_sig_bytes, sigVer_msg_bytes, msgLen, sigVer_ctx, sigVer_ctxLen, sigVer_pk_bytes, hashalg);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-65")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_65
+-		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_verify_pre_hash_internal(sigVer_sig_bytes, sigLen, sigVer_msg_bytes, msgLen, sigVer_ctx, sigVer_ctxLen, sigVer_pk_bytes, hashalg);
++		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_verify_pre_hash_internal(sigVer_sig_bytes, sigVer_msg_bytes, msgLen, sigVer_ctx, sigVer_ctxLen, sigVer_pk_bytes, hashalg);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-87")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_87
+-		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_verify_pre_hash_internal(sigVer_sig_bytes, sigLen, sigVer_msg_bytes, msgLen, sigVer_ctx, sigVer_ctxLen, sigVer_pk_bytes, hashalg);
++		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_verify_pre_hash_internal(sigVer_sig_bytes, sigVer_msg_bytes, msgLen, sigVer_ctx, sigVer_ctxLen, sigVer_pk_bytes, hashalg);
+ #endif
+ 	} else {
+ 		goto err;
+@@ -633,15 +625,15 @@ static int sig_gen_vector(const char *method_name,
+ 
+ 	if (!strcmp(method_name, "ML-DSA-44")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_44
+-		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_signature_internal(signature, &sigLen, sigGen_msg, sigGen_msgLen, NULL, 0, prng_output_stream, sigGen_sk, extMu);
++		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_signature_internal(signature, sigGen_msg, sigGen_msgLen, NULL, 0, prng_output_stream, sigGen_sk, extMu);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-65")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_65
+-		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_signature_internal(signature, &sigLen, sigGen_msg, sigGen_msgLen, NULL, 0, prng_output_stream, sigGen_sk, extMu);
++		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_signature_internal(signature, sigGen_msg, sigGen_msgLen, NULL, 0, prng_output_stream, sigGen_sk, extMu);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-87")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_87
+-		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_signature_internal(signature, &sigLen, sigGen_msg, sigGen_msgLen, NULL, 0, prng_output_stream, sigGen_sk, extMu);
++		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_signature_internal(signature, sigGen_msg, sigGen_msgLen, NULL, 0, prng_output_stream, sigGen_sk, extMu);
+ #endif
+ 	} else if (!strncmp(method_name, "SLH_DSA", 7)) {
+ #ifdef OQS_ENABLE_SIG_SLH_DSA
+@@ -842,15 +834,15 @@ static int sig_gen_prehash_vector_ext(const char *method_name,
+ 
+ 	if (!strcmp(method_name, "ML-DSA-44")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_44
+-		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_signature_pre_hash_internal(signature, &sigLen, sigGen_msg, sigGen_msgLen, sigGen_ctx, sigGen_ctxLen, prng_output_stream, sigGen_sk, algo_name);
++		rc = PQCP_MLDSA_NATIVE_MLDSA44_C_signature_pre_hash_internal(signature, sigGen_msg, sigGen_msgLen, sigGen_ctx, sigGen_ctxLen, prng_output_stream, sigGen_sk, algo_name);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-65")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_65
+-		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_signature_pre_hash_internal(signature, &sigLen, sigGen_msg, sigGen_msgLen, sigGen_ctx, sigGen_ctxLen, prng_output_stream, sigGen_sk, algo_name);
++		rc = PQCP_MLDSA_NATIVE_MLDSA65_C_signature_pre_hash_internal(signature, sigGen_msg, sigGen_msgLen, sigGen_ctx, sigGen_ctxLen, prng_output_stream, sigGen_sk, algo_name);
+ #endif
+ 	} else if (!strcmp(method_name, "ML-DSA-87")) {
+ #ifdef OQS_ENABLE_SIG_ml_dsa_87
+-		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_signature_pre_hash_internal(signature, &sigLen, sigGen_msg, sigGen_msgLen, sigGen_ctx, sigGen_ctxLen, prng_output_stream, sigGen_sk, algo_name);
++		rc = PQCP_MLDSA_NATIVE_MLDSA87_C_signature_pre_hash_internal(signature, sigGen_msg, sigGen_msgLen, sigGen_ctx, sigGen_ctxLen, prng_output_stream, sigGen_sk, algo_name);
+ #endif
+ 	} else {
+ 		goto err;

--- a/integration/pavona/drop-siglen.patch
+++ b/integration/pavona/drop-siglen.patch
@@ -1,0 +1,103 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Adapt the crypto library wrapper to the updated mldsa-native
+# API, where signing/verification no longer take a siglen argument
+# (signatures have a fixed length). The sign output length was unused and
+# is dropped; verification now validates the signature length itself,
+# since mldsa-native no longer does so internally.
+
+diff --git a/sw/device/lib/crypto/impl/mldsa.c b/sw/device/lib/crypto/impl/mldsa.c
+index 4c43482..b855c71 100644
+--- a/sw/device/lib/crypto/impl/mldsa.c
++++ b/sw/device/lib/crypto/impl/mldsa.c
+@@ -178,9 +178,8 @@ otcrypto_status_t otcrypto_mldsa44_sign_derand(
+     memcpy(pre + 2, context.data, context.len);
+   }
+ 
+-  size_t signature_len;
+   int result = mldsa44_signature_internal(
+-      signature.data, &signature_len, message.data, message.len, pre,
++      signature.data, message.data, message.len, pre,
+       2 + context.len, rnd.data, (const uint8_t *)sk_share0, 0, &ctx);
+ 
+   if (result != 0) {
+@@ -205,6 +204,9 @@ otcrypto_status_t otcrypto_mldsa44_verify(
+   if (public_key->key_length != kOtcryptoMldsa44PublicKeyBytes) {
+     return OTCRYPTO_BAD_ARGS;
+   }
++  if (signature.len != kOtcryptoMldsa44SignatureBytes) {
++    return OTCRYPTO_BAD_ARGS;
++  }
+   if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+     return OTCRYPTO_BAD_ARGS;
+   }
+@@ -218,7 +220,7 @@ otcrypto_status_t otcrypto_mldsa44_verify(
+   mld_alloc_ctx_t ctx = {.base = work,
+                          .size_words = kOtcryptoMldsa44WorkBufferVerifyWords,
+                          .offset_words = 0};
+-  int result = mldsa44_verify(signature.data, signature.len, message.data,
++  int result = mldsa44_verify(signature.data, message.data,
+                               message.len, context.data, context.len,
+                               (const uint8_t *)public_key->key, &ctx);
+ 
+@@ -359,9 +361,8 @@ otcrypto_status_t otcrypto_mldsa65_sign_derand(
+     memcpy(pre + 2, context.data, context.len);
+   }
+ 
+-  size_t signature_len;
+   int result = mldsa65_signature_internal(
+-      signature.data, &signature_len, message.data, message.len, pre,
++      signature.data, message.data, message.len, pre,
+       2 + context.len, rnd.data, (const uint8_t *)sk_share0, 0, &ctx);
+ 
+   if (result != 0) {
+@@ -386,6 +387,9 @@ otcrypto_status_t otcrypto_mldsa65_verify(
+   if (public_key->key_length != kOtcryptoMldsa65PublicKeyBytes) {
+     return OTCRYPTO_BAD_ARGS;
+   }
++  if (signature.len != kOtcryptoMldsa65SignatureBytes) {
++    return OTCRYPTO_BAD_ARGS;
++  }
+   if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+     return OTCRYPTO_BAD_ARGS;
+   }
+@@ -399,7 +403,7 @@ otcrypto_status_t otcrypto_mldsa65_verify(
+   mld_alloc_ctx_t ctx = {.base = work,
+                          .size_words = kOtcryptoMldsa65WorkBufferVerifyWords,
+                          .offset_words = 0};
+-  int result = mldsa65_verify(signature.data, signature.len, message.data,
++  int result = mldsa65_verify(signature.data, message.data,
+                               message.len, context.data, context.len,
+                               (const uint8_t *)public_key->key, &ctx);
+ 
+@@ -540,9 +544,8 @@ otcrypto_status_t otcrypto_mldsa87_sign_derand(
+     memcpy(pre + 2, context.data, context.len);
+   }
+ 
+-  size_t signature_len;
+   int result = mldsa87_signature_internal(
+-      signature.data, &signature_len, message.data, message.len, pre,
++      signature.data, message.data, message.len, pre,
+       2 + context.len, rnd.data, (const uint8_t *)sk_share0, 0, &ctx);
+ 
+   if (result != 0) {
+@@ -567,6 +570,9 @@ otcrypto_status_t otcrypto_mldsa87_verify(
+   if (public_key->key_length != kOtcryptoMldsa87PublicKeyBytes) {
+     return OTCRYPTO_BAD_ARGS;
+   }
++  if (signature.len != kOtcryptoMldsa87SignatureBytes) {
++    return OTCRYPTO_BAD_ARGS;
++  }
+   if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+     return OTCRYPTO_BAD_ARGS;
+   }
+@@ -580,7 +586,7 @@ otcrypto_status_t otcrypto_mldsa87_verify(
+   mld_alloc_ctx_t ctx = {.base = work,
+                          .size_words = kOtcryptoMldsa87WorkBufferVerifyWords,
+                          .offset_words = 0};
+-  int result = mldsa87_verify(signature.data, signature.len, message.data,
++  int result = mldsa87_verify(signature.data, message.data,
+                               message.len, context.data, context.len,
+                               (const uint8_t *)public_key->key, &ctx);
+ 

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -241,8 +241,7 @@ int MLD_API_NAMESPACE(keypair)(
 /**
  * Compute signature using a caller-supplied random seed and prefix.
  *
- * If the returned value is non-zero, then the values of *sig and *siglen
- * should not be referenced.
+ * On error (non-zero return value), the signature buffer sig is zeroized.
  *
  * @spec{Implements @[FIPS204, Algorithm 7, ML-DSA.Sign_internal].}
  *
@@ -250,8 +249,8 @@ int MLD_API_NAMESPACE(keypair)(
  *          Callers importing serialized keys can use crypto_sign_pk_from_sk
  *          to validate them before signing.
  *
- * @param[out] sig        Output signature.
- * @param[out] siglen     Pointer to output length of signature.
+ * @param[out] sig        Pointer to buffer to hold the generated signature of
+ *                        MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in]  m          Pointer to message to be signed (when
  *                        externalmu == 0), or to a precomputed
  *                        message representative mu (when externalmu != 0).
@@ -283,8 +282,8 @@ int MLD_API_NAMESPACE(keypair)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(signature_internal)(
-    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], size_t *siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *pre, size_t prelen,
+    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *m,
+    size_t mlen, const uint8_t *pre, size_t prelen,
     const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_SECRETKEYBYTES(MLD_CONFIG_PARAMETER_SET)],
     int externalmu
@@ -306,8 +305,8 @@ int MLD_API_NAMESPACE(signature_internal)(
  *          Callers importing serialized keys can use crypto_sign_pk_from_sk
  *          to validate them before signing.
  *
- * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
+ * @param[out] sig     Pointer to buffer to hold the generated signature of
+ *                     MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in]  m       Pointer to message to be signed.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string. May be NULL if ctxlen == 0.
@@ -330,8 +329,8 @@ int MLD_API_NAMESPACE(signature_internal)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(signature)(
-    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], size_t *siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen,
+    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *m,
+    size_t mlen, const uint8_t *ctx, size_t ctxlen,
     const uint8_t sk[MLDSA_SECRETKEYBYTES(MLD_CONFIG_PARAMETER_SET)]
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
     ,
@@ -352,8 +351,8 @@ int MLD_API_NAMESPACE(signature)(
  *          Callers importing serialized keys can use crypto_sign_pk_from_sk
  *          to validate them before signing.
  *
- * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
+ * @param[out] sig     Pointer to buffer to hold the generated signature of
+ *                     MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in]  mu      Precomputed message representative.
  * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
@@ -373,7 +372,7 @@ int MLD_API_NAMESPACE(signature)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(signature_extmu)(
-    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], size_t *siglen,
+    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)],
     const uint8_t mu[MLDSA_CRHBYTES],
     const uint8_t sk[MLDSA_SECRETKEYBYTES(MLD_CONFIG_PARAMETER_SET)]
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
@@ -391,8 +390,8 @@ int MLD_API_NAMESPACE(signature_extmu)(
  *
  * @spec{Implements @[FIPS204, Algorithm 8, ML-DSA.Verify_internal].}
  *
- * @param[in] sig        Pointer to input signature.
- * @param     siglen     Length of signature.
+ * @param[in] sig        Pointer to input signature of
+ *                       MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in] m          Pointer to message (when externalmu == 0), or to a
  *                       precomputed message representative mu (when
  *                       externalmu != 0).
@@ -417,8 +416,8 @@ int MLD_API_NAMESPACE(signature_extmu)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(verify_internal)(
-    const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen,
-    const uint8_t *pre, size_t prelen,
+    const uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *m,
+    size_t mlen, const uint8_t *pre, size_t prelen,
     const uint8_t pk[MLDSA_PUBLICKEYBYTES(MLD_CONFIG_PARAMETER_SET)],
     int externalmu
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
@@ -433,8 +432,8 @@ int MLD_API_NAMESPACE(verify_internal)(
  *
  * @spec{Implements @[FIPS204, Algorithm 3, ML-DSA.Verify].}
  *
- * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
+ * @param[in] sig     Pointer to input signature of
+ *                    MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in] m       Pointer to message.
  * @param     mlen    Length of message.
  * @param[in] ctx     Pointer to context string. May be NULL if ctxlen == 0.
@@ -452,8 +451,8 @@ int MLD_API_NAMESPACE(verify_internal)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(verify)(
-    const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen,
-    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *m,
+    size_t mlen, const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_PUBLICKEYBYTES(MLD_CONFIG_PARAMETER_SET)]
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
     ,
@@ -470,8 +469,8 @@ int MLD_API_NAMESPACE(verify)(
  *
  * @spec{Implements @[FIPS204, Algorithm 3, ML-DSA.Verify external mu variant].}
  *
- * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
+ * @param[in] sig     Pointer to input signature of
+ *                    MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in] mu      Precomputed message representative.
  * @param[in] pk      Bit-packed public key.
  * @param     context Application context. Only present when
@@ -486,7 +485,8 @@ int MLD_API_NAMESPACE(verify)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(verify_extmu)(
-    const uint8_t *sig, size_t siglen, const uint8_t mu[MLDSA_CRHBYTES],
+    const uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)],
+    const uint8_t mu[MLDSA_CRHBYTES],
     const uint8_t pk[MLDSA_PUBLICKEYBYTES(MLD_CONFIG_PARAMETER_SET)]
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
     ,
@@ -534,8 +534,8 @@ int MLD_API_NAMESPACE(verify_extmu)(
  *          Callers importing serialized keys can use crypto_sign_pk_from_sk
  *          to validate them before signing.
  *
- * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
+ * @param[out] sig     Pointer to buffer to hold the generated signature of
+ *                     MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in]  ph      Pointer to pre-hashed message.
  * @param      phlen   Length of pre-hashed message.
  * @param[in]  ctx     Pointer to context string.
@@ -559,8 +559,8 @@ int MLD_API_NAMESPACE(verify_extmu)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(signature_pre_hash_internal)(
-    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], size_t *siglen,
-    const uint8_t *ph, size_t phlen, const uint8_t *ctx, size_t ctxlen,
+    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *ph,
+    size_t phlen, const uint8_t *ctx, size_t ctxlen,
     const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_SECRETKEYBYTES(MLD_CONFIG_PARAMETER_SET)],
     int hashalg
@@ -588,8 +588,8 @@ int MLD_API_NAMESPACE(signature_pre_hash_internal)(
  * @warning This is an unstable API that may change in the future. If you need
  * a stable API use verify_pre_hash_shake256.
  *
- * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
+ * @param[in] sig     Pointer to input signature of
+ *                    MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in] ph      Pointer to pre-hashed message.
  * @param     phlen   Length of pre-hashed message.
  * @param[in] ctx     Pointer to context string.
@@ -608,8 +608,8 @@ int MLD_API_NAMESPACE(signature_pre_hash_internal)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(verify_pre_hash_internal)(
-    const uint8_t *sig, size_t siglen, const uint8_t *ph, size_t phlen,
-    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *ph,
+    size_t phlen, const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_PUBLICKEYBYTES(MLD_CONFIG_PARAMETER_SET)],
     int hashalg
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
@@ -631,8 +631,8 @@ int MLD_API_NAMESPACE(verify_pre_hash_internal)(
  *          Callers importing serialized keys can use crypto_sign_pk_from_sk
  *          to validate them before signing.
  *
- * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
+ * @param[out] sig     Pointer to buffer to hold the generated signature of
+ *                     MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in]  m       Pointer to message to be hashed and signed.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string.
@@ -655,8 +655,8 @@ int MLD_API_NAMESPACE(verify_pre_hash_internal)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(signature_pre_hash_shake256)(
-    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], size_t *siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen,
+    uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *m,
+    size_t mlen, const uint8_t *ctx, size_t ctxlen,
     const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_SECRETKEYBYTES(MLD_CONFIG_PARAMETER_SET)]
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
@@ -674,8 +674,8 @@ int MLD_API_NAMESPACE(signature_pre_hash_shake256)(
  * @spec{Implements @[FIPS204, Algorithm 5, HashML-DSA.Verify] with SHAKE256 as
  * the pre-hash.}
  *
- * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
+ * @param[in] sig     Pointer to input signature of
+ *                    MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
  * @param[in] m       Pointer to message to be hashed and verified.
  * @param     mlen    Length of message.
  * @param[in] ctx     Pointer to context string.
@@ -693,8 +693,8 @@ int MLD_API_NAMESPACE(signature_pre_hash_shake256)(
 MLD_API_QUALIFIER
 MLD_API_MUST_CHECK_RETURN_VALUE
 int MLD_API_NAMESPACE(verify_pre_hash_shake256)(
-    const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen,
-    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t sig[MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET)], const uint8_t *m,
+    size_t mlen, const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_PUBLICKEYBYTES(MLD_CONFIG_PARAMETER_SET)]
 #ifdef MLD_CONFIG_CONTEXT_PARAMETER
     ,

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -90,7 +90,6 @@ static int mld_check_pct(uint8_t const pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                          MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 {
   MLD_ALIGN uint8_t message[1] = {0};
-  size_t siglen;
   int ret;
   MLD_ALLOC(signature, uint8_t, MLDSA_CRYPTO_BYTES, context);
   MLD_ALLOC(pk_test, uint8_t, MLDSA_CRYPTO_PUBLICKEYBYTES, context);
@@ -105,8 +104,8 @@ static int mld_check_pct(uint8_t const pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
   mld_memcpy(pk_test, pk, MLDSA_CRYPTO_PUBLICKEYBYTES);
 
   /* Sign a test message using the original secret key */
-  ret = mld_sign_signature(signature, &siglen, message, sizeof(message), NULL,
-                           0, sk, context);
+  ret = mld_sign_signature(signature, message, sizeof(message), NULL, 0, sk,
+                           context);
   if (ret != 0)
   {
     goto cleanup;
@@ -121,8 +120,8 @@ static int mld_check_pct(uint8_t const pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
 #endif /* MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST */
 
   /* Verify the signature using the (potentially corrupted) public key */
-  ret = mld_sign_verify(signature, siglen, message, sizeof(message), NULL, 0,
-                        pk_test, context);
+  ret = mld_sign_verify(signature, message, sizeof(message), NULL, 0, pk_test,
+                        context);
 
 cleanup:
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
@@ -905,7 +904,7 @@ cleanup:
 }
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
+int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES],
                                 const uint8_t *m, size_t mlen,
                                 const uint8_t *pre, size_t prelen,
                                 const uint8_t rnd[MLDSA_RNDBYTES],
@@ -976,10 +975,10 @@ int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
   for (; attempt < max_signing_attempts; attempt++)
   __loop__(
     MLD_IF_NOT_REDUCE_RAM(
-      assigns(attempt, ret, object_whole(siglen), memory_slice(sig, MLDSA_CRYPTO_BYTES))
+      assigns(attempt, ret, memory_slice(sig, MLDSA_CRYPTO_BYTES))
     )
     MLD_IF_REDUCE_RAM(
-      assigns(attempt, ret, object_whole(siglen), memory_slice(sig, MLDSA_CRYPTO_BYTES),
+      assigns(attempt, ret, memory_slice(sig, MLDSA_CRYPTO_BYTES),
               memory_slice(mat, sizeof(mld_polymat)))
     )
     invariant(attempt <= max_signing_attempts)
@@ -1002,18 +1001,18 @@ int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
     const uint16_t kappa = (uint16_t)(attempt * MLDSA_L);
     ret = mld_attempt_signature_generation(sig, mu, rhoprime, kappa, mat, s1hat,
                                            s2hat, t0hat, context);
-    if (ret == 0)
-    {
-      *siglen = MLDSA_CRYPTO_BYTES;
-      goto cleanup;
-    }
-    else if (ret != MLD_ERR_FAIL)
-    {
-      /* For failures such as out-of-memory, propagate and exit immediately. */
-      goto cleanup;
-    }
 
-    /* Otherwise, the signature was rejected; try the next attempt. */
+    /* Decide whether to keep trying based on the return value:
+     *  - ret == 0: a valid signature was produced; we are done.
+     *  - ret == MLD_ERR_FAIL: this candidate was rejected by one of the norm
+     *    or hint checks. We continue the loop and try again with the next
+     *    nonce.
+     *  - any other value (e.g. MLD_ERR_OUT_OF_MEMORY): an unrecoverable error
+     *    occurred, so we propagate it to the caller. */
+    if (ret != MLD_ERR_FAIL)
+    {
+      goto cleanup;
+    }
   }
 
   /* Loop ran to completion: all attempts rejected, budget exhausted.
@@ -1026,7 +1025,6 @@ cleanup:
   if (ret != 0)
   {
     /* To be on the safe-side, we zeroize the signature buffer. */
-    *siglen = 0;
     mld_memset(sig, 0, MLDSA_CRYPTO_BYTES);
   }
 
@@ -1044,9 +1042,8 @@ cleanup:
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_signature(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
-                       const uint8_t *m, size_t mlen, const uint8_t *ctx,
-                       size_t ctxlen,
+int mld_sign_signature(uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m,
+                       size_t mlen, const uint8_t *ctx, size_t ctxlen,
                        const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
                        MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 {
@@ -1079,19 +1076,18 @@ int mld_sign_signature(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
   }
   MLD_CT_TESTING_SECRET(rnd, MLDSA_RNDBYTES);
 
-  ret = mld_sign_signature_internal(sig, siglen, m, mlen, pre, pre_len, rnd, sk,
-                                    0, context);
+  ret = mld_sign_signature_internal(sig, m, mlen, pre, pre_len, rnd, sk, 0,
+                                    context);
 
 cleanup:
   if (ret != 0)
   {
-    /* To be on the safe-side, make sure *siglen and sig have a well-defined
-     * value, even in the case of error.
+    /* To be on the safe-side, make sure sig has a well-defined value, even in
+     * the case of error.
      *
-     * If we come from mld_sign_signature_internal, both are redundant,
-     * but the error case should not be the norm, and the added cost of the
-     * memset insignificant. */
-    *siglen = 0;
+     * If we come from mld_sign_signature_internal, this is redundant, but the
+     * error case should not be the norm, and the added cost of the memset
+     * insignificant. */
     mld_memset(sig, 0, MLDSA_CRYPTO_BYTES);
   }
 
@@ -1106,7 +1102,7 @@ cleanup:
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_signature_extmu(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
+int mld_sign_signature_extmu(uint8_t sig[MLDSA_CRYPTO_BYTES],
                              const uint8_t mu[MLDSA_CRHBYTES],
                              const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
                              MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
@@ -1116,7 +1112,6 @@ int mld_sign_signature_extmu(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
 
   if (rnd == NULL)
   {
-    *siglen = 0;
     ret = MLD_ERR_OUT_OF_MEMORY;
     goto cleanup;
   }
@@ -1125,14 +1120,13 @@ int mld_sign_signature_extmu(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
    * call mld_sign_signature_internal directly with all-zero rnd. */
   if (mld_randombytes(rnd, MLDSA_RNDBYTES) != 0)
   {
-    *siglen = 0;
     ret = MLD_ERR_RNG_FAIL;
     goto cleanup;
   }
   MLD_CT_TESTING_SECRET(rnd, MLDSA_RNDBYTES);
 
-  ret = mld_sign_signature_internal(sig, siglen, mu, MLDSA_CRHBYTES, NULL, 0,
-                                    rnd, sk, 1, context);
+  ret = mld_sign_signature_internal(sig, mu, MLDSA_CRHBYTES, NULL, 0, rnd, sk,
+                                    1, context);
 
 cleanup:
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
@@ -1147,7 +1141,7 @@ cleanup:
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_verify_internal(const uint8_t *sig, size_t siglen,
+int mld_sign_verify_internal(const uint8_t sig[MLDSA_CRYPTO_BYTES],
                              const uint8_t *m, size_t mlen, const uint8_t *pre,
                              size_t prelen,
                              const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
@@ -1171,12 +1165,6 @@ int mld_sign_verify_internal(const uint8_t *sig, size_t siglen,
       cp == NULL || mat == NULL || w1 == NULL || tmp == NULL)
   {
     ret = MLD_ERR_OUT_OF_MEMORY;
-    goto cleanup;
-  }
-
-  if (siglen != MLDSA_CRYPTO_BYTES)
-  {
-    ret = MLD_ERR_FAIL;
     goto cleanup;
   }
 
@@ -1281,7 +1269,7 @@ cleanup:
 #if !defined(MLD_CONFIG_CORE_API_ONLY)
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
+int mld_sign_verify(const uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m,
                     size_t mlen, const uint8_t *ctx, size_t ctxlen,
                     const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
@@ -1298,8 +1286,7 @@ int mld_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
     goto cleanup;
   }
 
-  ret = mld_sign_verify_internal(sig, siglen, m, mlen, pre, pre_len, pk, 0,
-                                 context);
+  ret = mld_sign_verify_internal(sig, m, mlen, pre, pre_len, pk, 0, context);
 
 cleanup:
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
@@ -1310,13 +1297,13 @@ cleanup:
 
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_verify_extmu(const uint8_t *sig, size_t siglen,
+int mld_sign_verify_extmu(const uint8_t sig[MLDSA_CRYPTO_BYTES],
                           const uint8_t mu[MLDSA_CRHBYTES],
                           const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                           MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 {
-  return mld_sign_verify_internal(sig, siglen, mu, MLDSA_CRHBYTES, NULL, 0, pk,
-                                  1, context);
+  return mld_sign_verify_internal(sig, mu, MLDSA_CRHBYTES, NULL, 0, pk, 1,
+                                  context);
 }
 #endif /* !MLD_CONFIG_CORE_API_ONLY */
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
@@ -1326,9 +1313,8 @@ int mld_sign_verify_extmu(const uint8_t *sig, size_t siglen,
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_signature_pre_hash_internal(
-    uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen, const uint8_t *ph,
-    size_t phlen, const uint8_t *ctx, size_t ctxlen,
-    const uint8_t rnd[MLDSA_RNDBYTES],
+    uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *ph, size_t phlen,
+    const uint8_t *ctx, size_t ctxlen, const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES], int hashalg,
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 {
@@ -1350,18 +1336,17 @@ int mld_sign_signature_pre_hash_internal(
     goto cleanup;
   }
 
-  ret = mld_sign_signature_internal(sig, siglen, pre, pre_len, NULL, 0, rnd, sk,
-                                    0, context);
+  ret = mld_sign_signature_internal(sig, pre, pre_len, NULL, 0, rnd, sk, 0,
+                                    context);
 cleanup:
   if (ret != 0)
   {
-    /* To be on the safe-side, make sure *siglen and sig have a well-defined
-     * value, even in the case of error.
+    /* To be on the safe-side, make sure sig has a well-defined value, even in
+     * the case of error.
      *
-     * If we come from mld_sign_signature_internal, both are redundant,
-     * but the error case should not be the norm, and the added cost of the
-     * memset insignificant. */
-    *siglen = 0;
+     * If we come from mld_sign_signature_internal, this is redundant, but the
+     * error case should not be the norm, and the added cost of the memset
+     * insignificant. */
     mld_memset(sig, 0, MLDSA_CRYPTO_BYTES);
   }
 
@@ -1375,7 +1360,7 @@ cleanup:
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_verify_pre_hash_internal(
-    const uint8_t *sig, size_t siglen, const uint8_t *ph, size_t phlen,
+    const uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *ph, size_t phlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES], int hashalg,
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
@@ -1398,8 +1383,7 @@ int mld_sign_verify_pre_hash_internal(
     goto cleanup;
   }
 
-  ret = mld_sign_verify_internal(sig, siglen, pre, pre_len, NULL, 0, pk, 0,
-                                 context);
+  ret = mld_sign_verify_internal(sig, pre, pre_len, NULL, 0, pk, 0, context);
 
 cleanup:
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
@@ -1412,18 +1396,17 @@ cleanup:
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_signature_pre_hash_shake256(
-    uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen, const uint8_t *m,
-    size_t mlen, const uint8_t *ctx, size_t ctxlen,
-    const uint8_t rnd[MLDSA_RNDBYTES],
+    uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen, const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 {
   MLD_ALIGN uint8_t ph[64];
   int ret;
   mld_shake256(ph, sizeof(ph), m, mlen);
-  ret = mld_sign_signature_pre_hash_internal(sig, siglen, ph, sizeof(ph), ctx,
-                                             ctxlen, rnd, sk,
-                                             MLD_PREHASH_SHAKE_256, context);
+  ret = mld_sign_signature_pre_hash_internal(sig, ph, sizeof(ph), ctx, ctxlen,
+                                             rnd, sk, MLD_PREHASH_SHAKE_256,
+                                             context);
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
   mld_zeroize(ph, sizeof(ph));
   return ret;
@@ -1434,7 +1417,7 @@ int mld_sign_signature_pre_hash_shake256(
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_verify_pre_hash_shake256(
-    const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen,
+    const uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m, size_t mlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
@@ -1442,9 +1425,8 @@ int mld_sign_verify_pre_hash_shake256(
   MLD_ALIGN uint8_t ph[64];
   int ret;
   mld_shake256(ph, sizeof(ph), m, mlen);
-  ret = mld_sign_verify_pre_hash_internal(sig, siglen, ph, sizeof(ph), ctx,
-                                          ctxlen, pk, MLD_PREHASH_SHAKE_256,
-                                          context);
+  ret = mld_sign_verify_pre_hash_internal(sig, ph, sizeof(ph), ctx, ctxlen, pk,
+                                          MLD_PREHASH_SHAKE_256, context);
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
   mld_zeroize(ph, sizeof(ph));
   return ret;

--- a/mldsa/src/sign.h
+++ b/mldsa/src/sign.h
@@ -47,23 +47,23 @@
   MLD_NAMESPACE_KL(keypair_internal) MLD_CONTEXT_PARAMETERS_3
 #define mld_sign_keypair MLD_NAMESPACE_KL(keypair) MLD_CONTEXT_PARAMETERS_2
 #define mld_sign_signature_internal \
-  MLD_NAMESPACE_KL(signature_internal) MLD_CONTEXT_PARAMETERS_9
-#define mld_sign_signature MLD_NAMESPACE_KL(signature) MLD_CONTEXT_PARAMETERS_7
+  MLD_NAMESPACE_KL(signature_internal) MLD_CONTEXT_PARAMETERS_8
+#define mld_sign_signature MLD_NAMESPACE_KL(signature) MLD_CONTEXT_PARAMETERS_6
 #define mld_sign_signature_extmu \
-  MLD_NAMESPACE_KL(signature_extmu) MLD_CONTEXT_PARAMETERS_4
+  MLD_NAMESPACE_KL(signature_extmu) MLD_CONTEXT_PARAMETERS_3
 #define mld_sign_verify_internal \
-  MLD_NAMESPACE_KL(verify_internal) MLD_CONTEXT_PARAMETERS_8
-#define mld_sign_verify MLD_NAMESPACE_KL(verify) MLD_CONTEXT_PARAMETERS_7
+  MLD_NAMESPACE_KL(verify_internal) MLD_CONTEXT_PARAMETERS_7
+#define mld_sign_verify MLD_NAMESPACE_KL(verify) MLD_CONTEXT_PARAMETERS_6
 #define mld_sign_verify_extmu \
-  MLD_NAMESPACE_KL(verify_extmu) MLD_CONTEXT_PARAMETERS_4
+  MLD_NAMESPACE_KL(verify_extmu) MLD_CONTEXT_PARAMETERS_3
 #define mld_sign_signature_pre_hash_internal \
-  MLD_NAMESPACE_KL(signature_pre_hash_internal) MLD_CONTEXT_PARAMETERS_9
+  MLD_NAMESPACE_KL(signature_pre_hash_internal) MLD_CONTEXT_PARAMETERS_8
 #define mld_sign_verify_pre_hash_internal \
-  MLD_NAMESPACE_KL(verify_pre_hash_internal) MLD_CONTEXT_PARAMETERS_8
+  MLD_NAMESPACE_KL(verify_pre_hash_internal) MLD_CONTEXT_PARAMETERS_7
 #define mld_sign_signature_pre_hash_shake256 \
-  MLD_NAMESPACE_KL(signature_pre_hash_shake256) MLD_CONTEXT_PARAMETERS_8
+  MLD_NAMESPACE_KL(signature_pre_hash_shake256) MLD_CONTEXT_PARAMETERS_7
 #define mld_sign_verify_pre_hash_shake256 \
-  MLD_NAMESPACE_KL(verify_pre_hash_shake256) MLD_CONTEXT_PARAMETERS_7
+  MLD_NAMESPACE_KL(verify_pre_hash_shake256) MLD_CONTEXT_PARAMETERS_6
 #define mld_prepare_domain_separation_prefix \
   MLD_NAMESPACE_KL(prepare_domain_separation_prefix)
 #define mld_sign_pk_from_sk \
@@ -175,8 +175,7 @@ __contract__(
 /**
  * Compute signature using internal randomness.
  *
- * If the returned value is non-zero, then the values of *sig and *siglen
- * should not be referenced.
+ * On error (non-zero return value), the signature buffer sig is zeroized.
  *
  * @spec{Implements @[FIPS204, Algorithm 7, ML-DSA.Sign_internal].}
  *
@@ -184,8 +183,8 @@ __contract__(
  *          Callers importing serialized keys can use mld_sign_pk_from_sk
  *          to validate them before signing.
  *
- * @param[out] sig        Output signature.
- * @param[out] siglen     Pointer to output length of signature.
+ * @param[out] sig        Pointer to buffer to hold the generated signature of
+ *                        MLDSA_CRYPTO_BYTES bytes.
  * @param[in]  m          Pointer to message to be signed (when
  *                        externalmu == 0), or to a precomputed
  *                        message representative mu (when externalmu != 0).
@@ -216,7 +215,7 @@ __contract__(
  */
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
+int mld_sign_signature_internal(uint8_t sig[MLDSA_CRYPTO_BYTES],
                                 const uint8_t *m, size_t mlen,
                                 const uint8_t *pre, size_t prelen,
                                 const uint8_t rnd[MLDSA_RNDBYTES],
@@ -227,20 +226,15 @@ __contract__(
   requires(mlen <= MLD_MAX_BUFFER_SIZE)
   requires(prelen <= MLD_MAX_BUFFER_SIZE)
   requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
-  requires(memory_no_alias(siglen, sizeof(size_t)))
   requires(memory_no_alias(m, mlen))
   requires(memory_no_alias(rnd, MLDSA_RNDBYTES))
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
   requires((externalmu == 0) ==> ((prelen == 0) || memory_no_alias(pre, prelen)))
   requires((externalmu != 0) ==> (mlen == MLDSA_CRHBYTES))
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
-  assigns(object_whole(siglen))
   ensures(return_value == 0 || return_value == MLD_ERR_FAIL ||
           return_value == MLD_ERR_OUT_OF_MEMORY ||
-          return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
-  ensures(return_value == 0 ==> *siglen == MLDSA_CRYPTO_BYTES)
-  ensures(return_value != 0 ==> *siglen == 0)
-);
+          return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED));
 
 #if !defined(MLD_CONFIG_CORE_API_ONLY)
 /**
@@ -255,7 +249,6 @@ __contract__(
  *          to validate them before signing.
  *
  * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  m       Pointer to message to be signed.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string. May be NULL if ctxlen == 0.
@@ -277,23 +270,19 @@ __contract__(
  */
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_signature(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
-                       const uint8_t *m, size_t mlen, const uint8_t *ctx,
-                       size_t ctxlen,
+int mld_sign_signature(uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m,
+                       size_t mlen, const uint8_t *ctx, size_t ctxlen,
                        const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
                        MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(mlen <= MLD_MAX_BUFFER_SIZE)
   requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
-  requires(memory_no_alias(siglen, sizeof(size_t)))
   requires(memory_no_alias(m, mlen))
   requires(ctxlen <= MLD_MAX_BUFFER_SIZE)
   requires(ctxlen == 0 || memory_no_alias(ctx, ctxlen))
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
-  assigns(object_whole(siglen))
-  ensures((return_value == 0 && *siglen == MLDSA_CRYPTO_BYTES) ||
-          (MLD_ANY_ERROR(return_value) && *siglen == 0))
+  ensures(return_value == 0 || MLD_ANY_ERROR(return_value))
 );
 
 /**
@@ -311,7 +300,6 @@ __contract__(
  *          to validate them before signing.
  *
  * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  mu      Precomputed message representative.
  * @param[in]  sk      Bit-packed secret key; assumed to be valid.
  * @param      context Application context. Only present when
@@ -330,19 +318,16 @@ __contract__(
  */
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_signature_extmu(uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen,
+int mld_sign_signature_extmu(uint8_t sig[MLDSA_CRYPTO_BYTES],
                              const uint8_t mu[MLDSA_CRHBYTES],
                              const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
                              MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
-  requires(memory_no_alias(siglen, sizeof(size_t)))
   requires(memory_no_alias(mu, MLDSA_CRHBYTES))
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
-  assigns(object_whole(siglen))
-  ensures((return_value == 0 && *siglen == MLDSA_CRYPTO_BYTES) ||
-          (MLD_ANY_ERROR(return_value) && *siglen == 0))
+  ensures(return_value == 0 || MLD_ANY_ERROR(return_value))
 );
 
 #endif /* !MLD_CONFIG_CORE_API_ONLY */
@@ -354,8 +339,8 @@ __contract__(
  *
  * @spec{Implements @[FIPS204, Algorithm 8, ML-DSA.Verify_internal].}
  *
- * @param[in] sig        Pointer to input signature.
- * @param     siglen     Length of signature.
+ * @param[in] sig        Pointer to input signature of
+ *                       MLDSA_CRYPTO_BYTES bytes.
  * @param[in] m          Pointer to message (when externalmu == 0), or to a
  *                       precomputed message representative mu (when
  *                       externalmu != 0).
@@ -379,7 +364,7 @@ __contract__(
  */
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_verify_internal(const uint8_t *sig, size_t siglen,
+int mld_sign_verify_internal(const uint8_t sig[MLDSA_CRYPTO_BYTES],
                              const uint8_t *m, size_t mlen, const uint8_t *pre,
                              size_t prelen,
                              const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
@@ -388,8 +373,7 @@ int mld_sign_verify_internal(const uint8_t *sig, size_t siglen,
 __contract__(
   requires(prelen <= MLD_MAX_BUFFER_SIZE)
   requires(mlen <= MLD_MAX_BUFFER_SIZE)
-  requires(siglen <= MLD_MAX_BUFFER_SIZE)
-  requires(memory_no_alias(sig, siglen))
+  requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
   requires(memory_no_alias(m, mlen))
   requires((externalmu == 0) ==> ((prelen == 0) || memory_no_alias(pre, prelen)))
   requires((externalmu != 0) ==> (mlen == MLDSA_CRHBYTES))
@@ -404,7 +388,6 @@ __contract__(
  * @spec{Implements @[FIPS204, Algorithm 3, ML-DSA.Verify].}
  *
  * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
  * @param[in] m       Pointer to message.
  * @param     mlen    Length of message.
  * @param[in] ctx     Pointer to context string. May be NULL if ctxlen == 0.
@@ -421,15 +404,14 @@ __contract__(
  */
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
+int mld_sign_verify(const uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m,
                     size_t mlen, const uint8_t *ctx, size_t ctxlen,
                     const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(mlen <= MLD_MAX_BUFFER_SIZE)
-  requires(siglen <= MLD_MAX_BUFFER_SIZE)
   requires(ctxlen <= MLD_MAX_BUFFER_SIZE)
-  requires(memory_no_alias(sig, siglen))
+  requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
   requires(memory_no_alias(m, mlen))
   requires(ctxlen == 0 || memory_no_alias(ctx, ctxlen))
   requires(memory_no_alias(pk, MLDSA_CRYPTO_PUBLICKEYBYTES))
@@ -446,7 +428,6 @@ __contract__(
  * @spec{Implements @[FIPS204, Algorithm 3, ML-DSA.Verify external mu variant].}
  *
  * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
  * @param[in] mu      Precomputed message representative.
  * @param[in] pk      Bit-packed public key.
  * @param     context Application context. Only present when
@@ -460,13 +441,11 @@ __contract__(
  */
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
-int mld_sign_verify_extmu(const uint8_t *sig, size_t siglen,
+int mld_sign_verify_extmu(const uint8_t sig[MLDSA_CRYPTO_BYTES],
                           const uint8_t mu[MLDSA_CRHBYTES],
                           const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
                           MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
-__contract__(
-  requires(siglen <= MLD_MAX_BUFFER_SIZE)
-  requires(memory_no_alias(sig, siglen))
+__contract__(  requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
   requires(memory_no_alias(mu, MLDSA_CRHBYTES))
   requires(memory_no_alias(pk, MLDSA_CRYPTO_PUBLICKEYBYTES))
   ensures(return_value == 0 || return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY)
@@ -498,7 +477,6 @@ __contract__(
  *          to validate them before signing.
  *
  * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  ph      Pointer to pre-hashed message.
  * @param      phlen   Length of pre-hashed message.
  * @param[in]  ctx     Pointer to context string.
@@ -522,24 +500,20 @@ __contract__(
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_signature_pre_hash_internal(
-    uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen, const uint8_t *ph,
-    size_t phlen, const uint8_t *ctx, size_t ctxlen,
-    const uint8_t rnd[MLDSA_RNDBYTES],
+    uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *ph, size_t phlen,
+    const uint8_t *ctx, size_t ctxlen, const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES], int hashalg,
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(ctxlen <= MLD_MAX_BUFFER_SIZE)
   requires(phlen <= MLD_MAX_BUFFER_SIZE)
   requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
-  requires(memory_no_alias(siglen, sizeof(size_t)))
   requires(memory_no_alias(ph, phlen))
   requires(ctxlen == 0 || memory_no_alias(ctx, ctxlen))
   requires(memory_no_alias(rnd, MLDSA_RNDBYTES))
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
-  assigns(object_whole(siglen))
-  ensures((return_value == 0 && *siglen == MLDSA_CRYPTO_BYTES) ||
-          ((return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED) && *siglen == 0))
+  ensures(return_value == 0 || return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
 );
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 
@@ -561,7 +535,6 @@ __contract__(
  * a stable API use mld_sign_verify_pre_hash_shake256.
  *
  * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
  * @param[in] ph      Pointer to pre-hashed message.
  * @param     phlen   Length of pre-hashed message.
  * @param[in] ctx     Pointer to context string.
@@ -580,15 +553,14 @@ __contract__(
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_verify_pre_hash_internal(
-    const uint8_t *sig, size_t siglen, const uint8_t *ph, size_t phlen,
+    const uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *ph, size_t phlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES], int hashalg,
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(phlen <= MLD_MAX_BUFFER_SIZE)
   requires(ctxlen <= MLD_MAX_BUFFER_SIZE - 77)
-  requires(siglen <= MLD_MAX_BUFFER_SIZE)
-  requires(memory_no_alias(sig, siglen))
+  requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
   requires(memory_no_alias(ph, phlen))
   requires(ctxlen == 0 || memory_no_alias(ctx, ctxlen))
   requires(memory_no_alias(pk, MLDSA_CRYPTO_PUBLICKEYBYTES))
@@ -609,7 +581,6 @@ __contract__(
  *          to validate them before signing.
  *
  * @param[out] sig     Output signature.
- * @param[out] siglen  Pointer to output length of signature.
  * @param[in]  m       Pointer to message to be hashed and signed.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string.
@@ -632,24 +603,20 @@ __contract__(
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_signature_pre_hash_shake256(
-    uint8_t sig[MLDSA_CRYPTO_BYTES], size_t *siglen, const uint8_t *m,
-    size_t mlen, const uint8_t *ctx, size_t ctxlen,
-    const uint8_t rnd[MLDSA_RNDBYTES],
+    uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen, const uint8_t rnd[MLDSA_RNDBYTES],
     const uint8_t sk[MLDSA_CRYPTO_SECRETKEYBYTES],
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(mlen <= MLD_MAX_BUFFER_SIZE)
   requires(ctxlen <= MLD_MAX_BUFFER_SIZE)
   requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
-  requires(memory_no_alias(siglen, sizeof(size_t)))
   requires(memory_no_alias(m, mlen))
   requires(ctxlen == 0 || memory_no_alias(ctx, ctxlen))
   requires(memory_no_alias(rnd, MLDSA_RNDBYTES))
   requires(memory_no_alias(sk, MLDSA_CRYPTO_SECRETKEYBYTES))
   assigns(memory_slice(sig, MLDSA_CRYPTO_BYTES))
-  assigns(object_whole(siglen))
-  ensures((return_value == 0 && *siglen == MLDSA_CRYPTO_BYTES) ||
-          ((return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED) && *siglen == 0))
+  ensures(return_value == 0 || return_value == MLD_ERR_FAIL || return_value == MLD_ERR_OUT_OF_MEMORY || return_value == MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED)
 );
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 
@@ -662,7 +629,6 @@ __contract__(
  * the pre-hash.}
  *
  * @param[in] sig     Pointer to input signature.
- * @param     siglen  Length of signature.
  * @param[in] m       Pointer to message to be hashed and verified.
  * @param     mlen    Length of message.
  * @param[in] ctx     Pointer to context string.
@@ -680,15 +646,14 @@ __contract__(
 MLD_MUST_CHECK_RETURN_VALUE
 MLD_EXTERNAL_API
 int mld_sign_verify_pre_hash_shake256(
-    const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen,
+    const uint8_t sig[MLDSA_CRYPTO_BYTES], const uint8_t *m, size_t mlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t pk[MLDSA_CRYPTO_PUBLICKEYBYTES],
     MLD_CONFIG_CONTEXT_PARAMETER_TYPE context)
 __contract__(
   requires(mlen <= MLD_MAX_BUFFER_SIZE)
   requires(ctxlen <= MLD_MAX_BUFFER_SIZE - 77)
-  requires(siglen <= MLD_MAX_BUFFER_SIZE)
-  requires(memory_no_alias(sig, siglen))
+  requires(memory_no_alias(sig, MLDSA_CRYPTO_BYTES))
   requires(memory_no_alias(m, mlen))
   requires(ctxlen == 0 || memory_no_alias(ctx, ctxlen))
   requires(memory_no_alias(pk, MLDSA_CRYPTO_PUBLICKEYBYTES))

--- a/proofs/cbmc/sign_signature/sign_signature_harness.c
+++ b/proofs/cbmc/sign_signature/sign_signature_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   uint8_t *sig;
-  size_t *siglen;
   uint8_t *m;
   size_t mlen;
   uint8_t *ctx;
@@ -14,6 +13,6 @@ void harness(void)
   uint8_t *sk;
   int r;
 
-  r = mld_sign_signature(sig, siglen, m, mlen, ctx, ctxlen, sk,
+  r = mld_sign_signature(sig, m, mlen, ctx, ctxlen, sk,
                          NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_signature_extmu/sign_signature_extmu_harness.c
+++ b/proofs/cbmc/sign_signature_extmu/sign_signature_extmu_harness.c
@@ -6,11 +6,10 @@
 void harness(void)
 {
   uint8_t *sig;
-  size_t *siglen;
   uint8_t *mu;
   uint8_t *sk;
   int r;
 
   r = mld_sign_signature_extmu(
-      sig, siglen, mu, sk, NULL /* context will be dropped by preprocessor */);
+      sig, mu, sk, NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_signature_internal/sign_signature_internal_harness.c
+++ b/proofs/cbmc/sign_signature_internal/sign_signature_internal_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   uint8_t *sig;
-  size_t *siglen;
   uint8_t *m;
   size_t mlen;
   uint8_t *pre;
@@ -16,6 +15,6 @@ void harness(void)
   int externalmu;
   int r;
   r = mld_sign_signature_internal(
-      sig, siglen, m, mlen, pre, prelen, rnd, sk, externalmu,
+      sig, m, mlen, pre, prelen, rnd, sk, externalmu,
       NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_signature_pre_hash_internal/sign_signature_pre_hash_internal_harness.c
+++ b/proofs/cbmc/sign_signature_pre_hash_internal/sign_signature_pre_hash_internal_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   uint8_t *sig;
-  size_t *siglen;
   const uint8_t *ph;
   size_t phlen;
   const uint8_t *ctx;
@@ -16,6 +15,6 @@ void harness(void)
   int hashalg;
   int r;
   r = mld_sign_signature_pre_hash_internal(
-      sig, siglen, ph, phlen, ctx, ctxlen, rnd, sk, hashalg,
+      sig, ph, phlen, ctx, ctxlen, rnd, sk, hashalg,
       NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_signature_pre_hash_shake256/sign_signature_pre_hash_shake256_harness.c
+++ b/proofs/cbmc/sign_signature_pre_hash_shake256/sign_signature_pre_hash_shake256_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   uint8_t *sig;
-  size_t *siglen;
   const uint8_t *m;
   size_t mlen;
   const uint8_t *ctx;
@@ -15,6 +14,6 @@ void harness(void)
   const uint8_t *sk;
   int r;
   r = mld_sign_signature_pre_hash_shake256(
-      sig, siglen, m, mlen, ctx, ctxlen, rnd, sk,
+      sig, m, mlen, ctx, ctxlen, rnd, sk,
       NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_verify/sign_verify_harness.c
+++ b/proofs/cbmc/sign_verify/sign_verify_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   const uint8_t *sig;
-  size_t siglen;
   const uint8_t *m;
   size_t mlen;
   const uint8_t *ctx;
@@ -15,6 +14,6 @@ void harness(void)
 
   int r;
 
-  r = mld_sign_verify(sig, siglen, m, mlen, ctx, ctxlen, pk,
+  r = mld_sign_verify(sig, m, mlen, ctx, ctxlen, pk,
                       NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_verify_extmu/sign_verify_extmu_harness.c
+++ b/proofs/cbmc/sign_verify_extmu/sign_verify_extmu_harness.c
@@ -8,12 +8,11 @@
 void harness(void)
 {
   uint8_t *sig;
-  size_t siglen;
   uint8_t *mu;
   uint8_t *pk;
 
   int r;
 
-  r = mld_sign_verify_extmu(sig, siglen, mu, pk,
+  r = mld_sign_verify_extmu(sig, mu, pk,
                             NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_verify_internal/Makefile
+++ b/proofs/cbmc/sign_verify_internal/Makefile
@@ -46,7 +46,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_no_bv_extract --z3
 
 FUNCTION_NAME = sign_verify_internal
 

--- a/proofs/cbmc/sign_verify_internal/sign_verify_internal_harness.c
+++ b/proofs/cbmc/sign_verify_internal/sign_verify_internal_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   const uint8_t *sig;
-  size_t siglen;
   const uint8_t *m;
   size_t mlen;
   const uint8_t *pre;
@@ -14,6 +13,6 @@ void harness(void)
   const uint8_t *pk;
   int externalmu;
 
-  mld_sign_verify_internal(sig, siglen, m, mlen, pre, prelen, pk, externalmu,
+  mld_sign_verify_internal(sig, m, mlen, pre, prelen, pk, externalmu,
                            NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_verify_pre_hash_internal/sign_verify_pre_hash_internal_harness.c
+++ b/proofs/cbmc/sign_verify_pre_hash_internal/sign_verify_pre_hash_internal_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   const uint8_t *sig;
-  size_t siglen;
   const uint8_t *ph;
   size_t phlen;
   const uint8_t *ctx;
@@ -15,6 +14,6 @@ void harness(void)
   int hashalg;
   int r;
   r = mld_sign_verify_pre_hash_internal(
-      sig, siglen, ph, phlen, ctx, ctxlen, pk, hashalg,
+      sig, ph, phlen, ctx, ctxlen, pk, hashalg,
       NULL /* context will be dropped by preprocessor */);
 }

--- a/proofs/cbmc/sign_verify_pre_hash_shake256/sign_verify_pre_hash_shake256_harness.c
+++ b/proofs/cbmc/sign_verify_pre_hash_shake256/sign_verify_pre_hash_shake256_harness.c
@@ -6,7 +6,6 @@
 void harness(void)
 {
   const uint8_t *sig;
-  size_t siglen;
   const uint8_t *m;
   size_t mlen;
   const uint8_t *ctx;
@@ -14,6 +13,6 @@ void harness(void)
   const uint8_t *pk;
   int r;
   r = mld_sign_verify_pre_hash_shake256(
-      sig, siglen, m, mlen, ctx, ctxlen, pk,
+      sig, m, mlen, ctx, ctxlen, pk,
       NULL /* context will be dropped by preprocessor */);
 }

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -3656,6 +3656,9 @@ def get_oqs_shared_sources(backend):
         and not f == "mldsa_native.h"
     ]
 
+    # add the public header, which the glue consumes
+    sources.append("mldsa/mldsa_native.h")
+
     if backend != "ref":
         # add files mldsa/native/* (API definitions)
         sources += [
@@ -3663,10 +3666,11 @@ def get_oqs_shared_sources(backend):
             for f in os.listdir(f"{mldsa_dir}/native")
             if os.path.isfile(f"{mldsa_dir}/native/{f}")
         ]
-    # Add FIPS202 glue code
+    # Add FIPS202 glue code and the signature API glue
     sources += [
         "integration/liboqs/fips202_glue.h",
         "integration/liboqs/fips202x4_glue.h",
+        "integration/liboqs/sig_glue.c",
     ]
     # Add custom config
     if backend == "ref":

--- a/test/acvp/acvp_mldsa.c
+++ b/test/acvp/acvp_mldsa.c
@@ -294,7 +294,6 @@ static void acvp_mldsa_sigGen_AFT(const unsigned char *message, size_t mlen,
                                   const unsigned char *context, size_t ctxlen)
 {
   unsigned char sig[MLDSA_SIG_BYTES];
-  size_t siglen;
   unsigned char pre[MAX_CTX_LENGTH + 2];
 
   CHECK(ctxlen <= 255);
@@ -303,8 +302,8 @@ static void acvp_mldsa_sigGen_AFT(const unsigned char *message, size_t mlen,
   pre[1] = (uint8_t)ctxlen;
   memcpy(pre + 2, context, ctxlen);
 
-  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                    ctxlen + 2, rnd, sk, 0) == 0);
+  CHECK(mld_sign_signature_internal(sig, message, mlen, pre, ctxlen + 2, rnd,
+                                    sk, 0) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 
@@ -314,9 +313,8 @@ static void acvp_mldsa_sigGenInternal_AFT(
     const unsigned char sk[MLDSA_SK_BYTES], int externalMu)
 {
   unsigned char sig[MLDSA_SIG_BYTES];
-  size_t siglen;
-  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0, rnd,
-                                    sk, externalMu) == 0);
+  CHECK(mld_sign_signature_internal(sig, message, mlen, NULL, 0, rnd, sk,
+                                    externalMu) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 
@@ -328,7 +326,6 @@ static void acvp_mldsa_sigGenDeterministic_AFT(
     size_t ctxlen)
 {
   unsigned char sig[MLDSA_SIG_BYTES];
-  size_t siglen;
   unsigned char rnd[MLDSA_SEEDBYTES] = {0}; /* Zero rnd for deterministic */
 
   unsigned char pre[MAX_CTX_LENGTH + 2];
@@ -339,8 +336,8 @@ static void acvp_mldsa_sigGenDeterministic_AFT(
   pre[1] = (uint8_t)ctxlen;
   memcpy(pre + 2, context, ctxlen);
 
-  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                    ctxlen + 2, rnd, sk, 0) == 0);
+  CHECK(mld_sign_signature_internal(sig, message, mlen, pre, ctxlen + 2, rnd,
+                                    sk, 0) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 
@@ -349,11 +346,10 @@ static void acvp_mldsa_sigGenInternalDeterministic_AFT(
     const unsigned char sk[MLDSA_SK_BYTES], int externalMu)
 {
   unsigned char sig[MLDSA_SIG_BYTES];
-  size_t siglen;
   unsigned char rnd[MLDSA_SEEDBYTES] = {0}; /* Zero rnd for deterministic */
 
-  CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0, rnd,
-                                    sk, externalMu) == 0);
+  CHECK(mld_sign_signature_internal(sig, message, mlen, NULL, 0, rnd, sk,
+                                    externalMu) == 0);
   print_hex("signature", sig, sizeof(sig));
 }
 #endif /* !MLD_CONFIG_NO_SIGN_API */
@@ -365,8 +361,7 @@ static int acvp_mldsa_sigVer_AFT(const unsigned char *message, size_t mlen,
                                  const unsigned char signature[MLDSA_SIG_BYTES],
                                  const unsigned char pk[MLDSA_PK_BYTES])
 {
-  return mld_sign_verify(signature, MLDSA_SIG_BYTES, message, mlen, context,
-                         ctxlen, pk);
+  return mld_sign_verify(signature, message, mlen, context, ctxlen, pk);
 }
 
 
@@ -377,12 +372,11 @@ static int acvp_mldsa_sigVerInternal_AFT(
 {
   if (externalMu)
   {
-    return mld_sign_verify_extmu(signature, MLDSA_SIG_BYTES, message, pk);
+    return mld_sign_verify_extmu(signature, message, pk);
   }
   else
   {
-    return mld_sign_verify_internal(signature, MLDSA_SIG_BYTES, message, mlen,
-                                    NULL, 0, pk, 0);
+    return mld_sign_verify_internal(signature, message, mlen, NULL, 0, pk, 0);
   }
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
@@ -453,16 +447,14 @@ static int acvp_mldsa_sigGenPreHash_AFT(const unsigned char *ph, size_t phlen,
                                         const char *hashAlg)
 {
   unsigned char signature[MLDSA_SIG_BYTES];
-  size_t siglen;
-
-  if (mld_sign_signature_pre_hash_internal(signature, &siglen, ph, phlen,
-                                           context, ctxlen, rng, sk,
+  if (mld_sign_signature_pre_hash_internal(signature, ph, phlen, context,
+                                           ctxlen, rng, sk,
                                            str_to_hash_alg(hashAlg)) != 0)
   {
     return 1;
   }
 
-  print_hex("signature", signature, siglen);
+  print_hex("signature", signature, MLDSA_SIG_BYTES);
   return 0;
 }
 
@@ -474,9 +466,8 @@ static int acvp_mldsa_sigVerPreHash_AFT(
     size_t ctxlen, const unsigned char signature[MLDSA_SIG_BYTES],
     const unsigned char pk[MLDSA_PK_BYTES], const char *hashAlg)
 {
-  return mld_sign_verify_pre_hash_internal(signature, MLDSA_SIG_BYTES, ph,
-                                           phlen, context, ctxlen, pk,
-                                           str_to_hash_alg(hashAlg));
+  return mld_sign_verify_pre_hash_internal(
+      signature, ph, phlen, context, ctxlen, pk, str_to_hash_alg(hashAlg));
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 
@@ -487,15 +478,13 @@ static int acvp_mldsa_sigGenPreHashShake256_AFT(
     const unsigned char sk[MLDSA_SK_BYTES])
 {
   unsigned char signature[MLDSA_SIG_BYTES];
-  size_t siglen;
-
-  if (mld_sign_signature_pre_hash_shake256(signature, &siglen, message, mlen,
-                                           context, ctxlen, rnd, sk) != 0)
+  if (mld_sign_signature_pre_hash_shake256(signature, message, mlen, context,
+                                           ctxlen, rnd, sk) != 0)
   {
     return 1;
   }
 
-  print_hex("signature", signature, siglen);
+  print_hex("signature", signature, MLDSA_SIG_BYTES);
   return 0;
 }
 
@@ -507,8 +496,8 @@ static int acvp_mldsa_sigVerPreHashShake256_AFT(
     size_t ctxlen, const unsigned char signature[MLDSA_SIG_BYTES],
     const unsigned char pk[MLDSA_PK_BYTES])
 {
-  return mld_sign_verify_pre_hash_shake256(signature, MLDSA_SIG_BYTES, message,
-                                           mlen, context, ctxlen, pk);
+  return mld_sign_verify_pre_hash_shake256(signature, message, mlen, context,
+                                           ctxlen, pk);
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 
@@ -519,17 +508,16 @@ static int acvp_mldsa_sigGenPreHashDeterministic_AFT(
     size_t ctxlen, const unsigned char sk[MLDSA_SK_BYTES], const char *hashAlg)
 {
   unsigned char signature[MLDSA_SIG_BYTES];
-  size_t siglen;
   unsigned char rnd[MLDSA_RNDBYTES] = {0}; /* Zero rnd for deterministic */
 
-  if (mld_sign_signature_pre_hash_internal(signature, &siglen, ph, phlen,
-                                           context, ctxlen, rnd, sk,
+  if (mld_sign_signature_pre_hash_internal(signature, ph, phlen, context,
+                                           ctxlen, rnd, sk,
                                            str_to_hash_alg(hashAlg)) != 0)
   {
     return 1;
   }
 
-  print_hex("signature", signature, siglen);
+  print_hex("signature", signature, MLDSA_SIG_BYTES);
   return 0;
 }
 
@@ -538,16 +526,15 @@ static int acvp_mldsa_sigGenPreHashShake256Deterministic_AFT(
     size_t ctxlen, const unsigned char sk[MLDSA_SK_BYTES])
 {
   unsigned char signature[MLDSA_SIG_BYTES];
-  size_t siglen;
   unsigned char rnd[MLDSA_RNDBYTES] = {0}; /* Zero rnd for deterministic */
 
-  if (mld_sign_signature_pre_hash_shake256(signature, &siglen, message, mlen,
-                                           context, ctxlen, rnd, sk) != 0)
+  if (mld_sign_signature_pre_hash_shake256(signature, message, mlen, context,
+                                           ctxlen, rnd, sk) != 0)
   {
     return 1;
   }
 
-  print_hex("signature", signature, siglen);
+  print_hex("signature", signature, MLDSA_SIG_BYTES);
   return 0;
 }
 #endif /* !MLD_CONFIG_NO_SIGN_API */

--- a/test/bench/bench_mldsa.c
+++ b/test/bench/bench_mldsa.c
@@ -99,7 +99,6 @@ static int bench(void)
   uint8_t m[MLEN];
   uint8_t ctx[CTXLEN];
   unsigned char sig_rand[MLDSA_SEEDBYTES];
-  size_t siglen;
   unsigned char pre[CTXLEN + 2];
   uint64_t cycles_sign[MLD_BENCHMARK_NTESTS];
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API */
@@ -150,14 +149,14 @@ static int bench(void)
 
       for (j = 0; j < MLD_BENCHMARK_NWARMUP; j++)
       {
-        ret |= mld_sign_signature_internal(sig, &siglen, m, MLEN, pre,
-                                           CTXLEN + 2, sig_rand, sk, 0);
+        ret |= mld_sign_signature_internal(sig, m, MLEN, pre, CTXLEN + 2,
+                                           sig_rand, sk, 0);
       }
       t0 = get_cyclecounter();
       for (j = 0; j < MLD_BENCHMARK_NITERATIONS; j++)
       {
-        ret |= mld_sign_signature_internal(sig, &siglen, m, MLEN, pre,
-                                           CTXLEN + 2, sig_rand, sk, 0);
+        ret |= mld_sign_signature_internal(sig, m, MLEN, pre, CTXLEN + 2,
+                                           sig_rand, sk, 0);
       }
       t1 = get_cyclecounter();
       cycles_sign[i] = t1 - t0;
@@ -174,12 +173,12 @@ static int bench(void)
       /* Verification */
       for (j = 0; j < MLD_BENCHMARK_NWARMUP; j++)
       {
-        ret |= mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+        ret |= mld_sign_verify(sig, m, MLEN, ctx, CTXLEN, pk);
       }
       t0 = get_cyclecounter();
       for (j = 0; j < MLD_BENCHMARK_NITERATIONS; j++)
       {
-        ret |= mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+        ret |= mld_sign_verify(sig, m, MLEN, ctx, CTXLEN, pk);
       }
       t1 = get_cyclecounter();
       cycles_verify[i] = t1 - t0;

--- a/test/src/gen_KAT.c
+++ b/test/src/gen_KAT.c
@@ -75,7 +75,6 @@ int main(void)
   uint8_t *m;
   /* empty ctx */
   uint8_t pre[2] = {0, 0};
-  size_t slen;
 
   const uint8_t seed[64] = {
       32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
@@ -110,12 +109,12 @@ int main(void)
     print_hex(pk, MLDSA_PK_BYTES);
     print_hex(sk, MLDSA_SK_BYTES);
 
-    CHECK(mld_sign_signature_internal(s, &slen, m, i, pre, sizeof(pre),
+    CHECK(mld_sign_signature_internal(s, m, i, pre, sizeof(pre),
                                       coins + MLDSA_SEEDBYTES, sk, 0) == 0);
 
-    print_hex(s, slen);
+    print_hex(s, MLDSA_SIG_BYTES);
 
-    rc = mld_sign_verify(s, slen, m, i, NULL, CTXLEN, pk);
+    rc = mld_sign_verify(s, m, i, NULL, CTXLEN, pk);
 
     if (rc)
     {

--- a/test/src/test_alloc.c
+++ b/test/src/test_alloc.c
@@ -366,13 +366,11 @@ static int test_pk_from_sk_alloc_failure(test_ctx_t *ctx)
 static int test_sign_alloc_failure(test_ctx_t *ctx)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
-
   TEST_ALLOC_FAILURE(
       "mld_signature",
-      mld_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
-                    TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
-                    TEST_VECTOR_CTX_LEN, test_vector_sk, ctx),
+      mld_signature(sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
+                    (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+                    test_vector_sk, ctx),
       MLD_TOTAL_ALLOC_SIGN, &ctx->global_high_mark_sign);
   return 0;
 }
@@ -381,10 +379,8 @@ static int test_signature_extmu_alloc_failure(test_ctx_t *ctx)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t mu[64] = {0};
-  size_t siglen;
-
   TEST_ALLOC_FAILURE("mld_signature_extmu",
-                     mld_signature_extmu(sig, &siglen, mu, test_vector_sk, ctx),
+                     mld_signature_extmu(sig, mu, test_vector_sk, ctx),
                      MLD_TOTAL_ALLOC_SIGN, &ctx->global_high_mark_sign);
   return 0;
 }
@@ -393,11 +389,9 @@ static int test_signature_pre_hash_shake256_alloc_failure(test_ctx_t *ctx)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t rnd[32] = {0};
-  size_t siglen;
-
   TEST_ALLOC_FAILURE("mld_signature_pre_hash_shake256",
                      mld_signature_pre_hash_shake256(
-                         sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+                         sig, (const uint8_t *)TEST_VECTOR_MSG,
                          TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                          TEST_VECTOR_CTX_LEN, rnd, test_vector_sk, ctx),
                      MLD_TOTAL_ALLOC_SIGN, &ctx->global_high_mark_sign);
@@ -410,10 +404,9 @@ static int test_verify_alloc_failure(test_ctx_t *ctx)
 {
   TEST_ALLOC_FAILURE(
       "mld_verify",
-      mld_verify(test_vector_sig, MLDSA_SIG_BYTES,
-                 (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                 (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                 test_vector_pk, ctx),
+      mld_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                 TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                 TEST_VECTOR_CTX_LEN, test_vector_pk, ctx),
       MLD_TOTAL_ALLOC_VERIFY, &ctx->global_high_mark_verify);
   return 0;
 }
@@ -423,21 +416,21 @@ static int test_verify_alloc_failure(test_ctx_t *ctx)
 static int test_verify_extmu_alloc_failure(test_ctx_t *ctx)
 {
   TEST_ALLOC_FAILURE("mld_verify_extmu",
-                     mld_verify_extmu(test_vector_sig_extmu, MLDSA_SIG_BYTES,
-                                      test_vector_mu, test_vector_pk, ctx),
+                     mld_verify_extmu(test_vector_sig_extmu, test_vector_mu,
+                                      test_vector_pk, ctx),
                      MLD_TOTAL_ALLOC_VERIFY, &ctx->global_high_mark_verify);
   return 0;
 }
 
 static int test_verify_pre_hash_shake256_alloc_failure(test_ctx_t *ctx)
 {
-  TEST_ALLOC_FAILURE("mld_verify_pre_hash_shake256",
-                     mld_verify_pre_hash_shake256(
-                         test_vector_sig_pre_hash_shake256, MLDSA_SIG_BYTES,
-                         (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                         (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                         test_vector_pk, ctx),
-                     MLD_TOTAL_ALLOC_VERIFY, &ctx->global_high_mark_verify);
+  TEST_ALLOC_FAILURE(
+      "mld_verify_pre_hash_shake256",
+      mld_verify_pre_hash_shake256(
+          test_vector_sig_pre_hash_shake256, (const uint8_t *)TEST_VECTOR_MSG,
+          TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+          TEST_VECTOR_CTX_LEN, test_vector_pk, ctx),
+      MLD_TOTAL_ALLOC_VERIFY, &ctx->global_high_mark_verify);
   return 0;
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -55,7 +55,6 @@ static int test_sign_core(uint8_t pk[MLDSA_PK_BYTES],
                           uint8_t sig[MLDSA_SIG_BYTES], uint8_t m[MLEN],
                           uint8_t ctx[CTXLEN])
 {
-  size_t siglen;
   int rc;
 
 
@@ -65,9 +64,9 @@ static int test_sign_core(uint8_t pk[MLDSA_PK_BYTES],
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, MLEN);
 
-  CHECK_SIGN_RC(mld_sign_signature(sig, &siglen, m, MLEN, ctx, CTXLEN, sk));
+  CHECK_SIGN_RC(mld_sign_signature(sig, m, MLEN, ctx, CTXLEN, sk));
 
-  rc = mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+  rc = mld_sign_verify(sig, m, MLEN, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -75,12 +74,6 @@ static int test_sign_core(uint8_t pk[MLDSA_PK_BYTES],
   if (rc)
   {
     printf("ERROR: verify\n");
-    return 1;
-  }
-
-  if (siglen != MLDSA_SIG_BYTES)
-  {
-    printf("ERROR: signature - wrong siglen\n");
     return 1;
   }
 
@@ -115,14 +108,13 @@ static int test_sign_extmu(void)
   uint8_t sk[MLDSA_SK_BYTES];
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t mu[MLDSA_CRHBYTES];
-  size_t siglen;
 
   CHECK(mld_sign_keypair(pk, sk) == 0);
   CHECK(randombytes(mu, MLDSA_CRHBYTES) == 0);
   MLD_CT_TESTING_SECRET(mu, sizeof(mu));
 
-  CHECK_SIGN_RC(mld_sign_signature_extmu(sig, &siglen, mu, sk));
-  CHECK(mld_sign_verify_extmu(sig, siglen, mu, pk) == 0);
+  CHECK_SIGN_RC(mld_sign_signature_extmu(sig, mu, sk));
+  CHECK(mld_sign_verify_extmu(sig, mu, pk) == 0);
 
   return 0;
 }
@@ -136,7 +128,6 @@ static int test_sign_pre_hash(void)
   uint8_t m[MLEN];
   uint8_t ctx[CTXLEN];
   uint8_t rnd[MLDSA_RNDBYTES];
-  size_t siglen;
 
 
   CHECK(mld_sign_keypair(pk, sk) == 0);
@@ -147,16 +138,14 @@ static int test_sign_pre_hash(void)
   CHECK(randombytes(rnd, MLDSA_RNDBYTES) == 0);
   MLD_CT_TESTING_SECRET(rnd, sizeof(rnd));
 
-  CHECK_SIGN_RC(mld_sign_signature_pre_hash_shake256(sig, &siglen, m, MLEN, ctx,
-                                                     CTXLEN, rnd, sk));
-  CHECK(mld_sign_verify_pre_hash_shake256(sig, siglen, m, MLEN, ctx, CTXLEN,
-                                          pk) == 0);
+  CHECK_SIGN_RC(
+      mld_sign_signature_pre_hash_shake256(sig, m, MLEN, ctx, CTXLEN, rnd, sk));
+  CHECK(mld_sign_verify_pre_hash_shake256(sig, m, MLEN, ctx, CTXLEN, pk) == 0);
 
   /* MLD_PREHASH_NONE must be rejected by the internal prehash APIs. */
-  CHECK(mld_sign_verify_pre_hash_internal(sig, siglen, m, MLEN, ctx, CTXLEN, pk,
+  CHECK(mld_sign_verify_pre_hash_internal(sig, m, MLEN, ctx, CTXLEN, pk,
                                           MLD_PREHASH_NONE) == MLD_ERR_FAIL);
-  CHECK(mld_sign_signature_pre_hash_internal(sig, &siglen, m, MLEN, ctx, CTXLEN,
-                                             rnd, sk,
+  CHECK(mld_sign_signature_pre_hash_internal(sig, m, MLEN, ctx, CTXLEN, rnd, sk,
                                              MLD_PREHASH_NONE) == MLD_ERR_FAIL);
 
   return 0;
@@ -234,7 +223,6 @@ static int test_wrong_pk(void)
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t m[MLEN];
   uint8_t ctx[CTXLEN];
-  size_t siglen;
   int rc;
   size_t idx;
 
@@ -244,7 +232,7 @@ static int test_wrong_pk(void)
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, sizeof(m));
 
-  CHECK_SIGN_RC(mld_sign_signature(sig, &siglen, m, MLEN, ctx, CTXLEN, sk));
+  CHECK_SIGN_RC(mld_sign_signature(sig, m, MLEN, ctx, CTXLEN, sk));
 
   /* flip bit in public key */
   CHECK(randombytes((uint8_t *)&idx, sizeof(size_t)) == 0);
@@ -252,7 +240,7 @@ static int test_wrong_pk(void)
 
   pk[idx] ^= 1;
 
-  rc = mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+  rc = mld_sign_verify(sig, m, MLEN, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -272,7 +260,6 @@ static int test_wrong_sig(void)
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t m[MLEN];
   uint8_t ctx[CTXLEN];
-  size_t siglen;
   int rc;
   size_t idx;
 
@@ -282,7 +269,7 @@ static int test_wrong_sig(void)
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, sizeof(m));
 
-  CHECK_SIGN_RC(mld_sign_signature(sig, &siglen, m, MLEN, ctx, CTXLEN, sk));
+  CHECK_SIGN_RC(mld_sign_signature(sig, m, MLEN, ctx, CTXLEN, sk));
 
   /* flip bit in signature */
   CHECK(randombytes((uint8_t *)&idx, sizeof(size_t)) == 0);
@@ -290,7 +277,7 @@ static int test_wrong_sig(void)
 
   sig[idx] ^= 1;
 
-  rc = mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+  rc = mld_sign_verify(sig, m, MLEN, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -311,7 +298,6 @@ static int test_wrong_ctx(void)
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t m[MLEN];
   uint8_t ctx[CTXLEN];
-  size_t siglen;
   int rc;
   size_t idx;
 
@@ -321,7 +307,7 @@ static int test_wrong_ctx(void)
   CHECK(randombytes(m, MLEN) == 0);
   MLD_CT_TESTING_SECRET(m, sizeof(m));
 
-  CHECK_SIGN_RC(mld_sign_signature(sig, &siglen, m, MLEN, ctx, CTXLEN, sk));
+  CHECK_SIGN_RC(mld_sign_signature(sig, m, MLEN, ctx, CTXLEN, sk));
 
   /* flip bit in ctx */
   CHECK(randombytes((uint8_t *)&idx, sizeof(size_t)) == 0);
@@ -329,7 +315,7 @@ static int test_wrong_ctx(void)
 
   ctx[idx] ^= 1;
 
-  rc = mld_sign_verify(sig, siglen, m, MLEN, ctx, CTXLEN, pk);
+  rc = mld_sign_verify(sig, m, MLEN, ctx, CTXLEN, pk);
 
   /* Constant time: Declassify outputs to check them. */
   MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
@@ -372,7 +358,6 @@ static int test_sign_expected_keypair(void)
 static int test_sign_expected_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
 
   /* WARNING: Test-only
    * Normally, you would seed a PRNG _once_ with trustworthy entropy
@@ -380,9 +365,8 @@ static int test_sign_expected_sign(void)
    * independent and reproducible. */
   randombytes_reset();
   CHECK_SIGN_RC(mld_sign_signature(
-      sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
+      sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN, test_vector_sk));
-  CHECK(siglen == MLDSA_SIG_BYTES);
   CHECK(memcmp(sig, test_vector_sig, MLDSA_SIG_BYTES) == 0);
 
   return 0;
@@ -392,10 +376,9 @@ static int test_sign_expected_sign(void)
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
 static int test_sign_expected_verify(void)
 {
-  CHECK(mld_sign_verify(test_vector_sig, MLDSA_SIG_BYTES,
-                        (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                        (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                        test_vector_pk) == 0);
+  CHECK(mld_sign_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                        TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                        TEST_VECTOR_CTX_LEN, test_vector_pk) == 0);
 
   return 0;
 }

--- a/test/src/test_rng_fail.c
+++ b/test/src/test_rng_fail.c
@@ -136,11 +136,9 @@ static int test_pk_from_sk_rng_failure(void)
 static int test_sign_rng_failure(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
-
   TEST_RNG_FAILURE(
       "signature",
-      mld_sign_signature(sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+      mld_sign_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                          TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                          TEST_VECTOR_CTX_LEN, test_vector_sk));
   return 0;
@@ -149,11 +147,10 @@ static int test_sign_rng_failure(void)
 static int test_signature_extmu_rng_failure(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  size_t siglen;
   uint8_t mu[64] = {0};
 
   TEST_RNG_FAILURE("signature_extmu",
-                   mld_sign_signature_extmu(sig, &siglen, mu, test_vector_sk));
+                   mld_sign_signature_extmu(sig, mu, test_vector_sk));
   return 0;
 }
 
@@ -161,11 +158,9 @@ static int test_signature_pre_hash_shake256_rng_failure(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
   uint8_t rnd[32] = {0};
-  size_t siglen;
-
   TEST_RNG_FAILURE("signature_pre_hash_shake256",
                    mld_sign_signature_pre_hash_shake256(
-                       sig, &siglen, (const uint8_t *)TEST_VECTOR_MSG,
+                       sig, (const uint8_t *)TEST_VECTOR_MSG,
                        TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                        TEST_VECTOR_CTX_LEN, rnd, test_vector_sk));
   return 0;
@@ -177,29 +172,28 @@ static int test_verify_rng_failure(void)
 {
   TEST_RNG_FAILURE(
       "verify",
-      mld_sign_verify(test_vector_sig, MLDSA_SIG_BYTES,
-                      (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                      (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                      test_vector_pk));
+      mld_sign_verify(test_vector_sig, (const uint8_t *)TEST_VECTOR_MSG,
+                      TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+                      TEST_VECTOR_CTX_LEN, test_vector_pk));
   return 0;
 }
 
 static int test_verify_extmu_rng_failure(void)
 {
   TEST_RNG_FAILURE("verify_extmu",
-                   mld_sign_verify_extmu(test_vector_sig_extmu, MLDSA_SIG_BYTES,
-                                         test_vector_mu, test_vector_pk));
+                   mld_sign_verify_extmu(test_vector_sig_extmu, test_vector_mu,
+                                         test_vector_pk));
   return 0;
 }
 
 static int test_verify_pre_hash_shake256_rng_failure(void)
 {
-  TEST_RNG_FAILURE("verify_pre_hash_shake256",
-                   mld_sign_verify_pre_hash_shake256(
-                       test_vector_sig_pre_hash_shake256, MLDSA_SIG_BYTES,
-                       (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-                       (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
-                       test_vector_pk));
+  TEST_RNG_FAILURE(
+      "verify_pre_hash_shake256",
+      mld_sign_verify_pre_hash_shake256(
+          test_vector_sig_pre_hash_shake256, (const uint8_t *)TEST_VECTOR_MSG,
+          TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
+          TEST_VECTOR_CTX_LEN, test_vector_pk));
   return 0;
 }
 #endif /* !MLD_CONFIG_NO_VERIFY_API */

--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -30,14 +30,13 @@ static void test_sign_only(void)
 #if !defined(MLD_CONFIG_NO_SIGN_API)
   unsigned char sk[MLDSA_SK_BYTES] = {0};
   unsigned char sig[MLDSA_SIG_BYTES];
-  size_t siglen;
   const unsigned char msg[] = "test message for stack measurement";
   const unsigned char ctx[] = "test context";
 
   /* Only call signature - this is what we're measuring */
   /* sk is zero-initialized (invalid key, but OK for stack measurement) */
-  int ret = mld_sign_signature(sig, &siglen, msg, sizeof(msg) - 1, ctx,
-                               sizeof(ctx) - 1, sk);
+  int ret =
+      mld_sign_signature(sig, msg, sizeof(msg) - 1, ctx, sizeof(ctx) - 1, sk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_SIGN_API */
   printf("sign test skipped (API disabled)\n");
@@ -54,8 +53,8 @@ static void test_verify_only(void)
 
   /* Only call verify - this is what we're measuring */
   /* pk and sig are zero-initialized (invalid, but OK for stack measurement) */
-  int ret = mld_sign_verify(sig, MLDSA_SIG_BYTES, msg, sizeof(msg) - 1, ctx,
-                            sizeof(ctx) - 1, pk);
+  int ret =
+      mld_sign_verify(sig, msg, sizeof(msg) - 1, ctx, sizeof(ctx) - 1, pk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_VERIFY_API */
   printf("verify test skipped (API disabled)\n");

--- a/test/wycheproof/wycheproof_mldsa.c
+++ b/test/wycheproof/wycheproof_mldsa.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
     unsigned char sig[MLDSA_SIG_BYTES];
     unsigned char pre[MAX_CTX_LENGTH + 2];
     unsigned char rnd[MLDSA_RNDBYTES] = {0};
-    size_t mlen, ctxlen, siglen;
+    size_t mlen, ctxlen;
     int externalMu;
 
     if (argc != 6)
@@ -210,8 +210,8 @@ int main(int argc, char *argv[])
 
     if (externalMu)
     {
-      CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0,
-                                        rnd, sk, 1) == 0);
+      CHECK(mld_sign_signature_internal(sig, message, mlen, NULL, 0, rnd, sk,
+                                        1) == 0);
     }
     else
     {
@@ -219,10 +219,10 @@ int main(int argc, char *argv[])
       /* Safety: Truncation is safe due to the check above. */
       pre[1] = (uint8_t)ctxlen;
       memcpy(pre + 2, context, ctxlen);
-      CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                        ctxlen + 2, rnd, sk, 0) == 0);
+      CHECK(mld_sign_signature_internal(sig, message, mlen, pre, ctxlen + 2,
+                                        rnd, sk, 0) == 0);
     }
-    print_hex("signature", sig, siglen);
+    print_hex("signature", sig, MLDSA_SIG_BYTES);
   }
   else
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API */
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
     unsigned char sig[MLDSA_SIG_BYTES];
     unsigned char pre[MAX_CTX_LENGTH + 2];
     unsigned char rnd[MLDSA_RNDBYTES] = {0};
-    size_t mlen, ctxlen, siglen;
+    size_t mlen, ctxlen;
 
     if (argc != 5)
     {
@@ -270,9 +270,9 @@ int main(int argc, char *argv[])
     pre[1] = (uint8_t)ctxlen;
     memcpy(pre + 2, context, ctxlen);
 
-    CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, pre,
-                                      ctxlen + 2, rnd, sk, 0) == 0);
-    print_hex("signature", sig, siglen);
+    CHECK(mld_sign_signature_internal(sig, message, mlen, pre, ctxlen + 2, rnd,
+                                      sk, 0) == 0);
+    print_hex("signature", sig, MLDSA_SIG_BYTES);
   }
   else if (strcmp(argv[1], "sigGenInternalDeterministic") == 0)
   {
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
     unsigned char sk[MLDSA_SK_BYTES];
     unsigned char sig[MLDSA_SIG_BYTES];
     unsigned char rnd[MLDSA_RNDBYTES] = {0};
-    size_t mlen, siglen;
+    size_t mlen;
     int externalMu;
 
     if (argc != 5)
@@ -317,9 +317,9 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    CHECK(mld_sign_signature_internal(sig, &siglen, message, mlen, NULL, 0, rnd,
-                                      sk, externalMu) == 0);
-    print_hex("signature", sig, siglen);
+    CHECK(mld_sign_signature_internal(sig, message, mlen, NULL, 0, rnd, sk,
+                                      externalMu) == 0);
+    print_hex("signature", sig, MLDSA_SIG_BYTES);
   }
   else
 #endif /* !MLD_CONFIG_NO_SIGN_API */
@@ -366,8 +366,7 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    return mld_sign_verify(signature, sizeof(signature), message, mlen, context,
-                           ctxlen, pk);
+    return mld_sign_verify(signature, message, mlen, context, ctxlen, pk);
   }
   else
 #endif /* !MLD_CONFIG_NO_VERIFY_API */


### PR DESCRIPTION
I would like initiate the discussion on the following breaking change to our API. Please share your thoughts if this change should be made prior to releasing v1.0.0. I have updated the AWS-LC, Pavona, and liboqs integrations (see the patches).

ML-DSA signatures have a fixed size, so siglen was redundant: an always-MLDSA_BYTES output for signing and an input used only for a fixed-size check on verification. Drop it from all signing and verification functions (internal, randomized, extmu, and pre-hash variants). Verification now takes the signature as a fixed-size array.


- Resolves #789 
