### PR TITLE
Clear ML-DSA outputs on signing failure

### DIFF
--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -391,14 +391,21 @@ cleanup:
   MLD_FREE(inbuf, uint8_t, MLDSA_SEEDBYTES + 2, context);
   MLD_FREE(seedbuf, uint8_t, 2 * MLDSA_SEEDBYTES + MLDSA_CRHBYTES, context);
 
-  if (ret != 0)
-  {
-    return ret;
-  }
-
   /* Pairwise Consistency Test (PCT) @[FIPS140_3_IG, p.87] */
   /* Do this after freeing all temporaries. */
-  return mld_check_pct(pk, sk, context);
+  if (ret == 0)
+  {
+    ret = mld_check_pct(pk, sk, context);
+  }
+
+  if (ret != 0)
+  {
+    /* Clear caller outputs on failure. */
+    mld_zeroize(pk, MLDSA_CRYPTO_PUBLICKEYBYTES);
+    mld_zeroize(sk, MLDSA_CRYPTO_SECRETKEYBYTES);
+  }
+
+  return ret;
 }
 
 #if !defined(MLD_CONFIG_CORE_API_ONLY)

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -1050,7 +1050,7 @@ cleanup:
   if (ret != 0)
   {
     /* To be on the safe-side, we zeroize the signature buffer. */
-    mld_memset(sig, 0, MLDSA_CRYPTO_BYTES);
+    mld_zeroize(sig, MLDSA_CRYPTO_BYTES);
   }
 
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
@@ -1111,9 +1111,9 @@ cleanup:
      * the case of error.
      *
      * If we come from mld_sign_signature_internal, this is redundant, but the
-     * error case should not be the norm, and the added cost of the memset
+     * error case should not be the norm, and the added cost of the zeroization
      * insignificant. */
-    mld_memset(sig, 0, MLDSA_CRYPTO_BYTES);
+    mld_zeroize(sig, MLDSA_CRYPTO_BYTES);
   }
 
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */
@@ -1370,9 +1370,9 @@ cleanup:
      * the case of error.
      *
      * If we come from mld_sign_signature_internal, this is redundant, but the
-     * error case should not be the norm, and the added cost of the memset
+     * error case should not be the norm, and the added cost of the zeroization
      * insignificant. */
-    mld_memset(sig, 0, MLDSA_CRYPTO_BYTES);
+    mld_zeroize(sig, MLDSA_CRYPTO_BYTES);
   }
 
   /* @[FIPS204, Section 3.6.3] Destruction of intermediate values. */


### PR DESCRIPTION
## Summary

- clear caller-visible ML-DSA keypair outputs when key generation fails
- clear signature and signed-message outputs, and reset output lengths, when
  signing fails
- add RNG/allocation/PCT failure regression test coverage for stale output
  buffers
- keep verify-only reduced-api allocation and RNG-failure tests buildable by
  compiling the zeroization helper only when keypair or signing tests are
  enabled

## Notes

The reduced-api verify-only configuration disables both keypair and sign APIs.
Those verify tests intentionally keep no-op output checks because verification
does not expose a caller-owned output buffer that needs zeroing. Without the
API guard, the shared zeroization helper was compiled but unused in that mode,
which fails under `-Werror=unused-function`.

## Testing

- `make run_rng_fail`
- `make run_alloc`
- `make run_unit`
- `make run_func`
- focused reduced-api alloc/rng-fail with ASan/UBSan flags
- focused reduced-api-reduce-ram alloc/rng-fail with ASan/UBSan flags
- `git diff --check`

Co-authored-by: Codex <codex@openai.com>
Signed-off-by: Joe Doyle <joseph.doyle@trailofbits.com>

This work was completed by Trail of Bits as part of the Patch The Planet
project in collaboration with OpenAI. The issue was identified primarily by
the Codex coding agent, and manually reviewed before submission.
