### PR TITLE
Add missing MLD_INTERNAL_API/MLD_EXTERNAL_API declarations

### DIFF
--- a/dev/fips202/armv81m/mve.h
+++ b/dev/fips202/armv81m/mve.h
@@ -26,6 +26,7 @@
  */
 #define mld_keccak_f1600_x4_native_impl \
   MLD_NAMESPACE(keccak_f1600_x4_native_impl)
+MLD_INTERNAL_API
 int mld_keccak_f1600_x4_native_impl(uint64_t *state);
 
 MLD_MUST_CHECK_RETURN_VALUE

--- a/dev/fips202/armv81m/src/keccak_f1600_x4_mve.c
+++ b/dev/fips202/armv81m/src/keccak_f1600_x4_mve.c
@@ -19,6 +19,7 @@
  */
 #define mld_keccak_f1600_x4_native_impl \
   MLD_NAMESPACE(keccak_f1600_x4_native_impl)
+MLD_INTERNAL_API
 int mld_keccak_f1600_x4_native_impl(uint64_t *state)
 {
   MLD_ALIGN uint64_t state_tmp[100];

--- a/mldsa/src/debug.c
+++ b/mldsa/src/debug.c
@@ -19,6 +19,7 @@
 
 #define MLD_DEBUG_ERROR_HEADER "[ERROR:%s:%04d] "
 
+MLD_INTERNAL_API
 void mld_debug_check_assert(const char *file, int line, const int val)
 {
   if (val == 0)
@@ -29,6 +30,7 @@ void mld_debug_check_assert(const char *file, int line, const int val)
   }
 }
 
+MLD_INTERNAL_API
 void mld_debug_check_bounds(const char *file, int line, const int32_t *ptr,
                             unsigned len, int64_t lower_bound_exclusive,
                             int64_t upper_bound_exclusive)

--- a/mldsa/src/debug.h
+++ b/mldsa/src/debug.h
@@ -19,6 +19,7 @@
  * @param val  Value asserted to be non-zero.
  */
 #define mld_debug_check_assert MLD_NAMESPACE(mldsa_debug_assert)
+MLD_INTERNAL_API
 void mld_debug_check_assert(const char *file, int line, const int val);
 
 /**
@@ -34,6 +35,7 @@ void mld_debug_check_assert(const char *file, int line, const int val);
  * @param     upper_bound_exclusive Exclusive upper bound.
  */
 #define mld_debug_check_bounds MLD_NAMESPACE(mldsa_debug_check_bounds)
+MLD_INTERNAL_API
 void mld_debug_check_bounds(const char *file, int line, const int32_t *ptr,
                             unsigned len, int64_t lower_bound_exclusive,
                             int64_t upper_bound_exclusive);

--- a/mldsa/src/fips202/native/armv81m/mve.h
+++ b/mldsa/src/fips202/native/armv81m/mve.h
@@ -26,6 +26,7 @@
  */
 #define mld_keccak_f1600_x4_native_impl \
   MLD_NAMESPACE(keccak_f1600_x4_native_impl)
+MLD_INTERNAL_API
 int mld_keccak_f1600_x4_native_impl(uint64_t *state);
 
 MLD_MUST_CHECK_RETURN_VALUE

--- a/mldsa/src/fips202/native/armv81m/src/keccak_f1600_x4_mve.c
+++ b/mldsa/src/fips202/native/armv81m/src/keccak_f1600_x4_mve.c
@@ -19,6 +19,7 @@
  */
 #define mld_keccak_f1600_x4_native_impl \
   MLD_NAMESPACE(keccak_f1600_x4_native_impl)
+MLD_INTERNAL_API
 int mld_keccak_f1600_x4_native_impl(uint64_t *state)
 {
   MLD_ALIGN uint64_t state_tmp[100];

--- a/mldsa/src/poly_kl.c
+++ b/mldsa/src/poly_kl.c
@@ -694,6 +694,7 @@ void mld_polyeta_pack(uint8_t r[MLDSA_POLYETA_PACKEDBYTES], const mld_poly *a)
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API */
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) || !defined(MLD_CONFIG_NO_SIGN_API)
+MLD_INTERNAL_API
 void mld_polyeta_unpack(mld_poly *r, const uint8_t a[MLDSA_POLYETA_PACKEDBYTES])
 {
   unsigned int i;

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -1540,6 +1540,7 @@ static int mld_validate_hash_length(int hashalg, size_t len)
   }
 }
 
+MLD_EXTERNAL_API
 size_t mld_prepare_domain_separation_prefix(
     uint8_t prefix[MLD_DOMAIN_SEPARATION_MAX_BYTES], const uint8_t *ph,
     size_t phlen, const uint8_t *ctx, size_t ctxlen, int hashalg)


### PR DESCRIPTION
```
    Annotate mld_polyeta_unpack, mld_prepare_domain_separation_prefix,
    mld_debug_check_assert, mld_debug_check_bounds, and
    mld_keccak_f1600_x4_native_impl.
```

* Extracted from #1052.