### PR TITLE
CI: Add merge queue support

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches: ["main"]
     types: [ "opened", "synchronize" ]
+  merge_group:
 
 jobs:
   base:
@@ -124,3 +125,14 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/isabelle.yml
     secrets: inherit
+  # Single required status check for branch protection and the merge queue; jobs added to this workflow must also be added to the needs list below to gate merges.
+  # riscv excluded as the RISE runners tend to be flaky.
+  ci-summary:
+    name: CI Summary
+    if: always()
+    needs: [ base, lint-markdown, nix, ci, cbmc, oqs_integration, awslc_integration, ct-test, slothy, baremetal, pavona_integration, isabelle ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -6,8 +6,6 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
     types: [ "opened", "synchronize" ]

--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -1,0 +1,21 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# The DCO app (https://github.com/apps/dco) does not report a status on
+# merge_group events (dcoapp/app#199), which would leave queued PRs stuck
+# waiting for the required "DCO" check. This workflow reports it for merge
+# groups instead. DCO enforcement is not weakened: a PR can only enter the
+# merge queue once the real DCO check has passed on the PR, and the queue
+# merges exactly those commits.
+
+name: DCO
+permissions:
+  contents: read
+on:
+  merge_group:
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "DCO is checked on the pull request before it enters the merge queue."

--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -5,22 +5,6 @@ name: HOL-Light
 permissions:
   contents: read
 on:
-  push:
-    branches: ["main"]
-    paths:
-     - '.github/workflows/hol_light.yml'
-     - 'proofs/hol_light/common/**/*.ml'
-     - 'proofs/hol_light/aarch64/Makefile'
-     - 'proofs/hol_light/aarch64/**/*.S'
-     - 'proofs/hol_light/aarch64/**/*.ml'
-     - 'proofs/hol_light/common/**/*.ml'
-     - 'proofs/hol_light/x86_64/Makefile'
-     - 'proofs/hol_light/x86_64/**/*.S'
-     - 'proofs/hol_light/x86_64/**/*.ml'
-     - 'flake.nix'
-     - 'flake.lock'
-     - 'nix/hol_light/*'
-     - 'nix/s2n_bignum/*'
   pull_request:
     branches: ["main"]
     paths:

--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -37,6 +37,9 @@ on:
       - 'flake.lock'
       - 'nix/hol_light/*'
       - 'nix/s2n_bignum/*'
+  # No path filtering (unsupported for merge_group); the proof jobs skip
+  # themselves via their changed-files check.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nix_cache.yml
+++ b/.github/workflows/nix_cache.yml
@@ -1,0 +1,22 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# The nix caches are only refreshed from main, and CI does not run on
+# pushes to main as merges are already tested in the merge queue.
+
+name: Nix cache
+permissions:
+  contents: read
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  nix:
+    name: Nix
+    permissions:
+      actions: 'write'
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/nix.yml
+    secrets: inherit


### PR DESCRIPTION
Run CI on merge_group events and add a "CI Summary" gate job intended as the single required status check. Add a workflow reporting the "DCO" check on merge groups since the DCO app does not support them (dcoapp/app#199); DCO is still enforced on the PR before it can enter the queue. Also run the HOL-Light proofs (self-gated by their changed-files check) and the legacy compiler tests on merge groups.