### PR TITLE
aarch64: Use array parameters consistently in asm backend

### DIFF
--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -61,8 +61,8 @@ MLD_INTERNAL_DATA_DECLARATION const uint8_t mld_polyz_unpack_19_indices[64];
 #define MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN (2 * 136)
 
 #define mld_ntt_aarch64_asm MLD_NAMESPACE(ntt_aarch64_asm)
-void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456,
-                         const int32_t *zetas_l78)
+void mld_ntt_aarch64_asm(int32_t r[MLDSA_N], const int32_t zetas_l123456[144],
+                         const int32_t zetas_l78[384])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/ntt_aarch64_asm.ml */
 __contract__(
@@ -78,8 +78,8 @@ __contract__(
 );
 
 #define mld_intt_aarch64_asm MLD_NAMESPACE(intt_aarch64_asm)
-void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78,
-                          const int32_t *zetas_l123456)
+void mld_intt_aarch64_asm(int32_t r[MLDSA_N], const int32_t zetas_l78[384],
+                          const int32_t zetas_l123456[160])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/intt_aarch64_asm.ml */
 __contract__(
@@ -95,8 +95,8 @@ __contract__(
 
 #define mld_rej_uniform_aarch64_asm MLD_NAMESPACE(rej_uniform_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_aarch64_asm(int32_t r[MLDSA_N], const uint8_t *buf,
+                                     unsigned buflen, const uint8_t table[256])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_aarch64_asm.ml. */
 __contract__(
@@ -113,8 +113,9 @@ __contract__(
 #define mld_rej_uniform_eta2_aarch64_asm \
   MLD_NAMESPACE(rej_uniform_eta2_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                          unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[MLDSA_N],
+                                          const uint8_t *buf, unsigned buflen,
+                                          const uint8_t table[4096])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_eta2_aarch64_asm.ml */
 __contract__(
@@ -132,8 +133,9 @@ __contract__(
 #define mld_rej_uniform_eta4_aarch64_asm \
   MLD_NAMESPACE(rej_uniform_eta4_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                          unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[MLDSA_N],
+                                          const uint8_t *buf, unsigned buflen,
+                                          const uint8_t table[4096])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_eta4_aarch64_asm.ml */
 __contract__(
@@ -152,7 +154,7 @@ __contract__(
 #if !defined(MLD_CONFIG_NO_SIGN_API)
 #define mld_poly_decompose_32_aarch64_asm \
   MLD_NAMESPACE(poly_decompose_32_aarch64_asm)
-void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+void mld_poly_decompose_32_aarch64_asm(int32_t a1[MLDSA_N], int32_t a0[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_decompose_32_aarch64_asm.ml */
 __contract__(
@@ -169,7 +171,7 @@ __contract__(
 
 #define mld_poly_decompose_88_aarch64_asm \
   MLD_NAMESPACE(poly_decompose_88_aarch64_asm)
-void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+void mld_poly_decompose_88_aarch64_asm(int32_t a1[MLDSA_N], int32_t a0[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_decompose_88_aarch64_asm.ml */
 __contract__(
@@ -186,7 +188,7 @@ __contract__(
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 
 #define mld_poly_caddq_aarch64_asm MLD_NAMESPACE(poly_caddq_aarch64_asm)
-void mld_poly_caddq_aarch64_asm(int32_t *a)
+void mld_poly_caddq_aarch64_asm(int32_t a[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_caddq_aarch64_asm.ml */
 __contract__(
@@ -199,7 +201,8 @@ __contract__(
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
 #define mld_poly_use_hint_32_aarch64_asm \
   MLD_NAMESPACE(poly_use_hint_32_aarch64_asm)
-void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+void mld_poly_use_hint_32_aarch64_asm(int32_t a[MLDSA_N],
+                                      const int32_t h[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml */
 __contract__(
@@ -213,7 +216,8 @@ __contract__(
 
 #define mld_poly_use_hint_88_aarch64_asm \
   MLD_NAMESPACE(poly_use_hint_88_aarch64_asm)
-void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+void mld_poly_use_hint_88_aarch64_asm(int32_t a[MLDSA_N],
+                                      const int32_t h[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_use_hint_88_aarch64_asm.ml */
 __contract__(
@@ -228,7 +232,7 @@ __contract__(
 
 #define mld_poly_chknorm_aarch64_asm MLD_NAMESPACE(poly_chknorm_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+int mld_poly_chknorm_aarch64_asm(const int32_t a[MLDSA_N], int32_t B)
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_chknorm_aarch64_asm.ml */
 __contract__(
@@ -243,8 +247,8 @@ __contract__(
 #if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 #define mld_polyz_unpack_17_aarch64_asm \
   MLD_NAMESPACE(polyz_unpack_17_aarch64_asm)
-void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices)
+void mld_polyz_unpack_17_aarch64_asm(int32_t r[MLDSA_N], const uint8_t buf[576],
+                                     const uint8_t indices[64])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/polyz_unpack_17_aarch64_asm.ml */
 __contract__(
@@ -261,8 +265,8 @@ __contract__(
     (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 #define mld_polyz_unpack_19_aarch64_asm \
   MLD_NAMESPACE(polyz_unpack_19_aarch64_asm)
-void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices)
+void mld_polyz_unpack_19_aarch64_asm(int32_t r[MLDSA_N], const uint8_t buf[640],
+                                     const uint8_t indices[64])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/polyz_unpack_19_aarch64_asm.ml */
 __contract__(
@@ -280,7 +284,8 @@ __contract__(
     defined(MLD_CONFIG_REDUCE_RAM) || defined(MLD_UNIT_TEST)
 #define mld_poly_pointwise_montgomery_aarch64_asm \
   MLD_NAMESPACE(poly_pointwise_montgomery_aarch64_asm)
-void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[MLDSA_N],
+                                               const int32_t b[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/pointwise_montgomery_aarch64_asm.ml */
 __contract__(
@@ -301,7 +306,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(
-    int32_t *r, const int32_t a[4][MLDSA_N], const int32_t b[4][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[4][MLDSA_N],
+    const int32_t b[4][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.ml
@@ -320,7 +326,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(
-    int32_t *r, const int32_t a[5][MLDSA_N], const int32_t b[5][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[5][MLDSA_N],
+    const int32_t b[5][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.ml
@@ -339,7 +346,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(
-    int32_t *r, const int32_t a[7][MLDSA_N], const int32_t b[7][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[7][MLDSA_N],
+    const int32_t b[7][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.ml

--- a/dev/aarch64_clean/src/intt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/intt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: intt_aarch64_asm
   Description: AArch64 ML-DSA inverse NTT
-  Signature: void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78, const int32_t *zetas_l123456)
+  Signature: void mld_intt_aarch64_asm(int32_t r[256], const int32_t zetas_l78[384], const int32_t zetas_l123456[160])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
     x2:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[160]
       description: Twiddle factors for layers 1-6 (160 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l4_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-4 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t *r, const int32_t a[4][256], const int32_t b[4][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t r[256], const int32_t a[4][256], const int32_t b[4][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l5_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-5 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t *r, const int32_t a[5][256], const int32_t b[5][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t r[256], const int32_t a[5][256], const int32_t b[5][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l7_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-7 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t *r, const int32_t a[7][256], const int32_t b[7][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t r[256], const int32_t a[7][256], const int32_t b[7][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/dev/aarch64_clean/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/ntt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: ntt_aarch64_asm
   Description: AArch64 ML-DSA forward NTT
-  Signature: void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456, const int32_t *zetas_l78)
+  Signature: void mld_ntt_aarch64_asm(int32_t r[256], const int32_t zetas_l123456[144], const int32_t zetas_l78[384])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[144]
       description: Twiddle factors for layers 1-6 (144 x int32_t)
     x2:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/pointwise_montgomery_aarch64_asm.S
+++ b/dev/aarch64_clean/src/pointwise_montgomery_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_pointwise_montgomery_aarch64_asm
   Description: AArch64 pointwise Montgomery multiplication of two polynomials
-  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[256], const int32_t b[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *b
+      c_parameter: const int32_t b[256]
       description: Input polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/poly_caddq_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_caddq_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_caddq_aarch64_asm
   Description: AArch64 conditional addition of q to each coefficient
-  Signature: void mld_poly_caddq_aarch64_asm(int32_t *a)
+  Signature: void mld_poly_caddq_aarch64_asm(int32_t a[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/poly_chknorm_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_chknorm_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_chknorm_aarch64_asm
   Description: AArch64 infinity-norm bound check on polynomial coefficients
-  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t a[256], int32_t B)
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *a
+      c_parameter: const int32_t a[256]
       description: Input polynomial (256 x int32_t)
     x1:
       type: scalar

--- a/dev/aarch64_clean/src/poly_decompose_32_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_32_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/32)
-  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/poly_decompose_88_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_88_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/88)
-  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/poly_use_hint_32_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_use_hint_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_32_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/32)
-  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/poly_use_hint_88_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_use_hint_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_88_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/88)
-  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_clean/src/polyz_unpack_17_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_17_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_17_aarch64_asm
   Description: AArch64 unpacking of 17-bit packed coefficients
-  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t r[256], const uint8_t buf[576], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[576]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/dev/aarch64_clean/src/polyz_unpack_19_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_19_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_19_aarch64_asm
   Description: AArch64 unpacking of 19-bit packed coefficients
-  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t r[256], const uint8_t buf[640], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[640]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_aarch64_asm
   Description: AArch64 rejection sampling of uniform coefficients mod q
-  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 256
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[256]
       description: Lookup table (256 x uint8_t)
 */
 

--- a/dev/aarch64_clean/src/rej_uniform_eta2_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_eta2_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta2_aarch64_asm
   Description: AArch64 rejection sampling of eta=2 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/dev/aarch64_clean/src/rej_uniform_eta4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_eta4_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta4_aarch64_asm
   Description: AArch64 rejection sampling of eta=4 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -61,8 +61,8 @@ MLD_INTERNAL_DATA_DECLARATION const uint8_t mld_polyz_unpack_19_indices[64];
 #define MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN (2 * 136)
 
 #define mld_ntt_aarch64_asm MLD_NAMESPACE(ntt_aarch64_asm)
-void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456,
-                         const int32_t *zetas_l78)
+void mld_ntt_aarch64_asm(int32_t r[MLDSA_N], const int32_t zetas_l123456[144],
+                         const int32_t zetas_l78[384])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/ntt_aarch64_asm.ml */
 __contract__(
@@ -78,8 +78,8 @@ __contract__(
 );
 
 #define mld_intt_aarch64_asm MLD_NAMESPACE(intt_aarch64_asm)
-void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78,
-                          const int32_t *zetas_l123456)
+void mld_intt_aarch64_asm(int32_t r[MLDSA_N], const int32_t zetas_l78[384],
+                          const int32_t zetas_l123456[160])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/intt_aarch64_asm.ml */
 __contract__(
@@ -95,8 +95,8 @@ __contract__(
 
 #define mld_rej_uniform_aarch64_asm MLD_NAMESPACE(rej_uniform_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_aarch64_asm(int32_t r[MLDSA_N], const uint8_t *buf,
+                                     unsigned buflen, const uint8_t table[256])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_aarch64_asm.ml. */
 __contract__(
@@ -113,8 +113,9 @@ __contract__(
 #define mld_rej_uniform_eta2_aarch64_asm \
   MLD_NAMESPACE(rej_uniform_eta2_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                          unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[MLDSA_N],
+                                          const uint8_t *buf, unsigned buflen,
+                                          const uint8_t table[4096])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_eta2_aarch64_asm.ml */
 __contract__(
@@ -132,8 +133,9 @@ __contract__(
 #define mld_rej_uniform_eta4_aarch64_asm \
   MLD_NAMESPACE(rej_uniform_eta4_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                          unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[MLDSA_N],
+                                          const uint8_t *buf, unsigned buflen,
+                                          const uint8_t table[4096])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_eta4_aarch64_asm.ml */
 __contract__(
@@ -152,7 +154,7 @@ __contract__(
 #if !defined(MLD_CONFIG_NO_SIGN_API)
 #define mld_poly_decompose_32_aarch64_asm \
   MLD_NAMESPACE(poly_decompose_32_aarch64_asm)
-void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+void mld_poly_decompose_32_aarch64_asm(int32_t a1[MLDSA_N], int32_t a0[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_decompose_32_aarch64_asm.ml */
 __contract__(
@@ -169,7 +171,7 @@ __contract__(
 
 #define mld_poly_decompose_88_aarch64_asm \
   MLD_NAMESPACE(poly_decompose_88_aarch64_asm)
-void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+void mld_poly_decompose_88_aarch64_asm(int32_t a1[MLDSA_N], int32_t a0[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_decompose_88_aarch64_asm.ml */
 __contract__(
@@ -186,7 +188,7 @@ __contract__(
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 
 #define mld_poly_caddq_aarch64_asm MLD_NAMESPACE(poly_caddq_aarch64_asm)
-void mld_poly_caddq_aarch64_asm(int32_t *a)
+void mld_poly_caddq_aarch64_asm(int32_t a[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_caddq_aarch64_asm.ml */
 __contract__(
@@ -199,7 +201,8 @@ __contract__(
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
 #define mld_poly_use_hint_32_aarch64_asm \
   MLD_NAMESPACE(poly_use_hint_32_aarch64_asm)
-void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+void mld_poly_use_hint_32_aarch64_asm(int32_t a[MLDSA_N],
+                                      const int32_t h[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml */
 __contract__(
@@ -213,7 +216,8 @@ __contract__(
 
 #define mld_poly_use_hint_88_aarch64_asm \
   MLD_NAMESPACE(poly_use_hint_88_aarch64_asm)
-void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+void mld_poly_use_hint_88_aarch64_asm(int32_t a[MLDSA_N],
+                                      const int32_t h[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_use_hint_88_aarch64_asm.ml */
 __contract__(
@@ -228,7 +232,7 @@ __contract__(
 
 #define mld_poly_chknorm_aarch64_asm MLD_NAMESPACE(poly_chknorm_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+int mld_poly_chknorm_aarch64_asm(const int32_t a[MLDSA_N], int32_t B)
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_chknorm_aarch64_asm.ml */
 __contract__(
@@ -243,8 +247,8 @@ __contract__(
 #if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 #define mld_polyz_unpack_17_aarch64_asm \
   MLD_NAMESPACE(polyz_unpack_17_aarch64_asm)
-void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices)
+void mld_polyz_unpack_17_aarch64_asm(int32_t r[MLDSA_N], const uint8_t buf[576],
+                                     const uint8_t indices[64])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/polyz_unpack_17_aarch64_asm.ml */
 __contract__(
@@ -261,8 +265,8 @@ __contract__(
     (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 #define mld_polyz_unpack_19_aarch64_asm \
   MLD_NAMESPACE(polyz_unpack_19_aarch64_asm)
-void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices)
+void mld_polyz_unpack_19_aarch64_asm(int32_t r[MLDSA_N], const uint8_t buf[640],
+                                     const uint8_t indices[64])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/polyz_unpack_19_aarch64_asm.ml */
 __contract__(
@@ -280,7 +284,8 @@ __contract__(
     defined(MLD_CONFIG_REDUCE_RAM) || defined(MLD_UNIT_TEST)
 #define mld_poly_pointwise_montgomery_aarch64_asm \
   MLD_NAMESPACE(poly_pointwise_montgomery_aarch64_asm)
-void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[MLDSA_N],
+                                               const int32_t b[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/pointwise_montgomery_aarch64_asm.ml */
 __contract__(
@@ -301,7 +306,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(
-    int32_t *r, const int32_t a[4][MLDSA_N], const int32_t b[4][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[4][MLDSA_N],
+    const int32_t b[4][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.ml
@@ -320,7 +326,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(
-    int32_t *r, const int32_t a[5][MLDSA_N], const int32_t b[5][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[5][MLDSA_N],
+    const int32_t b[5][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.ml
@@ -339,7 +346,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(
-    int32_t *r, const int32_t a[7][MLDSA_N], const int32_t b[7][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[7][MLDSA_N],
+    const int32_t b[7][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.ml

--- a/dev/aarch64_opt/src/intt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/intt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: intt_aarch64_asm
   Description: AArch64 ML-DSA inverse NTT
-  Signature: void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78, const int32_t *zetas_l123456)
+  Signature: void mld_intt_aarch64_asm(int32_t r[256], const int32_t zetas_l78[384], const int32_t zetas_l123456[160])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
     x2:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[160]
       description: Twiddle factors for layers 1-6 (160 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l4_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-4 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t *r, const int32_t a[4][256], const int32_t b[4][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t r[256], const int32_t a[4][256], const int32_t b[4][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l5_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-5 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t *r, const int32_t a[5][256], const int32_t b[5][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t r[256], const int32_t a[5][256], const int32_t b[5][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l7_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-7 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t *r, const int32_t a[7][256], const int32_t b[7][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t r[256], const int32_t a[7][256], const int32_t b[7][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/dev/aarch64_opt/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/ntt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: ntt_aarch64_asm
   Description: AArch64 ML-DSA forward NTT
-  Signature: void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456, const int32_t *zetas_l78)
+  Signature: void mld_ntt_aarch64_asm(int32_t r[256], const int32_t zetas_l123456[144], const int32_t zetas_l78[384])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[144]
       description: Twiddle factors for layers 1-6 (144 x int32_t)
     x2:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/pointwise_montgomery_aarch64_asm.S
+++ b/dev/aarch64_opt/src/pointwise_montgomery_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_pointwise_montgomery_aarch64_asm
   Description: AArch64 pointwise Montgomery multiplication of two polynomials
-  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[256], const int32_t b[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *b
+      c_parameter: const int32_t b[256]
       description: Input polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/poly_caddq_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_caddq_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_caddq_aarch64_asm
   Description: AArch64 conditional addition of q to each coefficient
-  Signature: void mld_poly_caddq_aarch64_asm(int32_t *a)
+  Signature: void mld_poly_caddq_aarch64_asm(int32_t a[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/poly_chknorm_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_chknorm_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_chknorm_aarch64_asm
   Description: AArch64 infinity-norm bound check on polynomial coefficients
-  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t a[256], int32_t B)
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *a
+      c_parameter: const int32_t a[256]
       description: Input polynomial (256 x int32_t)
     x1:
       type: scalar

--- a/dev/aarch64_opt/src/poly_decompose_32_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_decompose_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_32_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/32)
-  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/poly_decompose_88_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_decompose_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_88_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/88)
-  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/poly_use_hint_32_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_use_hint_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_32_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/32)
-  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/poly_use_hint_88_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_use_hint_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_88_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/88)
-  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/dev/aarch64_opt/src/polyz_unpack_17_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_17_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_17_aarch64_asm
   Description: AArch64 unpacking of 17-bit packed coefficients
-  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t r[256], const uint8_t buf[576], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[576]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/dev/aarch64_opt/src/polyz_unpack_19_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_19_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_19_aarch64_asm
   Description: AArch64 unpacking of 19-bit packed coefficients
-  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t r[256], const uint8_t buf[640], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[640]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_aarch64_asm
   Description: AArch64 rejection sampling of uniform coefficients mod q
-  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 256
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[256]
       description: Lookup table (256 x uint8_t)
 */
 

--- a/dev/aarch64_opt/src/rej_uniform_eta2_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_eta2_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta2_aarch64_asm
   Description: AArch64 rejection sampling of eta=2 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/dev/aarch64_opt/src/rej_uniform_eta4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_eta4_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta4_aarch64_asm
   Description: AArch64 rejection sampling of eta=4 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/mldsa/src/native/aarch64/src/arith_native_aarch64.h
+++ b/mldsa/src/native/aarch64/src/arith_native_aarch64.h
@@ -61,8 +61,8 @@ MLD_INTERNAL_DATA_DECLARATION const uint8_t mld_polyz_unpack_19_indices[64];
 #define MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN (2 * 136)
 
 #define mld_ntt_aarch64_asm MLD_NAMESPACE(ntt_aarch64_asm)
-void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456,
-                         const int32_t *zetas_l78)
+void mld_ntt_aarch64_asm(int32_t r[MLDSA_N], const int32_t zetas_l123456[144],
+                         const int32_t zetas_l78[384])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/ntt_aarch64_asm.ml */
 __contract__(
@@ -78,8 +78,8 @@ __contract__(
 );
 
 #define mld_intt_aarch64_asm MLD_NAMESPACE(intt_aarch64_asm)
-void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78,
-                          const int32_t *zetas_l123456)
+void mld_intt_aarch64_asm(int32_t r[MLDSA_N], const int32_t zetas_l78[384],
+                          const int32_t zetas_l123456[160])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/intt_aarch64_asm.ml */
 __contract__(
@@ -95,8 +95,8 @@ __contract__(
 
 #define mld_rej_uniform_aarch64_asm MLD_NAMESPACE(rej_uniform_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_aarch64_asm(int32_t r[MLDSA_N], const uint8_t *buf,
+                                     unsigned buflen, const uint8_t table[256])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_aarch64_asm.ml. */
 __contract__(
@@ -113,8 +113,9 @@ __contract__(
 #define mld_rej_uniform_eta2_aarch64_asm \
   MLD_NAMESPACE(rej_uniform_eta2_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                          unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[MLDSA_N],
+                                          const uint8_t *buf, unsigned buflen,
+                                          const uint8_t table[4096])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_eta2_aarch64_asm.ml */
 __contract__(
@@ -132,8 +133,9 @@ __contract__(
 #define mld_rej_uniform_eta4_aarch64_asm \
   MLD_NAMESPACE(rej_uniform_eta4_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                          unsigned buflen, const uint8_t *table)
+uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[MLDSA_N],
+                                          const uint8_t *buf, unsigned buflen,
+                                          const uint8_t table[4096])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/rej_uniform_eta4_aarch64_asm.ml */
 __contract__(
@@ -152,7 +154,7 @@ __contract__(
 #if !defined(MLD_CONFIG_NO_SIGN_API)
 #define mld_poly_decompose_32_aarch64_asm \
   MLD_NAMESPACE(poly_decompose_32_aarch64_asm)
-void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+void mld_poly_decompose_32_aarch64_asm(int32_t a1[MLDSA_N], int32_t a0[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_decompose_32_aarch64_asm.ml */
 __contract__(
@@ -169,7 +171,7 @@ __contract__(
 
 #define mld_poly_decompose_88_aarch64_asm \
   MLD_NAMESPACE(poly_decompose_88_aarch64_asm)
-void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+void mld_poly_decompose_88_aarch64_asm(int32_t a1[MLDSA_N], int32_t a0[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_decompose_88_aarch64_asm.ml */
 __contract__(
@@ -186,7 +188,7 @@ __contract__(
 #endif /* !MLD_CONFIG_NO_SIGN_API */
 
 #define mld_poly_caddq_aarch64_asm MLD_NAMESPACE(poly_caddq_aarch64_asm)
-void mld_poly_caddq_aarch64_asm(int32_t *a)
+void mld_poly_caddq_aarch64_asm(int32_t a[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_caddq_aarch64_asm.ml */
 __contract__(
@@ -199,7 +201,8 @@ __contract__(
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
 #define mld_poly_use_hint_32_aarch64_asm \
   MLD_NAMESPACE(poly_use_hint_32_aarch64_asm)
-void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+void mld_poly_use_hint_32_aarch64_asm(int32_t a[MLDSA_N],
+                                      const int32_t h[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_use_hint_32_aarch64_asm.ml */
 __contract__(
@@ -213,7 +216,8 @@ __contract__(
 
 #define mld_poly_use_hint_88_aarch64_asm \
   MLD_NAMESPACE(poly_use_hint_88_aarch64_asm)
-void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+void mld_poly_use_hint_88_aarch64_asm(int32_t a[MLDSA_N],
+                                      const int32_t h[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_use_hint_88_aarch64_asm.ml */
 __contract__(
@@ -228,7 +232,7 @@ __contract__(
 
 #define mld_poly_chknorm_aarch64_asm MLD_NAMESPACE(poly_chknorm_aarch64_asm)
 MLD_MUST_CHECK_RETURN_VALUE
-int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+int mld_poly_chknorm_aarch64_asm(const int32_t a[MLDSA_N], int32_t B)
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/poly_chknorm_aarch64_asm.ml */
 __contract__(
@@ -243,8 +247,8 @@ __contract__(
 #if defined(MLD_CONFIG_MULTILEVEL_WITH_SHARED) || MLD_CONFIG_PARAMETER_SET == 44
 #define mld_polyz_unpack_17_aarch64_asm \
   MLD_NAMESPACE(polyz_unpack_17_aarch64_asm)
-void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices)
+void mld_polyz_unpack_17_aarch64_asm(int32_t r[MLDSA_N], const uint8_t buf[576],
+                                     const uint8_t indices[64])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/polyz_unpack_17_aarch64_asm.ml */
 __contract__(
@@ -261,8 +265,8 @@ __contract__(
     (MLD_CONFIG_PARAMETER_SET == 65 || MLD_CONFIG_PARAMETER_SET == 87)
 #define mld_polyz_unpack_19_aarch64_asm \
   MLD_NAMESPACE(polyz_unpack_19_aarch64_asm)
-void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices)
+void mld_polyz_unpack_19_aarch64_asm(int32_t r[MLDSA_N], const uint8_t buf[640],
+                                     const uint8_t indices[64])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/polyz_unpack_19_aarch64_asm.ml */
 __contract__(
@@ -280,7 +284,8 @@ __contract__(
     defined(MLD_CONFIG_REDUCE_RAM) || defined(MLD_UNIT_TEST)
 #define mld_poly_pointwise_montgomery_aarch64_asm \
   MLD_NAMESPACE(poly_pointwise_montgomery_aarch64_asm)
-void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[MLDSA_N],
+                                               const int32_t b[MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/aarch64/proofs/pointwise_montgomery_aarch64_asm.ml */
 __contract__(
@@ -301,7 +306,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l4_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(
-    int32_t *r, const int32_t a[4][MLDSA_N], const int32_t b[4][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[4][MLDSA_N],
+    const int32_t b[4][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.ml
@@ -320,7 +326,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l5_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(
-    int32_t *r, const int32_t a[5][MLDSA_N], const int32_t b[5][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[5][MLDSA_N],
+    const int32_t b[5][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.ml
@@ -339,7 +346,8 @@ __contract__(
 #define mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm \
   MLD_NAMESPACE(polyvecl_pointwise_acc_montgomery_l7_aarch64_asm)
 void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(
-    int32_t *r, const int32_t a[7][MLDSA_N], const int32_t b[7][MLDSA_N])
+    int32_t r[MLDSA_N], const int32_t a[7][MLDSA_N],
+    const int32_t b[7][MLDSA_N])
 /* This must be kept in sync with the HOL-Light specification
  * in
  * proofs/hol_light/aarch64/proofs/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.ml

--- a/mldsa/src/native/aarch64/src/intt_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/intt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: intt_aarch64_asm
   Description: AArch64 ML-DSA inverse NTT
-  Signature: void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78, const int32_t *zetas_l123456)
+  Signature: void mld_intt_aarch64_asm(int32_t r[256], const int32_t zetas_l78[384], const int32_t zetas_l123456[160])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
     x2:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[160]
       description: Twiddle factors for layers 1-6 (160 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l4_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-4 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t *r, const int32_t a[4][256], const int32_t b[4][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t r[256], const int32_t a[4][256], const int32_t b[4][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l5_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-5 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t *r, const int32_t a[5][256], const int32_t b[5][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t r[256], const int32_t a[5][256], const int32_t b[5][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l7_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-7 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t *r, const int32_t a[7][256], const int32_t b[7][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t r[256], const int32_t a[7][256], const int32_t b[7][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/mldsa/src/native/aarch64/src/ntt_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/ntt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: ntt_aarch64_asm
   Description: AArch64 ML-DSA forward NTT
-  Signature: void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456, const int32_t *zetas_l78)
+  Signature: void mld_ntt_aarch64_asm(int32_t r[256], const int32_t zetas_l123456[144], const int32_t zetas_l78[384])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[144]
       description: Twiddle factors for layers 1-6 (144 x int32_t)
     x2:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/pointwise_montgomery_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/pointwise_montgomery_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_pointwise_montgomery_aarch64_asm
   Description: AArch64 pointwise Montgomery multiplication of two polynomials
-  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[256], const int32_t b[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *b
+      c_parameter: const int32_t b[256]
       description: Input polynomial (256 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/poly_caddq_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_caddq_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_caddq_aarch64_asm
   Description: AArch64 conditional addition of q to each coefficient
-  Signature: void mld_poly_caddq_aarch64_asm(int32_t *a)
+  Signature: void mld_poly_caddq_aarch64_asm(int32_t a[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/poly_chknorm_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_chknorm_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_chknorm_aarch64_asm
   Description: AArch64 infinity-norm bound check on polynomial coefficients
-  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t a[256], int32_t B)
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *a
+      c_parameter: const int32_t a[256]
       description: Input polynomial (256 x int32_t)
     x1:
       type: scalar

--- a/mldsa/src/native/aarch64/src/poly_decompose_32_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_decompose_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_32_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/32)
-  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/poly_decompose_88_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_decompose_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_88_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/88)
-  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/poly_use_hint_32_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_use_hint_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_32_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/32)
-  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/poly_use_hint_88_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_use_hint_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_88_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/88)
-  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/mldsa/src/native/aarch64/src/polyz_unpack_17_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_17_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_17_aarch64_asm
   Description: AArch64 unpacking of 17-bit packed coefficients
-  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t r[256], const uint8_t buf[576], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[576]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/mldsa/src/native/aarch64/src/polyz_unpack_19_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_19_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_19_aarch64_asm
   Description: AArch64 unpacking of 19-bit packed coefficients
-  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t r[256], const uint8_t buf[640], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[640]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/mldsa/src/native/aarch64/src/rej_uniform_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_aarch64_asm
   Description: AArch64 rejection sampling of uniform coefficients mod q
-  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 256
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[256]
       description: Lookup table (256 x uint8_t)
 */
 

--- a/mldsa/src/native/aarch64/src/rej_uniform_eta2_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_eta2_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta2_aarch64_asm
   Description: AArch64 rejection sampling of eta=2 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/mldsa/src/native/aarch64/src/rej_uniform_eta4_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_eta4_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta4_aarch64_asm
   Description: AArch64 rejection sampling of eta=4 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/intt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/intt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: intt_aarch64_asm
   Description: AArch64 ML-DSA inverse NTT
-  Signature: void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78, const int32_t *zetas_l123456)
+  Signature: void mld_intt_aarch64_asm(int32_t r[256], const int32_t zetas_l78[384], const int32_t zetas_l123456[160])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
     x2:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[160]
       description: Twiddle factors for layers 1-6 (160 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l4_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-4 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t *r, const int32_t a[4][256], const int32_t b[4][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(int32_t r[256], const int32_t a[4][256], const int32_t b[4][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l5_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-5 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t *r, const int32_t a[5][256], const int32_t b[5][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(int32_t r[256], const int32_t a[5][256], const int32_t b[5][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: polyvecl_pointwise_acc_montgomery_l7_aarch64_asm
   Description: AArch64 pointwise multiply-accumulate of length-7 polynomial vectors
-  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t *r, const int32_t a[7][256], const int32_t b[7][256])
+  Signature: void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(int32_t r[256], const int32_t a[7][256], const int32_t b[7][256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer

--- a/proofs/hol_light/aarch64/mldsa/ntt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/ntt_aarch64_asm.S
@@ -30,7 +30,7 @@
 /*yaml
   Name: ntt_aarch64_asm
   Description: AArch64 ML-DSA forward NTT
-  Signature: void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456, const int32_t *zetas_l78)
+  Signature: void mld_ntt_aarch64_asm(int32_t r[256], const int32_t zetas_l123456[144], const int32_t zetas_l78[384])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -38,19 +38,19 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const int32_t *zetas_l123456
+      c_parameter: const int32_t zetas_l123456[144]
       description: Twiddle factors for layers 1-6 (144 x int32_t)
     x2:
       type: buffer
       size_bytes: 1536
       permissions: read-only
-      c_parameter: const int32_t *zetas_l78
+      c_parameter: const int32_t zetas_l78[384]
       description: Twiddle factors for layers 7-8 (384 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/pointwise_montgomery_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/pointwise_montgomery_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_pointwise_montgomery_aarch64_asm
   Description: AArch64 pointwise Montgomery multiplication of two polynomials
-  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b)
+  Signature: void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[256], const int32_t b[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *b
+      c_parameter: const int32_t b[256]
       description: Input polynomial (256 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/poly_caddq_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_caddq_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_caddq_aarch64_asm
   Description: AArch64 conditional addition of q to each coefficient
-  Signature: void mld_poly_caddq_aarch64_asm(int32_t *a)
+  Signature: void mld_poly_caddq_aarch64_asm(int32_t a[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/poly_chknorm_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_chknorm_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_chknorm_aarch64_asm
   Description: AArch64 infinity-norm bound check on polynomial coefficients
-  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B)
+  Signature: int mld_poly_chknorm_aarch64_asm(const int32_t a[256], int32_t B)
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,7 +13,7 @@
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *a
+      c_parameter: const int32_t a[256]
       description: Input polynomial (256 x int32_t)
     x1:
       type: scalar

--- a/proofs/hol_light/aarch64/mldsa/poly_decompose_32_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_decompose_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_32_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/32)
-  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_32_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/poly_decompose_88_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_decompose_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_decompose_88_aarch64_asm
   Description: AArch64 coefficient decomposition (alpha = (Q-1)/88)
-  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0)
+  Signature: void mld_poly_decompose_88_aarch64_asm(int32_t a1[256], int32_t a0[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *a1
+      c_parameter: int32_t a1[256]
       description: Output high-part polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a0
+      c_parameter: int32_t a0[256]
       description: Input polynomial / output low-part (256 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/poly_use_hint_32_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_use_hint_32_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_32_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/32)
-  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_32_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/poly_use_hint_88_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_use_hint_88_aarch64_asm.S
@@ -5,7 +5,7 @@
 /*yaml
   Name: poly_use_hint_88_aarch64_asm
   Description: AArch64 hint application (alpha = (Q-1)/88)
-  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h)
+  Signature: void mld_poly_use_hint_88_aarch64_asm(int32_t a[256], const int32_t h[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -13,13 +13,13 @@
       type: buffer
       size_bytes: 1024
       permissions: read/write
-      c_parameter: int32_t *a
+      c_parameter: int32_t a[256]
       description: Input/output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 1024
       permissions: read-only
-      c_parameter: const int32_t *h
+      c_parameter: const int32_t h[256]
       description: Hint polynomial (256 x int32_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/polyz_unpack_17_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/polyz_unpack_17_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_17_aarch64_asm
   Description: AArch64 unpacking of 17-bit packed coefficients
-  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_17_aarch64_asm(int32_t r[256], const uint8_t buf[576], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 576
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[576]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/polyz_unpack_19_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/polyz_unpack_19_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: polyz_unpack_19_aarch64_asm
   Description: AArch64 unpacking of 19-bit packed coefficients
-  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf, const uint8_t *indices)
+  Signature: void mld_polyz_unpack_19_aarch64_asm(int32_t r[256], const uint8_t buf[640], const uint8_t indices[64])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,19 +15,19 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output polynomial (256 x int32_t)
     x1:
       type: buffer
       size_bytes: 640
       permissions: read-only
-      c_parameter: const uint8_t *buf
+      c_parameter: const uint8_t buf[640]
       description: Packed input bytes
     x2:
       type: buffer
       size_bytes: 64
       permissions: read-only
-      c_parameter: const uint8_t *indices
+      c_parameter: const uint8_t indices[64]
       description: Permutation index table (64 x uint8_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/rej_uniform_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/rej_uniform_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_aarch64_asm
   Description: AArch64 rejection sampling of uniform coefficients mod q
-  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[256])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 256
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[256]
       description: Lookup table (256 x uint8_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/rej_uniform_eta2_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/rej_uniform_eta2_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta2_aarch64_asm
   Description: AArch64 rejection sampling of eta=2 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/proofs/hol_light/aarch64/mldsa/rej_uniform_eta4_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/rej_uniform_eta4_aarch64_asm.S
@@ -7,7 +7,7 @@
 /*yaml
   Name: rej_uniform_eta4_aarch64_asm
   Description: AArch64 rejection sampling of eta=4 secret coefficients
-  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf, unsigned buflen, const uint8_t *table)
+  Signature: uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[4096])
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
@@ -15,7 +15,7 @@
       type: buffer
       size_bytes: 1024
       permissions: write-only
-      c_parameter: int32_t *r
+      c_parameter: int32_t r[256]
       description: Output buffer (256 x int32_t)
     x1:
       type: buffer
@@ -32,7 +32,7 @@
       type: buffer
       size_bytes: 4096
       permissions: read-only
-      c_parameter: const uint8_t *table
+      c_parameter: const uint8_t table[4096]
       description: Lookup table (4096 x uint8_t)
 */
 

--- a/test/abicheck/aarch64/checks/check_intt_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_intt_aarch64_asm.c
@@ -20,8 +20,8 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_intt_aarch64_asm(int32_t *r, const int32_t *zetas_l78,
-                          const int32_t *zetas_l123456);
+void mld_intt_aarch64_asm(int32_t r[256], const int32_t zetas_l78[384],
+                          const int32_t zetas_l123456[160]);
 
 int check_intt_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_ntt_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_ntt_aarch64_asm.c
@@ -20,8 +20,8 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_ntt_aarch64_asm(int32_t *r, const int32_t *zetas_l123456,
-                         const int32_t *zetas_l78);
+void mld_ntt_aarch64_asm(int32_t r[256], const int32_t zetas_l123456[144],
+                         const int32_t zetas_l78[384]);
 
 int check_ntt_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_caddq_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_caddq_aarch64_asm.c
@@ -20,7 +20,7 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_poly_caddq_aarch64_asm(int32_t *a);
+void mld_poly_caddq_aarch64_asm(int32_t a[256]);
 
 int check_poly_caddq_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_chknorm_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_chknorm_aarch64_asm.c
@@ -20,7 +20,7 @@
 
 typedef struct aarch64_register_state reg_state;
 
-int mld_poly_chknorm_aarch64_asm(const int32_t *a, int32_t B);
+int mld_poly_chknorm_aarch64_asm(const int32_t a[256], int32_t B);
 
 int check_poly_chknorm_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_decompose_32_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_decompose_32_aarch64_asm.c
@@ -20,7 +20,7 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_poly_decompose_32_aarch64_asm(int32_t *a1, int32_t *a0);
+void mld_poly_decompose_32_aarch64_asm(int32_t a1[256], int32_t a0[256]);
 
 int check_poly_decompose_32_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_decompose_88_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_decompose_88_aarch64_asm.c
@@ -20,7 +20,7 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_poly_decompose_88_aarch64_asm(int32_t *a1, int32_t *a0);
+void mld_poly_decompose_88_aarch64_asm(int32_t a1[256], int32_t a0[256]);
 
 int check_poly_decompose_88_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_pointwise_montgomery_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_pointwise_montgomery_aarch64_asm.c
@@ -20,7 +20,8 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_poly_pointwise_montgomery_aarch64_asm(int32_t *a, const int32_t *b);
+void mld_poly_pointwise_montgomery_aarch64_asm(int32_t a[256],
+                                               const int32_t b[256]);
 
 int check_poly_pointwise_montgomery_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_use_hint_32_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_use_hint_32_aarch64_asm.c
@@ -20,7 +20,7 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_poly_use_hint_32_aarch64_asm(int32_t *a, const int32_t *h);
+void mld_poly_use_hint_32_aarch64_asm(int32_t a[256], const int32_t h[256]);
 
 int check_poly_use_hint_32_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_poly_use_hint_88_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_use_hint_88_aarch64_asm.c
@@ -20,7 +20,7 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_poly_use_hint_88_aarch64_asm(int32_t *a, const int32_t *h);
+void mld_poly_use_hint_88_aarch64_asm(int32_t a[256], const int32_t h[256]);
 
 int check_poly_use_hint_88_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.c
@@ -21,7 +21,7 @@
 typedef struct aarch64_register_state reg_state;
 
 void mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(
-    int32_t *r, const int32_t a[4][256], const int32_t b[4][256]);
+    int32_t r[256], const int32_t a[4][256], const int32_t b[4][256]);
 
 int check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.c
@@ -21,7 +21,7 @@
 typedef struct aarch64_register_state reg_state;
 
 void mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(
-    int32_t *r, const int32_t a[5][256], const int32_t b[5][256]);
+    int32_t r[256], const int32_t a[5][256], const int32_t b[5][256]);
 
 int check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.c
@@ -21,7 +21,7 @@
 typedef struct aarch64_register_state reg_state;
 
 void mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(
-    int32_t *r, const int32_t a[7][256], const int32_t b[7][256]);
+    int32_t r[256], const int32_t a[7][256], const int32_t b[7][256]);
 
 int check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_polyz_unpack_17_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyz_unpack_17_aarch64_asm.c
@@ -20,8 +20,8 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_polyz_unpack_17_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices);
+void mld_polyz_unpack_17_aarch64_asm(int32_t r[256], const uint8_t buf[576],
+                                     const uint8_t indices[64]);
 
 int check_polyz_unpack_17_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_polyz_unpack_19_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyz_unpack_19_aarch64_asm.c
@@ -20,8 +20,8 @@
 
 typedef struct aarch64_register_state reg_state;
 
-void mld_polyz_unpack_19_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     const uint8_t *indices);
+void mld_polyz_unpack_19_aarch64_asm(int32_t r[256], const uint8_t buf[640],
+                                     const uint8_t indices[64]);
 
 int check_polyz_unpack_19_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_rej_uniform_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_aarch64_asm.c
@@ -20,8 +20,8 @@
 
 typedef struct aarch64_register_state reg_state;
 
-uint64_t mld_rej_uniform_aarch64_asm(int32_t *r, const uint8_t *buf,
-                                     unsigned buflen, const uint8_t *table);
+uint64_t mld_rej_uniform_aarch64_asm(int32_t r[256], const uint8_t *buf,
+                                     unsigned buflen, const uint8_t table[256]);
 
 int check_rej_uniform_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_rej_uniform_eta2_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_eta2_aarch64_asm.c
@@ -20,9 +20,9 @@
 
 typedef struct aarch64_register_state reg_state;
 
-uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t *r, const uint8_t *buf,
+uint64_t mld_rej_uniform_eta2_aarch64_asm(int32_t r[256], const uint8_t *buf,
                                           unsigned buflen,
-                                          const uint8_t *table);
+                                          const uint8_t table[4096]);
 
 int check_rej_uniform_eta2_aarch64_asm(void)
 {

--- a/test/abicheck/aarch64/checks/check_rej_uniform_eta4_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_eta4_aarch64_asm.c
@@ -20,9 +20,9 @@
 
 typedef struct aarch64_register_state reg_state;
 
-uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t *r, const uint8_t *buf,
+uint64_t mld_rej_uniform_eta4_aarch64_asm(int32_t r[256], const uint8_t *buf,
                                           unsigned buflen,
-                                          const uint8_t *table);
+                                          const uint8_t table[4096]);
 
 int check_rej_uniform_eta4_aarch64_asm(void)
 {


### PR DESCRIPTION
Convert all fixed-size pointer parameters in the AArch64 assembly interface to array notation.

 - Resolves #1033