### PR TITLE
CI: Authenticate GitHub API requests in more test-running jobs

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -139,4 +139,6 @@ runs:
     - name: Dependency check
       shell: ${{ env.SHELL }}
       if: inputs.script != ''
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
       run: eval ${{ inputs.script }}

--- a/.github/actions/setup-shell/action.yml
+++ b/.github/actions/setup-shell/action.yml
@@ -44,6 +44,8 @@ runs:
     - name: Set custom shell
       shell: bash
       if: ${{ inputs.nix-shell == '' }}
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
       run: |
           echo SHELL="${{ inputs.custom_shell }}" >> $GITHUB_ENV
 

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -152,6 +152,8 @@ jobs:
              }}
     name: Quickcheck C90 (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: make quickcheck
@@ -176,6 +178,8 @@ jobs:
         system: [windows-2025, windows-2022]
     name: Quickcheck ${{ matrix.system }}
     runs-on: ${{ matrix.system }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -193,6 +197,8 @@ jobs:
         mingw-version: [5.4.0, 13.2.0, 14.2.0, 15.2.0]
     name: Quickcheck (Mingw-w64 ${{ matrix.mingw-version }})
     runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install MinGW-w64
@@ -318,6 +324,8 @@ jobs:
            name: 'x86_64'
     name: scan-build (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-apt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,8 @@ jobs:
              }}
     name: Check API consistency
     runs-on: ${{ matrix.target.runner }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: make quickcheck
@@ -603,6 +605,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       ${{ matrix.container.id }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # We're not using the checkout action here because on it's not supported
       # on all containers we want to test. Resort to a manual checkout.

--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -189,6 +189,8 @@ jobs:
           sudo: ""
       - name: make quickcheck
         if: ${{ inputs.quickcheck }}
+        env:
+          GH_TOKEN: ${{ secrets.AWS_GITHUB_TOKEN }}
         run: |
           OPT=0 make quickcheck
           make clean            >/dev/null

--- a/.github/workflows/legacy-compilers.yml
+++ b/.github/workflows/legacy-compilers.yml
@@ -499,6 +499,8 @@ jobs:
          - "14.2.0"
          - "15.2.0"
     runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install MinGW-w64

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -14,6 +14,8 @@ jobs:
     if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
     # via https://riseproject-dev.github.io/riscv-runner/
     runs-on: ubuntu-24.04-riscv
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: make quickcheck

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -25,7 +25,7 @@ exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
 
 def download_file(url, dest, token):
-    """Fetch url to dest via the authenticated contents API, retrying on 429/403.
+    """Fetch url to dest via the authenticated contents API, retrying on failure.
 
     Using api.github.com with a token raises the rate limit (per-user, not
     per-IP), which avoids throttling when many CI jobs share an egress IP.
@@ -39,11 +39,13 @@ def download_file(url, dest, token):
             with urllib.request.urlopen(req) as resp:
                 dest.write_bytes(resp.read())
             return
-        except urllib.error.HTTPError as e:
-            if e.code not in (429, 403) or attempt == 4:
+        except Exception as e:
+            if attempt == 4:
                 raise
-            wait = min(int(e.headers.get("Retry-After") or 2**attempt), 60)
-            print(f"Rate-limited ({e.code}); retrying in {wait}s", file=sys.stderr)
+            wait = 2**attempt
+            if isinstance(e, urllib.error.HTTPError):
+                wait = min(int(e.headers.get("Retry-After") or wait), 60)
+            print(f"Download failed ({e}); retrying in {wait}s", file=sys.stderr)
             time.sleep(wait)
 
 

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -64,7 +64,7 @@ def info(msg, **kwargs):
 
 
 def download_file(url, dest, token):
-    """Fetch url to dest via the authenticated contents API, retrying on 429/403.
+    """Fetch url to dest via the authenticated contents API, retrying on failure.
 
     Using api.github.com with a token raises the rate limit (per-user, not
     per-IP), which avoids throttling when many CI jobs share an egress IP.
@@ -78,11 +78,13 @@ def download_file(url, dest, token):
             with urllib.request.urlopen(req) as resp:
                 dest.write_bytes(resp.read())
             return
-        except urllib.error.HTTPError as e:
-            if e.code not in (429, 403) or attempt == 4:
+        except Exception as e:
+            if attempt == 4:
                 raise
-            wait = min(int(e.headers.get("Retry-After") or 2**attempt), 60)
-            print(f"Rate-limited ({e.code}); retrying in {wait}s", file=sys.stderr)
+            wait = 2**attempt
+            if isinstance(e, urllib.error.HTTPError):
+                wait = min(int(e.headers.get("Retry-After") or wait), 60)
+            print(f"Download failed ({e}); retrying in {wait}s", file=sys.stderr)
             time.sleep(wait)
 
 


### PR DESCRIPTION
- Follow up to #1275 

Jobs running make quickcheck or scripts/tests download ACVP and Wycheproof test vectors from the GitHub API. Several jobs ran these downloads unauthenticated and intermittently failed with HTTP 403 rate-limit errors on the shared runner IPs.

This commit adds the authentication token to more jobs.