### PR TITLE
Fix double level-suffixing of default namespace in multi-level builds

### DIFF
--- a/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
@@ -748,7 +748,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/basic_lowram/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_lowram/mldsa_native/mldsa_native_config.h
@@ -750,7 +750,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
@@ -748,7 +748,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
@@ -749,7 +749,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/custom_backend/mldsa_native/mldsa_native_config.h
+++ b/examples/custom_backend/mldsa_native/mldsa_native_config.h
@@ -744,7 +744,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/monolithic_build/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build/mldsa_native/mldsa_native_config.h
@@ -747,7 +747,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
@@ -748,7 +748,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
@@ -754,7 +754,11 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
@@ -747,7 +747,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/multilevel_build/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build/mldsa_native/mldsa_native_config.h
@@ -747,7 +747,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
@@ -745,7 +745,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/mldsa/mldsa_native_config.h
+++ b/mldsa/mldsa_native_config.h
@@ -732,7 +732,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/proofs/cbmc/mldsa_native_config_cbmc.h
+++ b/proofs/cbmc/mldsa_native_config_cbmc.h
@@ -746,7 +746,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -752,7 +752,11 @@ static MLD_INLINE int mld_break_pct(void)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -765,7 +765,11 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -755,7 +755,11 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -754,7 +754,11 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -754,7 +754,11 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -753,7 +753,11 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -785,7 +785,11 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -772,7 +772,11 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -747,7 +747,11 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -763,7 +763,11 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -748,7 +748,11 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/low_signing_bound_config.h
+++ b/test/configs/low_signing_bound_config.h
@@ -750,7 +750,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -749,7 +749,11 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -747,7 +747,11 @@
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -755,7 +755,11 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * e.g., PQCP_MLDSA_NATIVE_MLDSA44_
  */
 
-#if MLD_CONFIG_PARAMETER_SET == 44
+#if defined(MLD_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA
+#elif MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA44
 #elif MLD_CONFIG_PARAMETER_SET == 65
 #define MLD_DEFAULT_NAMESPACE_PREFIX PQCP_MLDSA_NATIVE_MLDSA65


### PR DESCRIPTION
The default namespace prefix embeds the parameter set (PQCP_MLDSA_NATIVE_MLDSA44/65/87), which is correct for single-level builds but wrong in a multi-level build: the config is processed once (at the 44 level) and the namespacing machinery appends the parameter set again, yielding PQCP_MLDSA_NATIVE_MLDSA44{44,65,87}_. Use a level-independent default (PQCP_MLDSA_NATIVE_MLDSA) when MLD_CONFIG_MULTILEVEL_BUILD is set so the level is appended exactly once. Single-level builds are unchanged.

- Fixes #1266 