### PR TITLE
CBMC: Functional specs for `make_hint` and hint unpacking

### DIFF
--- a/mldsa/src/packing.c
+++ b/mldsa/src/packing.c
@@ -166,6 +166,9 @@ int mld_sig_unpack_hints(mld_poly *h, const uint8_t sig[MLDSA_CRYPTO_BYTES],
     invariant(j >= old_hint_count && j <= new_hint_count &&
               new_hint_count <= MLDSA_OMEGA)
     invariant(array_bound(h->coeffs, 0, MLDSA_N, 0, 2))
+    invariant(forall(p, 0, MLDSA_N,
+      (h->coeffs[p] == 1) ==
+      exists(hj, old_hint_count, j, packed_hints[hj] == p)))
     decreases(new_hint_count - j)
   )
   {
@@ -192,6 +195,14 @@ int mld_sig_unpack_hints(mld_poly *h, const uint8_t sig[MLDSA_CRYPTO_BYTES],
       }
     }
   }
+
+  /* On success, h->coeffs[p] is 1 exactly for the hint indices decoded for this
+   * row, i.e. packed_hints[old_hint_count, new_hint_count). Asserted here
+   * rather than posted as a contract so callers need not assume it. */
+  cassert(forall(
+      p, 0, MLDSA_N,
+      (h->coeffs[p] == 1) ==
+          exists(hj, old_hint_count, new_hint_count, packed_hints[hj] == p)));
 
   return 0;
 }

--- a/mldsa/src/packing.c
+++ b/mldsa/src/packing.c
@@ -198,7 +198,8 @@ int mld_sig_unpack_hints(mld_poly *h, const uint8_t sig[MLDSA_CRYPTO_BYTES],
 
   /* On success, h->coeffs[p] is 1 exactly for the hint indices decoded for this
    * row, i.e. packed_hints[old_hint_count, new_hint_count). Asserted here
-   * rather than posted as a contract so callers need not assume it. */
+   * rather than posted as a contract to not unnecessarily increase proof
+   * complexity at callers that do not need the functional description. */
   cassert(forall(
       p, 0, MLDSA_N,
       (h->coeffs[p] == 1) ==

--- a/mldsa/src/rounding.h
+++ b/mldsa/src/rounding.h
@@ -201,6 +201,8 @@ MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE unsigned int mld_make_hint(int32_t a0, int32_t a1)
 __contract__(
   ensures(return_value >= 0 && return_value <= 1)
+  ensures(return_value == (a0 > MLDSA_GAMMA2 || a0 < -MLDSA_GAMMA2 ||
+                           (a0 == -MLDSA_GAMMA2 && a1 != 0)))
 )
 {
   if (a0 > MLDSA_GAMMA2 || a0 < -MLDSA_GAMMA2 ||


### PR DESCRIPTION
Strengthen the contracts beyond type/memory safety: pin mld_make_hint's return value to the exact hint predicate, and prove mld_sig_unpack_hints sets h->coeffs[p] exactly for the hint indices decoded for row i.

 - Resolves https://github.com/pq-code-package/mldsa-native/issues/1099