### PR TITLE
Document public API conventions

### DIFF
--- a/API-CONVENTIONS.md
+++ b/API-CONVENTIONS.md
@@ -1,0 +1,23 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# API conventions
+
+This document describes conventions shared by all public functions declared in [`mldsa/mldsa_native.h`](mldsa/mldsa_native.h). The per-function documentation in that header takes precedence wherever it is more specific.
+
+## Return values
+
+Functions returning `int` return `0` on success and a negative error code on failure. Error codes are enumerated as `MLD_ERR_XXX` constants in `mldsa_native.h`.
+
+Errors have different origins, and not all are fatal. For example, signature verification routines use `MLD_ERR_FAIL` to signal an invalid signature, and signing hooks use `MLD_ERR_SIGNING_PAUSED` to signal a paused signing operation. Other errors, such as `MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED` or `MLD_ERR_RNG_FAIL`, should never be observed in normal operation and hint at a deeper failure in the system.
+
+Return values must always be checked; the public API is annotated with `warn_unused_result` on compilers that support it.
+
+## Pointer arguments
+
+All pointer arguments are assumed to be valid and non-NULL, and every buffer is assumed to have the size implied by its parameter type. mldsa-native does not check pointers for NULL and does not validate buffer sizes; passing a NULL or otherwise invalid pointer, or an undersized buffer, is undefined behavior. Ensuring these preconditions is the caller's responsibility.
+
+The exception is a pointer paired with a length: it may be NULL when that length is `0` — for example, the message `m` when `mlen == 0`, or `ctx` when `ctxlen == 0`. Such cases are called out in the per-function documentation.
+
+## Output buffers on error
+
+When a function returns an error, each caller-owned output buffer is left either unchanged or fully zeroized. An output buffer is never left holding partially computed or otherwise stale data that could be mistaken for a valid result.

