### PR TITLE
Enforce ML-DSA x86 native assumptions

### DIFF
--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -137,6 +137,7 @@ void mld_poly_caddq_avx2_asm(int32_t *r)
  * in proofs/hol_light/x86_64/proofs/poly_caddq_avx2_asm.ml */
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(array_abs_bound(r, 0, MLDSA_N, MLDSA_Q))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(array_bound(r, 0, MLDSA_N, 0, MLDSA_Q))
@@ -151,6 +152,8 @@ void mld_poly_use_hint_32_avx2_asm(int32_t *a, const int32_t *h)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(h, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
+  requires(((uintptr_t)h % MLD_DEFAULT_ALIGN) == 0)
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   requires(array_bound(h, 0, MLDSA_N, 0, 2))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
@@ -166,6 +169,8 @@ void mld_poly_use_hint_88_avx2_asm(int32_t *a, const int32_t *h)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(h, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
+  requires(((uintptr_t)h % MLD_DEFAULT_ALIGN) == 0)
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   requires(array_bound(h, 0, MLDSA_N, 0, 2))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
@@ -197,6 +202,7 @@ void mld_polyz_unpack_17_avx2_asm(int32_t *r, const uint8_t *a)
  * in proofs/hol_light/x86_64/proofs/polyz_unpack_17_avx2_asm.ml */
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(memory_no_alias(a, 576))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(array_bound(r, 0, MLDSA_N, -((1 << 17) - 1), (1 << 17) + 1))
@@ -209,6 +215,7 @@ void mld_polyz_unpack_19_avx2_asm(int32_t *r, const uint8_t *a)
  * in proofs/hol_light/x86_64/proofs/polyz_unpack_19_avx2_asm.ml */
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(memory_no_alias(a, 640))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(array_bound(r, 0, MLDSA_N, -((1 << 19) - 1), (1 << 19) + 1))

--- a/dev/x86_64/src/intt_avx2_asm.S
+++ b/dev/x86_64/src/intt_avx2_asm.S
@@ -43,9 +43,28 @@
 #include "../../../common.h"
 #if defined(MLD_ARITH_BACKEND_X86_64_DEFAULT) && \
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
-/* simpasm: header-end */
-
 #include "consts.h"
+
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
+.error "Update intt_avx2_asm.S qdata displacements for 8XQ"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV != 8
+.error "Update intt_avx2_asm.S qdata displacements for 8XQINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV_QINV != 16
+.error "Update intt_avx2_asm.S qdata displacements for 8XDIV_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV != 24
+.error "Update intt_avx2_asm.S qdata displacements for 8XDIV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS_QINV != 32
+.error "Update intt_avx2_asm.S qdata displacements for ZETAS_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
+.error "Update intt_avx2_asm.S qdata displacements for ZETAS"
+.endif
+
+/* simpasm: header-end */
 
 .macro shuffle8 r0, r1, r2, r3
 vperm2i128 $0x20,%ymm\r1,%ymm\r0,%ymm\r2

--- a/dev/x86_64/src/intt_avx2_asm.S
+++ b/dev/x86_64/src/intt_avx2_asm.S
@@ -45,6 +45,8 @@
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
 #include "consts.h"
 
+/* simpasm: header-end */
+
 .if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
 .error "Update intt_avx2_asm.S qdata displacements for 8XQ"
 .endif
@@ -63,8 +65,6 @@
 .if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
 .error "Update intt_avx2_asm.S qdata displacements for ZETAS"
 .endif
-
-/* simpasm: header-end */
 
 .macro shuffle8 r0, r1, r2, r3
 vperm2i128 $0x20,%ymm\r1,%ymm\r0,%ymm\r2

--- a/dev/x86_64/src/ntt_avx2_asm.S
+++ b/dev/x86_64/src/ntt_avx2_asm.S
@@ -43,9 +43,28 @@
 #include "../../../common.h"
 #if defined(MLD_ARITH_BACKEND_X86_64_DEFAULT) && \
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
-/* simpasm: header-end */
-
 #include "consts.h"
+
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
+.error "Update ntt_avx2_asm.S qdata displacements for 8XQ"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV != 8
+.error "Update ntt_avx2_asm.S qdata displacements for 8XQINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV_QINV != 16
+.error "Update ntt_avx2_asm.S qdata displacements for 8XDIV_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV != 24
+.error "Update ntt_avx2_asm.S qdata displacements for 8XDIV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS_QINV != 32
+.error "Update ntt_avx2_asm.S qdata displacements for ZETAS_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
+.error "Update ntt_avx2_asm.S qdata displacements for ZETAS"
+.endif
+
+/* simpasm: header-end */
 
 .macro shuffle8 r0, r1, r2, r3
 vperm2i128 $0x20,%ymm\r1,%ymm\r0,%ymm\r2

--- a/dev/x86_64/src/ntt_avx2_asm.S
+++ b/dev/x86_64/src/ntt_avx2_asm.S
@@ -45,6 +45,8 @@
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
 #include "consts.h"
 
+/* simpasm: header-end */
+
 .if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
 .error "Update ntt_avx2_asm.S qdata displacements for 8XQ"
 .endif
@@ -63,8 +65,6 @@
 .if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
 .error "Update ntt_avx2_asm.S qdata displacements for ZETAS"
 .endif
-
-/* simpasm: header-end */
 
 .macro shuffle8 r0, r1, r2, r3
 vperm2i128 $0x20,%ymm\r1,%ymm\r0,%ymm\r2

--- a/mldsa/src/native/api.h
+++ b/mldsa/src/native/api.h
@@ -334,12 +334,13 @@ __contract__(
 /**
  * For all coefficients of in/out polynomial add Q if coefficient is negative.
  *
- * @param[in,out] a Pointer to input/output polynomial.
+ * @param[in,out] a Pointer to 32-byte-aligned input/output polynomial.
  */
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
   requires(array_abs_bound(a, 0, MLDSA_N, MLDSA_Q))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
   ensures(return_value == MLD_NATIVE_FUNC_FALLBACK || return_value == MLD_NATIVE_FUNC_SUCCESS)
@@ -358,14 +359,16 @@ __contract__(
  *
  * Use hint h to correct the high bits of a in-place.
  *
- * @param[in,out] a Input/output polynomial.
- * @param[in]     h Hint polynomial.
+ * @param[in,out] a 32-byte-aligned input/output polynomial.
+ * @param[in]     h 32-byte-aligned hint polynomial.
  */
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(h, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
+  requires(((uintptr_t)h % MLD_DEFAULT_ALIGN) == 0)
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   requires(array_bound(h, 0, MLDSA_N, 0, 2))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
@@ -384,14 +387,16 @@ __contract__(
  *
  * Use hint h to correct the high bits of a in-place.
  *
- * @param[in,out] a Input/output polynomial.
- * @param[in]     h Hint polynomial.
+ * @param[in,out] a 32-byte-aligned input/output polynomial.
+ * @param[in]     h 32-byte-aligned hint polynomial.
  */
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(h, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
+  requires(((uintptr_t)h % MLD_DEFAULT_ALIGN) == 0)
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   requires(array_bound(h, 0, MLDSA_N, 0, 2))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
@@ -441,13 +446,14 @@ __contract__(
  * Unpack polynomial z with coefficients in
  * [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1].
  *
- * @param[out] r Pointer to output polynomial.
+ * @param[out] r Pointer to 32-byte-aligned output polynomial.
  * @param[in]  a Byte array with bit-packed polynomial.
  */
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(memory_no_alias(a, MLDSA_POLYZ_PACKEDBYTES))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(return_value == MLD_NATIVE_FUNC_FALLBACK || return_value == MLD_NATIVE_FUNC_SUCCESS)
@@ -467,13 +473,14 @@ __contract__(
  * Unpack polynomial z with coefficients in
  * [-(MLDSA_GAMMA1 - 1), MLDSA_GAMMA1].
  *
- * @param[out] r Pointer to output polynomial.
+ * @param[out] r Pointer to 32-byte-aligned output polynomial.
  * @param[in]  a Byte array with bit-packed polynomial.
  */
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *a)
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(memory_no_alias(a, MLDSA_POLYZ_PACKEDBYTES))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(return_value == MLD_NATIVE_FUNC_FALLBACK || return_value == MLD_NATIVE_FUNC_SUCCESS)

--- a/mldsa/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mldsa/src/native/x86_64/src/arith_native_x86_64.h
@@ -137,6 +137,7 @@ void mld_poly_caddq_avx2_asm(int32_t *r)
  * in proofs/hol_light/x86_64/proofs/poly_caddq_avx2_asm.ml */
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(array_abs_bound(r, 0, MLDSA_N, MLDSA_Q))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(array_bound(r, 0, MLDSA_N, 0, MLDSA_Q))
@@ -151,6 +152,8 @@ void mld_poly_use_hint_32_avx2_asm(int32_t *a, const int32_t *h)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(h, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
+  requires(((uintptr_t)h % MLD_DEFAULT_ALIGN) == 0)
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   requires(array_bound(h, 0, MLDSA_N, 0, 2))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
@@ -166,6 +169,8 @@ void mld_poly_use_hint_88_avx2_asm(int32_t *a, const int32_t *h)
 __contract__(
   requires(memory_no_alias(a, sizeof(int32_t) * MLDSA_N))
   requires(memory_no_alias(h, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)a % MLD_DEFAULT_ALIGN) == 0)
+  requires(((uintptr_t)h % MLD_DEFAULT_ALIGN) == 0)
   requires(array_bound(a, 0, MLDSA_N, 0, MLDSA_Q))
   requires(array_bound(h, 0, MLDSA_N, 0, 2))
   assigns(memory_slice(a, sizeof(int32_t) * MLDSA_N))
@@ -197,6 +202,7 @@ void mld_polyz_unpack_17_avx2_asm(int32_t *r, const uint8_t *a)
  * in proofs/hol_light/x86_64/proofs/polyz_unpack_17_avx2_asm.ml */
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(memory_no_alias(a, 576))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(array_bound(r, 0, MLDSA_N, -((1 << 17) - 1), (1 << 17) + 1))
@@ -209,6 +215,7 @@ void mld_polyz_unpack_19_avx2_asm(int32_t *r, const uint8_t *a)
  * in proofs/hol_light/x86_64/proofs/polyz_unpack_19_avx2_asm.ml */
 __contract__(
   requires(memory_no_alias(r, sizeof(int32_t) * MLDSA_N))
+  requires(((uintptr_t)r % MLD_DEFAULT_ALIGN) == 0)
   requires(memory_no_alias(a, 640))
   assigns(memory_slice(r, sizeof(int32_t) * MLDSA_N))
   ensures(array_bound(r, 0, MLDSA_N, -((1 << 19) - 1), (1 << 19) + 1))

--- a/mldsa/src/native/x86_64/src/intt_avx2_asm.S
+++ b/mldsa/src/native/x86_64/src/intt_avx2_asm.S
@@ -45,25 +45,6 @@
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
 #include "consts.h"
 
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
-.error "Update intt_avx2_asm.S qdata displacements for 8XQ"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV != 8
-.error "Update intt_avx2_asm.S qdata displacements for 8XQINV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV_QINV != 16
-.error "Update intt_avx2_asm.S qdata displacements for 8XDIV_QINV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV != 24
-.error "Update intt_avx2_asm.S qdata displacements for 8XDIV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS_QINV != 32
-.error "Update intt_avx2_asm.S qdata displacements for ZETAS_QINV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
-.error "Update intt_avx2_asm.S qdata displacements for ZETAS"
-.endif
-
 
 /*
  * WARNING: This file is auto-derived from the mldsa-native source file

--- a/mldsa/src/native/x86_64/src/intt_avx2_asm.S
+++ b/mldsa/src/native/x86_64/src/intt_avx2_asm.S
@@ -43,6 +43,27 @@
 #include "../../../common.h"
 #if defined(MLD_ARITH_BACKEND_X86_64_DEFAULT) && \
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
+#include "consts.h"
+
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
+.error "Update intt_avx2_asm.S qdata displacements for 8XQ"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV != 8
+.error "Update intt_avx2_asm.S qdata displacements for 8XQINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV_QINV != 16
+.error "Update intt_avx2_asm.S qdata displacements for 8XDIV_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV != 24
+.error "Update intt_avx2_asm.S qdata displacements for 8XDIV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS_QINV != 32
+.error "Update intt_avx2_asm.S qdata displacements for ZETAS_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
+.error "Update intt_avx2_asm.S qdata displacements for ZETAS"
+.endif
+
 
 /*
  * WARNING: This file is auto-derived from the mldsa-native source file

--- a/mldsa/src/native/x86_64/src/ntt_avx2_asm.S
+++ b/mldsa/src/native/x86_64/src/ntt_avx2_asm.S
@@ -43,6 +43,27 @@
 #include "../../../common.h"
 #if defined(MLD_ARITH_BACKEND_X86_64_DEFAULT) && \
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
+#include "consts.h"
+
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
+.error "Update ntt_avx2_asm.S qdata displacements for 8XQ"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV != 8
+.error "Update ntt_avx2_asm.S qdata displacements for 8XQINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV_QINV != 16
+.error "Update ntt_avx2_asm.S qdata displacements for 8XDIV_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV != 24
+.error "Update ntt_avx2_asm.S qdata displacements for 8XDIV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS_QINV != 32
+.error "Update ntt_avx2_asm.S qdata displacements for ZETAS_QINV"
+.endif
+.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
+.error "Update ntt_avx2_asm.S qdata displacements for ZETAS"
+.endif
+
 
 /*
  * WARNING: This file is auto-derived from the mldsa-native source file

--- a/mldsa/src/native/x86_64/src/ntt_avx2_asm.S
+++ b/mldsa/src/native/x86_64/src/ntt_avx2_asm.S
@@ -45,25 +45,6 @@
     !defined(MLD_CONFIG_MULTILEVEL_NO_SHARED)
 #include "consts.h"
 
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQ != 0
-.error "Update ntt_avx2_asm.S qdata displacements for 8XQ"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XQINV != 8
-.error "Update ntt_avx2_asm.S qdata displacements for 8XQINV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV_QINV != 16
-.error "Update ntt_avx2_asm.S qdata displacements for 8XDIV_QINV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_8XDIV != 24
-.error "Update ntt_avx2_asm.S qdata displacements for 8XDIV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS_QINV != 32
-.error "Update ntt_avx2_asm.S qdata displacements for ZETAS_QINV"
-.endif
-.if MLD_AVX2_BACKEND_DATA_OFFSET_ZETAS != 328
-.error "Update ntt_avx2_asm.S qdata displacements for ZETAS"
-.endif
-
 
 /*
  * WARNING: This file is auto-derived from the mldsa-native source file

--- a/proofs/hol_light/x86_64/mldsa/intt_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mldsa/intt_avx2_asm.S
@@ -41,6 +41,7 @@
 */
 
 
+
 /*
  * WARNING: This file is auto-derived from the mldsa-native source file
  *   dev/x86_64/src/intt_avx2_asm.S using scripts/simpasm. Do not modify it directly.

--- a/proofs/hol_light/x86_64/mldsa/ntt_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mldsa/ntt_avx2_asm.S
@@ -41,6 +41,7 @@
 */
 
 
+
 /*
  * WARNING: This file is auto-derived from the mldsa-native source file
  *   dev/x86_64/src/ntt_avx2_asm.S using scripts/simpasm. Do not modify it directly.


### PR DESCRIPTION
# Enforce ML-DSA x86 native assumptions

## Summary

- Add assembler-time guards that fail the AVX2 NTT/INTT assembly build if the qdata table offsets drift away from the hard-coded displacements.
- Strengthen the native API, dev-source declarations, and generated x86 implementation contracts for AVX2 polynomial routines that require 32-byte-aligned polynomial buffers.
- Keep the public native wrapper contracts, implementation declarations, and proof-facing assumptions aligned for `poly_caddq`, `poly_use_hint`, and `polyz_unpack`.

## Why

The x86_64 NTT/INTT assembly uses fixed qdata displacements after simplification. The dev source includes the symbolic layout, but the checked-in simplified assembly has numeric offsets; the new assembler guards make a future qdata layout mismatch fail at build time instead of silently preserving stale displacements.

Several AVX2 polynomial routines also use aligned loads or stores, and the HOL/CBMC proof assumptions already model aligned polynomial buffers. The in-tree typed callers pass `mld_poly` storage, which is declared with the project alignment attribute; this patch makes that precondition explicit at the native API and raw x86 contract boundary.

## Verification

- `./scripts/tests cbmc -kl ALL -p poly_use_hint_native --single-step -j1`
- `./scripts/tests cbmc -kl ALL -p poly_caddq_native_x86_64 --single-step -j1`
- `./scripts/tests cbmc -kl 44 -p polyz_unpack_native_x86_64 --single-step -j1`
- `./scripts/tests cbmc -kl 65 -p polyz_unpack_native_x86_64 --single-step -j1`
- `./scripts/tests cbmc -kl 87 -p polyz_unpack_native_x86_64 --single-step -j1`
- `./scripts/tests cbmc -kl ALL -p polyz_unpack_native --single-step -j1`

Co-authored-by: Codex <codex@openai.com>
Signed-off-by: Joe Doyle <joseph.doyle@trailofbits.com>

This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.
