### PR TITLE
liboqs: Normalize return codes to OQS_STATUS

### DIFF
--- a/integration/liboqs/ML-DSA-44_META.yml
+++ b/integration/liboqs/ML-DSA-44_META.yml
@@ -25,7 +25,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_C_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_extmu_oqs
@@ -43,7 +43,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_extmu_oqs
@@ -70,7 +70,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_extmu_oqs

--- a/integration/liboqs/ML-DSA-65_META.yml
+++ b/integration/liboqs/ML-DSA-65_META.yml
@@ -25,7 +25,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_C_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_extmu_oqs
@@ -43,7 +43,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_extmu_oqs
@@ -70,7 +70,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_extmu_oqs

--- a/integration/liboqs/ML-DSA-87_META.yml
+++ b/integration/liboqs/ML-DSA-87_META.yml
@@ -25,7 +25,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_C_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_extmu_oqs
@@ -43,7 +43,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_extmu_oqs
@@ -70,7 +70,7 @@ implementations:
   version: FIPS204
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
-  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair
+  signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_extmu_oqs

--- a/integration/liboqs/sig_glue.c
+++ b/integration/liboqs/sig_glue.c
@@ -13,12 +13,18 @@
  * length-carrying API expected by liboqs on top of the fixed-length one, and
  * are referenced from the per-level META.yml files.
  *
+ * The shims also normalize return codes to OQS_STATUS: mldsa-native returns a
+ * wider error set than liboqs's OQS_SUCCESS / OQS_ERROR, so any nonzero result
+ * is collapsed to OQS_ERROR. keypair is shimmed for this normalization alone.
+ *
  * The shims are compiled once per build (parameter set and backend), so the
  * namespaced symbol names match the names liboqs links against.
  */
 
 #include <stddef.h>
 #include <stdint.h>
+
+#include <oqs/common.h>
 
 #include "mldsa/mldsa_native.h"
 
@@ -34,10 +40,23 @@
 #define MLD_OQS_NS(sym) \
   MLD_OQS_CONCAT(MLD_OQS_CONCAT(MLD_CONFIG_NAMESPACE_PREFIX, _), sym)
 
+#define mld_oqs_keypair MLD_OQS_NS(keypair_oqs)
 #define mld_oqs_signature MLD_OQS_NS(signature_oqs)
 #define mld_oqs_verify MLD_OQS_NS(verify_oqs)
 #define mld_oqs_signature_extmu MLD_OQS_NS(signature_extmu_oqs)
 #define mld_oqs_verify_extmu MLD_OQS_NS(verify_extmu_oqs)
+
+/* Collapse mldsa-native's error set to OQS_SUCCESS / OQS_ERROR. liboqs declares
+ * these shims as returning int and casts the result to OQS_STATUS itself. */
+static int mld_oqs_status(int ret)
+{
+  return ret == 0 ? OQS_SUCCESS : OQS_ERROR;
+}
+
+int mld_oqs_keypair(uint8_t *pk, uint8_t *sk)
+{
+  return mld_oqs_status(MLD_OQS_NS(keypair)(pk, sk));
+}
 
 int mld_oqs_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
                       size_t mlen, const uint8_t *ctx, size_t ctxlen,
@@ -48,7 +67,7 @@ int mld_oqs_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
   {
     *siglen = MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET);
   }
-  return ret;
+  return mld_oqs_status(ret);
 }
 
 int mld_oqs_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
@@ -59,9 +78,9 @@ int mld_oqs_verify(const uint8_t *sig, size_t siglen, const uint8_t *m,
    * other length here. */
   if (siglen != MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET))
   {
-    return MLD_ERR_FAIL;
+    return OQS_ERROR;
   }
-  return MLD_OQS_NS(verify)(sig, m, mlen, ctx, ctxlen, pk);
+  return mld_oqs_status(MLD_OQS_NS(verify)(sig, m, mlen, ctx, ctxlen, pk));
 }
 
 int mld_oqs_signature_extmu(uint8_t *sig, size_t *siglen, const uint8_t *mu,
@@ -72,7 +91,7 @@ int mld_oqs_signature_extmu(uint8_t *sig, size_t *siglen, const uint8_t *mu,
   {
     *siglen = MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET);
   }
-  return ret;
+  return mld_oqs_status(ret);
 }
 
 int mld_oqs_verify_extmu(const uint8_t *sig, size_t siglen, const uint8_t *mu,
@@ -80,11 +99,12 @@ int mld_oqs_verify_extmu(const uint8_t *sig, size_t siglen, const uint8_t *mu,
 {
   if (siglen != MLDSA_BYTES(MLD_CONFIG_PARAMETER_SET))
   {
-    return MLD_ERR_FAIL;
+    return OQS_ERROR;
   }
-  return MLD_OQS_NS(verify_extmu)(sig, mu, pk);
+  return mld_oqs_status(MLD_OQS_NS(verify_extmu)(sig, mu, pk));
 }
 
+#undef mld_oqs_keypair
 #undef mld_oqs_signature
 #undef mld_oqs_verify
 #undef mld_oqs_signature_extmu


### PR DESCRIPTION
Collapse any nonzero result to OQS_ERROR in the sig_glue.c shims, since OQS_STATUS is a closed enum and mldsa-native returns a wider error set. Add a keypair shim so keypair is normalized too rather than wired directly to the mldsa-native symbol.

 - Resolves #1296