### PR TITLE
bench: Add Graviton5 (c9g) to EC2 benchmark matrix

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -139,6 +139,13 @@ jobs:
             cflags: "-flto -DMLD_FORCE_AARCH64"
             ldflags: "-flto"
             perf: PERF
+          - name: Graviton5
+            ec2_instance_type: c9g.medium
+            ec2_ami: ubuntu-latest (aarch64)
+            archflags: -march=armv9-a+sha3
+            cflags: "-flto -DMLD_FORCE_AARCH64"
+            ldflags: "-flto"
+            perf: PERF
           - name: AMD EPYC 4th gen (c7a)
             ec2_instance_type: c7a.medium
             ec2_ami: ubuntu-latest (x86_64)


### PR DESCRIPTION
bench: Add Graviton5 (c9g) to EC2 benchmark matrix

Adds a c9g.medium row to the ec2_all matrix in bench.yml so
benchmarks also run on Neoverse V3 / Graviton5, alongside the existing
Graviton2/3/4 entries. Configuration mirrors Graviton4 (aarch64 AMI,
armv9-a+sha3, -flto, PERF).

- Resolves #1251