### PR TITLE
SOUNDNESS/README: Use proper markdown citation syntax for Round3_Spec

### DIFF
--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -367,7 +367,9 @@ source code and documentation.
   - Damien Stehlé
 * URL: https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 * Referenced from:
+  - [SOUNDNESS.md](SOUNDNESS.md)
   - [mldsa/src/sign.c](mldsa/src/sign.c)
+  - [proofs/hol_light/README.md](proofs/hol_light/README.md)
 
 ### `SLOTHY_Paper`
 

--- a/SOUNDNESS.md
+++ b/SOUNDNESS.md
@@ -40,9 +40,10 @@ and memory-safe, but their secret-independent timing is not yet formally proved 
 pattern depends on which coefficients fall inside vs. outside the acceptance interval, but no
 other information about the secret coefficients is leaked, and the indices of in-bound vs.
 out-of-bound coefficients are statistically independent of the secret key; see Section 5.5 of
-@[Round3_Spec]. This property is validated empirically through the `valgrind`-based
+the Dilithium Round 3 specification[^Round3_Spec]. This property is validated empirically through the `valgrind`-based
 constant-time tests, but not formally proved.
 
 <!--- bibliography --->
+[^Round3_Spec]: Bai, Ducas, Kiltz, Lepoint, Lyubashevsky, Schwabe, Seiler, Stehlé: CRYSTALS-Dilithium Algorithm Specifications and Supporting Documentation (Version 3.1), [https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf](https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)
 [^mlkem_native_soundness]: pq-code-package: mlkem-native SOUNDNESS document, [https://github.com/pq-code-package/mlkem-native/blob/main/SOUNDNESS.md](https://github.com/pq-code-package/mlkem-native/blob/main/SOUNDNESS.md)
 [^s2n_bignum_soundness]: Amazon Web Services: s2n-bignum soundness documentation, [https://github.com/awslabs/s2n-bignum/blob/main/doc/s2n_bignum_soundness.md](https://github.com/awslabs/s2n-bignum/blob/main/doc/s2n_bignum_soundness.md)

--- a/proofs/hol_light/README.md
+++ b/proofs/hol_light/README.md
@@ -23,7 +23,7 @@ The AArch64 and AVX2 kernels `rej_uniform_eta{2,4}` have secret-independent timi
 [#1160](https://github.com/pq-code-package/mldsa-native/issues/1160)): Their memory access pattern depends on which
 coefficients fall inside vs. outside the acceptance interval, but no other information about the secret coefficients is
 leaked. The indices of in bound vs. out of bounds coefficients are statistically independent of the secret key; see
-Section 5.5 of @[Round3_Spec].
+Section 5.5 of the Dilithium Round 3 specification[^Round3_Spec].
 
 ## Primer
 
@@ -182,3 +182,4 @@ All routines listed below have been proven correct, memory-safe, and secret-inde
 
 <!--- bibliography --->
 [^HYBRID]: Becker, Kannwischer: Hybrid scalar/vector implementations of Keccak and SPHINCS+ on AArch64, [https://eprint.iacr.org/2022/1243](https://eprint.iacr.org/2022/1243)
+[^Round3_Spec]: Bai, Ducas, Kiltz, Lepoint, Lyubashevsky, Schwabe, Seiler, Stehlé: CRYSTALS-Dilithium Algorithm Specifications and Supporting Documentation (Version 3.1), [https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf](https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf)


### PR DESCRIPTION
* Based on #1188 

```
SOUNDNESS/README: Use proper markdown citation syntax for Round3_Spec

Replace @[Round3_Spec] (C-comment citation syntax) with the markdown
footnote form [^Round3_Spec] in SOUNDNESS.md and proofs/hol_light/README.md,
and regenerate the bibliography footer via autogen.
```