### PR TITLE
AWS-LC: Patch capability enum to include X86_64 prefix

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/integration-awslc.yml
     with:
-      commit: v5.0.0
+      commit: v5.1.0
     secrets: inherit
   ct-test:
     name: Constant-time

--- a/integration/aws-lc/post_import.patch
+++ b/integration/aws-lc/post_import.patch
@@ -19,6 +19,81 @@ diff --git a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h b/crypto/fipsmodule/
    {
      return CRYPTO_is_AVX2_capable();
    }
+diff --git a/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h b/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h
+--- a/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h
++++ b/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h
+@@ -37,7 +37,7 @@
+ 
+ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
+ {
+-  if (mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     mld_nttunpack_avx2_asm(data);
+   }
+@@ -46,7 +46,7 @@ static MLD_INLINE void mld_poly_permute_bitrev_to_custom(int32_t data[MLDSA_N])
+ MLD_MUST_CHECK_RETURN_VALUE
+ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
+@@ -57,7 +57,7 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
+ MLD_MUST_CHECK_RETURN_VALUE
+ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
+@@ -68,7 +68,7 @@ static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
+ MLD_MUST_CHECK_RETURN_VALUE
+ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
+@@ -80,7 +80,7 @@ MLD_MUST_CHECK_RETURN_VALUE
+ static MLD_INLINE int mld_poly_pointwise_montgomery_native(
+     int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
+@@ -93,7 +93,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
+     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
+     const int32_t v[4][MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
+@@ -106,7 +106,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
+     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
+     const int32_t v[5][MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
+@@ -119,7 +119,7 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
+     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
+     const int32_t v[7][MLDSA_N])
+ {
+-  if (!mld_sys_check_capability(MLD_SYS_CAP_AVX2))
++  if (!mld_sys_check_capability(MLD_SYS_CAP_X86_64_AVX2))
+   {
+     return MLD_NATIVE_FUNC_FALLBACK;
+   }
 diff --git a/crypto/fipsmodule/ml_dsa/ml_dsa.c b/crypto/fipsmodule/ml_dsa/ml_dsa.c
 index f6b8342..2ac93f7 100644
 --- a/crypto/fipsmodule/ml_dsa/ml_dsa.c


### PR DESCRIPTION
AWS-LC commit 340c501fd10a added a hand-maintained mldsa_x86_64_meta.h that is using the old mld_sys_check_capability enum entries without the X86_64 prefix add in
https://github.com/pq-code-package/mldsa-native/pull/1208. This caused our tests against the AWS-LC main branch to fail.

This commit updates the regular CI to test against AWS-LC v5.1.0 (which includes the change), and adjusts the AWS-LC integration patches to adjust the capability names accordingly.

- Resolves #1282