### PR TITLE
Fetch ACVP/Wycheproof vectors via authenticated GitHub API

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -121,6 +121,8 @@ runs:
           EOF
       - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.EXAMPLES }}, ${{ env.STACK }}, ${{ env.UNIT }}, ${{ env.ALLOC }}, ${{ env.RNGFAIL }})
         shell: ${{ env.SHELL }}
+        env:
+          GH_TOKEN: ${{ inputs.gh_token }}
         run: |
           make clean
           ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.WYCHEPROOF }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.RNGFAIL }} -v ${{ inputs.extra_args }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -46,6 +46,8 @@ jobs:
              }}
     name: Quickcheck (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: make quickcheck
@@ -80,6 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run ACVP test
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/tests acvp --version ${{ matrix.acvp-version }}
   quickcheck_bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,8 @@ jobs:
   check_test_vectors:
     runs-on: ubuntu-latest
     name: Check test vectors
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-shell

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -14,6 +14,8 @@ import os
 import json
 import sys
 import subprocess
+import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -22,9 +24,34 @@ exec_prefix = os.environ.get("EXEC_WRAPPER", "")
 exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
 
+def download_file(url, dest, token):
+    """Fetch url to dest via the authenticated contents API, retrying on 429/403.
+
+    Using api.github.com with a token raises the rate limit (per-user, not
+    per-IP), which avoids throttling when many CI jobs share an egress IP.
+    """
+    headers = {"Accept": "application/vnd.github.raw"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    for attempt in range(5):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req) as resp:
+                dest.write_bytes(resp.read())
+            return
+        except urllib.error.HTTPError as e:
+            if e.code not in (429, 403) or attempt == 4:
+                raise
+            wait = min(int(e.headers.get("Retry-After") or 2**attempt), 60)
+            print(f"Rate-limited ({e.code}); retrying in {wait}s", file=sys.stderr)
+            time.sleep(wait)
+
+
 def download_acvp_files(version):
     """Download ACVP test files for the specified version if not present."""
-    base_url = f"https://raw.githubusercontent.com/usnistgov/ACVP-Server/{version}/gen-val/json-files"
+    api_base = (
+        "https://api.github.com/repos/usnistgov/ACVP-Server/contents/gen-val/json-files"
+    )
 
     # Files we need to download for ML-KEM
     files_to_download = [
@@ -40,15 +67,17 @@ def download_acvp_files(version):
     data_dir = Path(f"test/acvp/.acvp-data/{version}/files")
     data_dir.mkdir(parents=True, exist_ok=True)
 
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    auth = "authenticated" if token else "anonymous"
     for file_path in files_to_download:
         local_file = data_dir / file_path
         local_file.parent.mkdir(parents=True, exist_ok=True)
 
         if not local_file.exists():
-            url = f"{base_url}/{file_path}"
-            print(f"Downloading {file_path}...", file=sys.stderr)
+            url = f"{api_base}/{file_path}?ref={version}"
+            print(f"Downloading {file_path} ({auth})...", file=sys.stderr)
             try:
-                urllib.request.urlretrieve(url, local_file)
+                download_file(url, local_file, token)
                 # Verify the file is valid JSON
                 with open(local_file, "r") as f:
                     json.load(f)

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -11,6 +11,8 @@ import os
 import json
 import sys
 import subprocess
+import time
+import urllib.error
 import urllib.request
 from enum import Enum, auto
 from pathlib import Path
@@ -20,7 +22,9 @@ exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
 # Pinned to a specific commit (2026-06-04).
 WYCHEPROOF_COMMIT = "4f5e05f71e6b724c20e2c1b6934c7bd7ef6d89e7"
-WYCHEPROOF_BASE_URL = f"https://raw.githubusercontent.com/C2SP/wycheproof/{WYCHEPROOF_COMMIT}/testvectors_v1"
+WYCHEPROOF_BASE_URL = (
+    "https://api.github.com/repos/C2SP/wycheproof/contents/testvectors_v1"
+)
 
 WYCHEPROOF_FILES = [
     "mldsa_44_sign_seed_test.json",
@@ -59,18 +63,43 @@ def info(msg, **kwargs):
     print(msg, **kwargs)
 
 
+def download_file(url, dest, token):
+    """Fetch url to dest via the authenticated contents API, retrying on 429/403.
+
+    Using api.github.com with a token raises the rate limit (per-user, not
+    per-IP), which avoids throttling when many CI jobs share an egress IP.
+    """
+    headers = {"Accept": "application/vnd.github.raw"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    for attempt in range(5):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req) as resp:
+                dest.write_bytes(resp.read())
+            return
+        except urllib.error.HTTPError as e:
+            if e.code not in (429, 403) or attempt == 4:
+                raise
+            wait = min(int(e.headers.get("Retry-After") or 2**attempt), 60)
+            print(f"Rate-limited ({e.code}); retrying in {wait}s", file=sys.stderr)
+            time.sleep(wait)
+
+
 def download_wycheproof_files(data_dir):
     """Download Wycheproof test vector files if not present."""
     data_dir = Path(data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)
 
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    auth = "authenticated" if token else "anonymous"
     for filename in WYCHEPROOF_FILES:
         local_file = data_dir / filename
         if not local_file.exists():
-            url = f"{WYCHEPROOF_BASE_URL}/{filename}"
-            print(f"Downloading {filename}...", file=sys.stderr)
+            url = f"{WYCHEPROOF_BASE_URL}/{filename}?ref={WYCHEPROOF_COMMIT}"
+            print(f"Downloading {filename} ({auth})...", file=sys.stderr)
             try:
-                urllib.request.urlretrieve(url, local_file)
+                download_file(url, local_file, token)
                 with open(local_file, "r", encoding="utf-8") as f:
                     json.load(f)
             except (json.JSONDecodeError, Exception) as e:


### PR DESCRIPTION
Download test vectors from the api.github.com contents endpoint with a GH_TOKEN and retry on 429/403, replacing unauthenticated raw.githubusercontent requests that were hitting rate limits frequently.