--- a/API-CONVENTIONS.md
+++ b/API-CONVENTIONS.md
@@ -14,7 +14,7 @@ Return values must always be checked; the public API is annotated with `warn_unu
 
 ## Pointer arguments
 
-All pointer arguments are assumed to be valid and non-NULL, and every buffer is assumed to have the size implied by its parameter type. mldsa-native does not check pointers for NULL and does not validate buffer sizes; passing a NULL or otherwise invalid pointer, or an undersized buffer, is undefined behavior. Ensuring these preconditions is the caller's responsibility.
+All pointers to non-empty buffers are assumed to be valid and non-NULL, and every buffer is assumed to have the size implied by its parameter type or associated length parameter. mldsa-native does not conduct pointer validity checks such as NULL comparisons; passing a NULL or otherwise invalid pointer, or an undersized buffer, is undefined behavior. Ensuring these preconditions is the caller's responsibility.
 
 The exception is a pointer paired with a length: it may be NULL when that length is `0` — for example, the message `m` when `mlen == 0`, or `ctx` when `ctxlen == 0`. Such cases are called out in the per-function documentation.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ For CI benchmark results and historical performance data, see the [benchmarking 
 
 If you want to use mldsa-native, import [mldsa](mldsa) into your project's source tree and build using your favourite build system. See [examples/basic](examples/basic) for a simple example. The build system provided in this repository is for development purposes only.
 
+See [API-CONVENTIONS.md](API-CONVENTIONS.md) for conventions that apply to all public functions, such as return values, pointer validity, and the state of output buffers on error.
+
 ### Can I bring my own FIPS-202?
 
 mldsa-native relies on and comes with an implementation of FIPS-202[^FIPS202]. If your library has its own FIPS-202 implementation, you

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -23,6 +23,11 @@
  * Make sure the configuration file is in the include path
  * (this is "mldsa_native_config.h" by default, or MLD_CONFIG_FILE if defined).
  *
+ * # API conventions
+ *
+ * Conventions shared by all functions below (return values, pointer validity,
+ * output buffers on error) are documented in API-CONVENTIONS.md.
+ *
  * # Multi-level builds
  *
  * This header specifies a build of mldsa-native for a fixed security level.

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -319,7 +319,8 @@ int MLD_API_NAMESPACE(signature_internal)(
  *
  * @param[out] sig     Pointer to buffer to hold the generated signature of
  *                     MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
- * @param[in]  m       Pointer to message to be signed.
+ * @param[in]  m       Pointer to message to be signed. May be NULL if
+ *                     mlen == 0.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string. May be NULL if ctxlen == 0.
  * @param      ctxlen  Length of context string. Should be <= 255.
@@ -446,7 +447,7 @@ int MLD_API_NAMESPACE(verify_internal)(
  *
  * @param[in] sig     Pointer to input signature of
  *                    MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
- * @param[in] m       Pointer to message.
+ * @param[in] m       Pointer to message. May be NULL if mlen == 0.
  * @param     mlen    Length of message.
  * @param[in] ctx     Pointer to context string. May be NULL if ctxlen == 0.
  * @param     ctxlen  Length of context string.
@@ -647,7 +648,8 @@ int MLD_API_NAMESPACE(verify_pre_hash_internal)(
  *
  * @param[out] sig     Pointer to buffer to hold the generated signature of
  *                     MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
- * @param[in]  m       Pointer to message to be hashed and signed.
+ * @param[in]  m       Pointer to message to be hashed and signed. May be
+ *                     NULL if mlen == 0.
  * @param      mlen    Length of message.
  * @param[in]  ctx     Pointer to context string.
  * @param      ctxlen  Length of context string.
@@ -692,7 +694,8 @@ int MLD_API_NAMESPACE(signature_pre_hash_shake256)(
  *
  * @param[in] sig     Pointer to input signature of
  *                    MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET) bytes.
- * @param[in] m       Pointer to message to be hashed and verified.
+ * @param[in] m       Pointer to message to be hashed and verified. May be
+ *                    NULL if mlen == 0.
  * @param     mlen    Length of message.
  * @param[in] ctx     Pointer to context string.
  * @param     ctxlen  Length of context string.

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -150,6 +150,48 @@ static int test_sign_pre_hash(void)
 
   return 0;
 }
+
+/* Empty message with a NULL pointer: m may be NULL when mlen == 0.
+ * Covers both the pure and SHAKE256 pre-hash paths, so the mlen == 0
+ * behaviour is exercised for prehash as well, across all backends in CI. */
+static int test_sign_empty_message(void)
+{
+  uint8_t pk[MLDSA_PK_BYTES];
+  uint8_t sk[MLDSA_SK_BYTES];
+  uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t ctx[CTXLEN];
+  uint8_t rnd[MLDSA_RNDBYTES];
+  int rc;
+
+  CHECK(mld_sign_keypair(pk, sk) == 0);
+  CHECK(randombytes(ctx, CTXLEN) == 0);
+  MLD_CT_TESTING_SECRET(ctx, CTXLEN);
+
+  /* Pure ML-DSA */
+  CHECK_SIGN_RC(mld_sign_signature(sig, NULL, 0, ctx, CTXLEN, sk));
+  rc = mld_sign_verify(sig, NULL, 0, ctx, CTXLEN, pk);
+  MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
+  if (rc)
+  {
+    printf("ERROR: empty_message: pure verify\n");
+    return 1;
+  }
+
+  /* HashML-DSA (SHAKE256 pre-hash) */
+  CHECK(randombytes(rnd, MLDSA_RNDBYTES) == 0);
+  MLD_CT_TESTING_SECRET(rnd, sizeof(rnd));
+  CHECK_SIGN_RC(
+      mld_sign_signature_pre_hash_shake256(sig, NULL, 0, ctx, CTXLEN, rnd, sk));
+  rc = mld_sign_verify_pre_hash_shake256(sig, NULL, 0, ctx, CTXLEN, pk);
+  MLD_CT_TESTING_DECLASSIFY(rc, sizeof(int));
+  if (rc)
+  {
+    printf("ERROR: empty_message: pre-hash verify\n");
+    return 1;
+  }
+
+  return 0;
+}
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \
           !MLD_CONFIG_NO_VERIFY_API */
 
@@ -444,6 +486,7 @@ int main(void)
     r |= test_wrong_ctx();
     r |= test_sign_extmu();
     r |= test_sign_pre_hash();
+    r |= test_sign_empty_message();
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \
           !MLD_CONFIG_NO_VERIFY_API */
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)


### PR DESCRIPTION
Add API-CONVENTIONS.md covering return values, pointer validity (all pointers assumed valid, no NULL checks), and the state of output buffers on error (left unchanged or fully zeroized). Link it from the mldsa_native.h header comment and the README Usage section.