### PR TITLE
Add Windows MSVC test support: rng_fail, alloc, wycheproof

### DIFF
--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -127,6 +127,21 @@ gen_KAT87: $(OBJ_FILES_87) $(MLDSA87_BUILD_DIR)\test\gen_KAT.obj $(BUILD_DIR)\ra
     @if NOT EXIST $(MLDSA87_BUILD_DIR)\bin mkdir $(MLDSA87_BUILD_DIR)\bin
     $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /Fe$(MLDSA87_BUILD_DIR)\bin\gen_KAT87 $** /link
 
+# compile RNG fail test for mldsa44
+test_rng_fail44: $(OBJ_FILES_44) $(MLDSA44_BUILD_DIR)\test\test_rng_fail.obj
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\bin mkdir $(MLDSA44_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /Fe$(MLDSA44_BUILD_DIR)\bin\test_rng_fail44 $** /link
+
+# compile RNG fail test for mldsa65
+test_rng_fail65: $(OBJ_FILES_65) $(MLDSA65_BUILD_DIR)\test\test_rng_fail.obj
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\bin mkdir $(MLDSA65_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /Fe$(MLDSA65_BUILD_DIR)\bin\test_rng_fail65 $** /link
+
+# compile RNG fail test for mldsa87
+test_rng_fail87: $(OBJ_FILES_87) $(MLDSA87_BUILD_DIR)\test\test_rng_fail.obj
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\bin mkdir $(MLDSA87_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /Fe$(MLDSA87_BUILD_DIR)\bin\test_rng_fail87 $** /link
+
 acvp: acvp_mldsa44 acvp_mldsa65 acvp_mldsa87
 
 gen_KAT: gen_KAT44 gen_KAT65 gen_KAT87
@@ -144,7 +159,12 @@ run_func: test_mldsa44 test_mldsa65 test_mldsa87
     $(MLDSA65_BUILD_DIR)\bin\test_mldsa65.exe
     $(MLDSA87_BUILD_DIR)\bin\test_mldsa87.exe
 
-test: run_func run_acvp run_kat
+run_rng_fail: test_rng_fail44 test_rng_fail65 test_rng_fail87
+    $(MLDSA44_BUILD_DIR)\bin\test_rng_fail44.exe
+    $(MLDSA65_BUILD_DIR)\bin\test_rng_fail65.exe
+    $(MLDSA87_BUILD_DIR)\bin\test_rng_fail87.exe
+
+test: run_func run_rng_fail run_acvp run_kat
     @echo   Everything checks fine!
 
 quickcheck: test

--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -132,6 +132,21 @@ OPT = 0
     @if NOT EXIST $(MLDSA87_BUILD_DIR)\test\acvp mkdir $(MLDSA87_BUILD_DIR)\test\acvp
     $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /c /Fo$(MLDSA87_BUILD_DIR)\test\acvp\ $<
 
+# compilation of wycheproof test for mldsa44
+{test\wycheproof}.c{$(MLDSA44_BUILD_DIR)\test\wycheproof}.obj::
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\test\wycheproof mkdir $(MLDSA44_BUILD_DIR)\test\wycheproof
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /c /Fo$(MLDSA44_BUILD_DIR)\test\wycheproof\ $<
+
+# compilation of wycheproof test for mldsa65
+{test\wycheproof}.c{$(MLDSA65_BUILD_DIR)\test\wycheproof}.obj::
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\test\wycheproof mkdir $(MLDSA65_BUILD_DIR)\test\wycheproof
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /c /Fo$(MLDSA65_BUILD_DIR)\test\wycheproof\ $<
+
+# compilation of wycheproof test for mldsa87
+{test\wycheproof}.c{$(MLDSA87_BUILD_DIR)\test\wycheproof}.obj::
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\test\wycheproof mkdir $(MLDSA87_BUILD_DIR)\test\wycheproof
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /c /Fo$(MLDSA87_BUILD_DIR)\test\wycheproof\ $<
+
 # compile functional test for mldsa44
 test_mldsa44: $(OBJ_FILES_44) $(MLDSA44_BUILD_DIR)\test\test_mldsa.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
     @if NOT EXIST $(MLDSA44_BUILD_DIR)\bin mkdir $(MLDSA44_BUILD_DIR)\bin
@@ -207,7 +222,24 @@ test_alloc87: $(OBJ_FILES_87_ALLOC) $(MLDSA87_BUILD_DIR)\test\alloc\test_alloc.o
     @if NOT EXIST $(MLDSA87_BUILD_DIR)\bin mkdir $(MLDSA87_BUILD_DIR)\bin
     $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /Fe$(MLDSA87_BUILD_DIR)\bin\test_alloc87 $** /link
 
+# compile wycheproof test for mldsa44
+wycheproof_mldsa44: $(OBJ_FILES_44) $(MLDSA44_BUILD_DIR)\test\wycheproof\wycheproof_mldsa.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\bin mkdir $(MLDSA44_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /Fe$(MLDSA44_BUILD_DIR)\bin\wycheproof_mldsa44 $** /link
+
+# compile wycheproof test for mldsa65
+wycheproof_mldsa65: $(OBJ_FILES_65) $(MLDSA65_BUILD_DIR)\test\wycheproof\wycheproof_mldsa.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\bin mkdir $(MLDSA65_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /Fe$(MLDSA65_BUILD_DIR)\bin\wycheproof_mldsa65 $** /link
+
+# compile wycheproof test for mldsa87
+wycheproof_mldsa87: $(OBJ_FILES_87) $(MLDSA87_BUILD_DIR)\test\wycheproof\wycheproof_mldsa.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\bin mkdir $(MLDSA87_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /Fe$(MLDSA87_BUILD_DIR)\bin\wycheproof_mldsa87 $** /link
+
 acvp: acvp_mldsa44 acvp_mldsa65 acvp_mldsa87
+
+wycheproof: wycheproof_mldsa44 wycheproof_mldsa65 wycheproof_mldsa87
 
 gen_KAT: gen_KAT44 gen_KAT65 gen_KAT87
 
@@ -218,6 +250,9 @@ run_kat: gen_KAT
 
 run_acvp: acvp
     python test/acvp/acvp_client.py
+
+run_wycheproof: wycheproof
+    python test/wycheproof/wycheproof_client.py
 
 run_func: test_mldsa44 test_mldsa65 test_mldsa87
     $(MLDSA44_BUILD_DIR)\bin\test_mldsa44.exe
@@ -234,7 +269,7 @@ run_alloc: test_alloc44 test_alloc65 test_alloc87
     $(MLDSA65_BUILD_DIR)\bin\test_alloc65.exe
     $(MLDSA87_BUILD_DIR)\bin\test_alloc87.exe
 
-test: run_func run_rng_fail run_alloc run_acvp run_kat
+test: run_func run_rng_fail run_alloc run_acvp run_kat run_wycheproof
     @echo   Everything checks fine!
 
 quickcheck: test

--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 
 CFLAGS = /nologo /O2 /Imldsa /Imldsa/src /Imldsa/src/fips202 /Imldsa/src/fips202/native /Imldsa/src/native
 
+ALLOC_CFLAGS = \
+    $(CFLAGS) \
+    /D MLD_CONFIG_FILE="\"../test/configs/test_alloc_config.h\""
+
 OBJ_FILES = .\mldsa\*.obj \
             .\mldsa\fips202\*.obj
 
@@ -18,6 +22,13 @@ OBJ_FILES_65 = $(MLDSA65_BUILD_DIR)\mldsa\*.obj \
                 $(MLDSA65_BUILD_DIR)\mldsa\fips202\*.obj
 OBJ_FILES_87 = $(MLDSA87_BUILD_DIR)\mldsa\*.obj \
                  $(MLDSA87_BUILD_DIR)\mldsa\fips202\*.obj
+
+OBJ_FILES_44_ALLOC = $(MLDSA44_BUILD_DIR)\alloc\mldsa\*.obj \
+                     $(MLDSA44_BUILD_DIR)\alloc\mldsa\fips202\*.obj
+OBJ_FILES_65_ALLOC = $(MLDSA65_BUILD_DIR)\alloc\mldsa\*.obj \
+                     $(MLDSA65_BUILD_DIR)\alloc\mldsa\fips202\*.obj
+OBJ_FILES_87_ALLOC = $(MLDSA87_BUILD_DIR)\alloc\mldsa\*.obj \
+                     $(MLDSA87_BUILD_DIR)\alloc\mldsa\fips202\*.obj
 
 # NOTE: We currently only build code for non-opt code, as we haven't yet made the assembly compatible on Windows
 !IFNDEF OPT
@@ -66,6 +77,45 @@ OPT = 0
 {test\src}.c{$(MLDSA87_BUILD_DIR)\test}.obj::
     @if NOT EXIST $(MLDSA87_BUILD_DIR)\test mkdir $(MLDSA87_BUILD_DIR)\test
     $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /c /Fo$(MLDSA87_BUILD_DIR)\test\ $<
+
+# compilation for mldsa44 alloc test
+{mldsa\src}.c{$(MLDSA44_BUILD_DIR)\alloc\mldsa}.obj::
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\alloc\mldsa mkdir $(MLDSA44_BUILD_DIR)\alloc\mldsa
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /c /Fo$(MLDSA44_BUILD_DIR)\alloc\mldsa\ $<
+
+{mldsa\src\fips202}.c{$(MLDSA44_BUILD_DIR)\alloc\mldsa\fips202}.obj::
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\alloc\mldsa\fips202 mkdir $(MLDSA44_BUILD_DIR)\alloc\mldsa\fips202
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /c /Fo$(MLDSA44_BUILD_DIR)\alloc\mldsa\fips202\ $<
+
+{test\src}.c{$(MLDSA44_BUILD_DIR)\test\alloc}.obj::
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\test\alloc mkdir $(MLDSA44_BUILD_DIR)\test\alloc
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /c /Fo$(MLDSA44_BUILD_DIR)\test\alloc\ $<
+
+# compilation for mldsa65 alloc test
+{mldsa\src}.c{$(MLDSA65_BUILD_DIR)\alloc\mldsa}.obj::
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\alloc\mldsa mkdir $(MLDSA65_BUILD_DIR)\alloc\mldsa
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /c /Fo$(MLDSA65_BUILD_DIR)\alloc\mldsa\ $<
+
+{mldsa\src\fips202}.c{$(MLDSA65_BUILD_DIR)\alloc\mldsa\fips202}.obj::
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\alloc\mldsa\fips202 mkdir $(MLDSA65_BUILD_DIR)\alloc\mldsa\fips202
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /c /Fo$(MLDSA65_BUILD_DIR)\alloc\mldsa\fips202\ $<
+
+{test\src}.c{$(MLDSA65_BUILD_DIR)\test\alloc}.obj::
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\test\alloc mkdir $(MLDSA65_BUILD_DIR)\test\alloc
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /c /Fo$(MLDSA65_BUILD_DIR)\test\alloc\ $<
+
+# compilation for mldsa87 alloc test
+{mldsa\src}.c{$(MLDSA87_BUILD_DIR)\alloc\mldsa}.obj::
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\alloc\mldsa mkdir $(MLDSA87_BUILD_DIR)\alloc\mldsa
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /c /Fo$(MLDSA87_BUILD_DIR)\alloc\mldsa\ $<
+
+{mldsa\src\fips202}.c{$(MLDSA87_BUILD_DIR)\alloc\mldsa\fips202}.obj::
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\alloc\mldsa\fips202 mkdir $(MLDSA87_BUILD_DIR)\alloc\mldsa\fips202
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /c /Fo$(MLDSA87_BUILD_DIR)\alloc\mldsa\fips202\ $<
+
+{test\src}.c{$(MLDSA87_BUILD_DIR)\test\alloc}.obj::
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\test\alloc mkdir $(MLDSA87_BUILD_DIR)\test\alloc
+    $(CC) $(ALLOC_CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /c /Fo$(MLDSA87_BUILD_DIR)\test\alloc\ $<
 
 # compilation of acvp test for mldsa44
 {test\acvp}.c{$(MLDSA44_BUILD_DIR)\test\acvp}.obj::
@@ -142,6 +192,21 @@ test_rng_fail87: $(OBJ_FILES_87) $(MLDSA87_BUILD_DIR)\test\test_rng_fail.obj
     @if NOT EXIST $(MLDSA87_BUILD_DIR)\bin mkdir $(MLDSA87_BUILD_DIR)\bin
     $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /Fe$(MLDSA87_BUILD_DIR)\bin\test_rng_fail87 $** /link
 
+# compile alloc test for mldsa44
+test_alloc44: $(OBJ_FILES_44_ALLOC) $(MLDSA44_BUILD_DIR)\test\alloc\test_alloc.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLDSA44_BUILD_DIR)\bin mkdir $(MLDSA44_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=44 /Fe$(MLDSA44_BUILD_DIR)\bin\test_alloc44 $** /link
+
+# compile alloc test for mldsa65
+test_alloc65: $(OBJ_FILES_65_ALLOC) $(MLDSA65_BUILD_DIR)\test\alloc\test_alloc.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLDSA65_BUILD_DIR)\bin mkdir $(MLDSA65_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=65 /Fe$(MLDSA65_BUILD_DIR)\bin\test_alloc65 $** /link
+
+# compile alloc test for mldsa87
+test_alloc87: $(OBJ_FILES_87_ALLOC) $(MLDSA87_BUILD_DIR)\test\alloc\test_alloc.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLDSA87_BUILD_DIR)\bin mkdir $(MLDSA87_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLD_CONFIG_PARAMETER_SET=87 /Fe$(MLDSA87_BUILD_DIR)\bin\test_alloc87 $** /link
+
 acvp: acvp_mldsa44 acvp_mldsa65 acvp_mldsa87
 
 gen_KAT: gen_KAT44 gen_KAT65 gen_KAT87
@@ -164,7 +229,12 @@ run_rng_fail: test_rng_fail44 test_rng_fail65 test_rng_fail87
     $(MLDSA65_BUILD_DIR)\bin\test_rng_fail65.exe
     $(MLDSA87_BUILD_DIR)\bin\test_rng_fail87.exe
 
-test: run_func run_rng_fail run_acvp run_kat
+run_alloc: test_alloc44 test_alloc65 test_alloc87
+    $(MLDSA44_BUILD_DIR)\bin\test_alloc44.exe
+    $(MLDSA65_BUILD_DIR)\bin\test_alloc65.exe
+    $(MLDSA87_BUILD_DIR)\bin\test_alloc87.exe
+
+test: run_func run_rng_fail run_alloc run_acvp run_kat
     @echo   Everything checks fine!
 
 quickcheck: test


### PR DESCRIPTION
- Ported from: https://github.com/pq-code-package/mlkem-native/pull/1738

mldsa-native already runs tests on Windows via Mingw-w64, but the MSVC/nmake build only covers the functional tests. This PR closes the remaining gap by porting the following tests to Makefile.Microsoft_nmake from mlkem-native PR [#1738](https://github.com/pq-code-package/mlkem-native/pull/1738), against the portable C backend:

- rng_fail: link rules added.
- alloc: added test/src/test_alloc.c and test/configs/test_alloc_config.h, referencing the Linux Makefile. Needs to rebuild the .obj files since it uses a different config from the default functional test. A new ALLOC_CFLAGS macro keeps the build rules short.
- wycheproof: test obj building rules and link rules added.
Unit tests are intentionally omitted from this PR and can be added later once native backend support becomes available on Windows.