### PR TITLE
CI: Bump Wycheproof vectors to fc24cd5 (2026-07-07)

### DIFF
--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -20,8 +20,8 @@ from pathlib import Path
 exec_prefix = os.environ.get("EXEC_WRAPPER", "")
 exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
-# Pinned to a specific commit (2026-06-06).
-WYCHEPROOF_COMMIT = "6d7cccd0fcb1917368579adeeac10fe802f1b521"
+# Pinned to a specific commit (2026-07-07).
+WYCHEPROOF_COMMIT = "fc24cd5b787d8e496bff31b0468af693a652b0f2"
 WYCHEPROOF_BASE_URL = (
     "https://api.github.com/repos/C2SP/wycheproof/contents/testvectors_v1"
 )


### PR DESCRIPTION
The only ML-DSA change upstream is two new ML-DSA-87 verify vectors (MissingReduction) targeting a missing reduction in the verify NTT path.

- Resolves https://github.com/pq-code-package/mldsa-native/issues/1289