### PR TITLE
CI: Gate merges on HOL-Light proofs

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -123,12 +123,18 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/isabelle.yml
     secrets: inherit
+  hol-light:
+    name: HOL-Light
+    permissions:
+      contents: 'read'
+    uses: ./.github/workflows/hol_light.yml
+    secrets: inherit
   # Single required status check for branch protection and the merge queue; jobs added to this workflow must also be added to the needs list below to gate merges.
   # riscv excluded as the RISE runners tend to be flaky.
   ci-summary:
     name: CI Summary
     if: always()
-    needs: [ base, lint-markdown, nix, ci, cbmc, oqs_integration, awslc_integration, ct-test, slothy, baremetal, pavona_integration, isabelle ]
+    needs: [ base, lint-markdown, nix, ci, cbmc, oqs_integration, awslc_integration, ct-test, slothy, baremetal, pavona_integration, isabelle, hol-light ]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any job failed or was cancelled

--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -5,38 +5,47 @@ name: HOL-Light
 permissions:
   contents: read
 on:
-  pull_request:
-    branches: ["main"]
-    paths:
-      - '.github/workflows/hol_light.yml'
-      - 'proofs/hol_light/common/**/*.ml'
-      - 'proofs/hol_light/aarch64/Makefile'
-      - 'proofs/hol_light/aarch64/**/*.S'
-      - 'proofs/hol_light/aarch64/**/*.ml'
-      - 'proofs/hol_light/common/**/*.ml'
-      - 'proofs/hol_light/x86_64/Makefile'
-      - 'proofs/hol_light/x86_64/**/*.S'
-      - 'proofs/hol_light/x86_64/**/*.ml'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'nix/hol_light/*'
-      - 'nix/s2n_bignum/*'
-  # No path filtering (unsupported for merge_group); the proof jobs skip
-  # themselves via their changed-files check.
-  merge_group:
+  workflow_call:
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: hol-light-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Coarse gate so the proof runners only start when relevant files changed.
+  # The owner/fork guard lives here, so on forks all downstream jobs skip too.
+  check_modified_files:
+    name: Determine changed files
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    outputs:
+      run_needed: ${{ steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
+      - name: Get changed files
+        id: changed-files
+        if: github.event_name != 'workflow_dispatch'
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            .github/workflows/hol_light.yml
+            proofs/hol_light/**
+            flake.nix
+            flake.lock
+            nix/**
   # The proofs also check that the byte code is up to date,
   # but we use this as a fast path to not even start the proofs
   # if the byte code needs updating.
   hol_light_bytecode:
     name: AArch64 HOL-Light bytecode check
     runs-on: ubuntu-24.04-arm
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    needs: [ check_modified_files ]
+    if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-shell
@@ -48,8 +57,8 @@ jobs:
   hol_light_interactive:
     name: AArch64 HOL-Light interactive shell test
     runs-on: ubuntu-24.04-arm
-    needs: [ hol_light_bytecode ]
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    needs: [ check_modified_files, hol_light_bytecode ]
+    if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-shell
@@ -60,7 +69,7 @@ jobs:
             make -C proofs/hol_light/aarch64 mldsa/poly_caddq_aarch64_asm.o
             echo 'needs "aarch64/proofs/poly_caddq_aarch64_asm.ml";;' | hol.sh
   hol_light_proofs:
-    needs: [ hol_light_bytecode ]
+    needs: [ check_modified_files, hol_light_bytecode ]
     strategy:
       fail-fast: false
       matrix:
@@ -112,7 +121,7 @@ jobs:
             needs: ["mldsa_specs.ml", "aarch64_utils.ml", "mldsa_rej_uniform_table.ml"]
     name: AArch64 HOL Light proof for ${{ matrix.proof.name }}.S
     runs-on: ubuntu-24.04-arm
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -156,7 +165,8 @@ jobs:
   hol_light_bytecode_x86_64:
     name: x86_64 HOL-Light bytecode check
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    needs: [ check_modified_files ]
+    if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-shell
@@ -168,8 +178,8 @@ jobs:
   hol_light_interactive_x86_64:
     name: x86_64 HOL-Light interactive shell test
     runs-on: ubuntu-latest
-    needs: [ hol_light_bytecode_x86_64 ]
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    needs: [ check_modified_files, hol_light_bytecode_x86_64 ]
+    if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-shell
@@ -182,7 +192,7 @@ jobs:
             # echo 'needs "x86_64/proofs/ntt_avx2_asm.ml";;' | hol.sh
             echo 'needs "x86/proofs/base.ml";; needs "common/mldsa_specs.ml";; #quit;;' | hol.sh
   hol_light_proofs_x86_64:
-    needs: [ hol_light_bytecode_x86_64 ]
+    needs: [ check_modified_files, hol_light_bytecode_x86_64 ]
     strategy:
       fail-fast: false
       matrix:
@@ -222,7 +232,7 @@ jobs:
             needs: ["keccak_utils.ml", "keccak_spec.ml", "keccak_f1600_x4_avx2_constants.ml", "keccak_constants.ml"]
     name: x86_64 HOL Light proof for ${{ matrix.proof.name }}.S
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # mldsa-native
 
 ![CI](https://github.com/pq-code-package/mldsa-native/actions/workflows/all.yml/badge.svg)
-![Proof: HOL-Light](https://github.com/pq-code-package/mldsa-native/actions/workflows/hol_light.yml/badge.svg)
 ![Benchmarks](https://github.com/pq-code-package/mldsa-native/actions/workflows/bench.yml/badge.svg)
 ![C90](https://img.shields.io/badge/language-C90-blue.svg)
 


### PR DESCRIPTION
Fold the HOL-Light proofs into the CI Summary gate so the merge queue waits for them. hol_light.yml becomes a reusable workflow called by all.yml and added to ci-summary's needs; a coarse check_modified_files job keeps unrelated PRs from spinning up proof runners while still reporting the gate. Drop the now-stale standalone HOL-Light README badge.

 - Resolves https://github.com/pq-code-package/mldsa-native/issues/1281