### PR TITLE
AArch64: Add runtime NEON capability gate to native backend

### DIFF
--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -38,6 +38,10 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_ntt_aarch64_asm(data, mld_aarch64_ntt_zetas_layer123456,
                       mld_aarch64_ntt_zetas_layer78);
   return MLD_NATIVE_FUNC_SUCCESS;
@@ -46,6 +50,10 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_intt_aarch64_asm(data, mld_aarch64_intt_zetas_layer78,
                        mld_aarch64_intt_zetas_layer123456);
   return MLD_NATIVE_FUNC_SUCCESS;
@@ -56,8 +64,8 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLDSA_N ||
-      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen % 24 != 0)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -76,7 +84,8 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
 {
   uint64_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
-  if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -104,7 +113,8 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 {
   uint64_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
-  if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -131,6 +141,10 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_decompose_32_aarch64_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -141,6 +155,10 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_decompose_88_aarch64_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -151,6 +169,10 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_caddq_aarch64_asm(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -161,6 +183,10 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_use_hint_32_aarch64_asm(a, h);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -171,6 +197,10 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_use_hint_88_aarch64_asm(a, h);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -181,6 +211,10 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   return mld_poly_chknorm_aarch64_asm(a, B);
 }
 
@@ -189,6 +223,10 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyz_unpack_17_aarch64_asm(r, buf, mld_polyz_unpack_17_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -200,6 +238,10 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *buf)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyz_unpack_19_aarch64_asm(r, buf, mld_polyz_unpack_19_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -213,6 +255,10 @@ MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_pointwise_montgomery_aarch64_asm(a, b);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -225,6 +271,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -236,6 +286,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -247,6 +301,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }

--- a/dev/aarch64_clean/src/intt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/intt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/dev/aarch64_clean/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/ntt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/pointwise_montgomery_aarch64_asm.S
+++ b/dev/aarch64_clean/src/pointwise_montgomery_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/poly_caddq_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_caddq_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/poly_chknorm_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_chknorm_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/poly_decompose_32_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/poly_decompose_88_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_decompose_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/poly_use_hint_32_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_use_hint_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/poly_use_hint_88_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_use_hint_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/polyz_unpack_17_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_17_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/polyz_unpack_19_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyz_unpack_19_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/rej_uniform_eta2_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_eta2_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_clean/src/rej_uniform_eta4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_eta4_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -38,6 +38,10 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_ntt_aarch64_asm(data, mld_aarch64_ntt_zetas_layer123456,
                       mld_aarch64_ntt_zetas_layer78);
   return MLD_NATIVE_FUNC_SUCCESS;
@@ -46,6 +50,10 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_intt_aarch64_asm(data, mld_aarch64_intt_zetas_layer78,
                        mld_aarch64_intt_zetas_layer123456);
   return MLD_NATIVE_FUNC_SUCCESS;
@@ -56,8 +64,8 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLDSA_N ||
-      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen % 24 != 0)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -76,7 +84,8 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
 {
   uint64_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
-  if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -104,7 +113,8 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 {
   uint64_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
-  if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -131,6 +141,10 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_decompose_32_aarch64_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -141,6 +155,10 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_decompose_88_aarch64_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -151,6 +169,10 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_caddq_aarch64_asm(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -161,6 +183,10 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_use_hint_32_aarch64_asm(a, h);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -171,6 +197,10 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_use_hint_88_aarch64_asm(a, h);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -181,6 +211,10 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   return mld_poly_chknorm_aarch64_asm(a, B);
 }
 
@@ -189,6 +223,10 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyz_unpack_17_aarch64_asm(r, buf, mld_polyz_unpack_17_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -200,6 +238,10 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *buf)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyz_unpack_19_aarch64_asm(r, buf, mld_polyz_unpack_19_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -213,6 +255,10 @@ MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_pointwise_montgomery_aarch64_asm(a, b);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -225,6 +271,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -236,6 +286,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -247,6 +301,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }

--- a/dev/aarch64_opt/src/intt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/intt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/dev/aarch64_opt/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/ntt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/pointwise_montgomery_aarch64_asm.S
+++ b/dev/aarch64_opt/src/pointwise_montgomery_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/poly_caddq_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_caddq_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/poly_chknorm_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_chknorm_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/poly_decompose_32_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_decompose_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/poly_decompose_88_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_decompose_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/poly_use_hint_32_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_use_hint_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/poly_use_hint_88_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_use_hint_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/polyz_unpack_17_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_17_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/polyz_unpack_19_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyz_unpack_19_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/rej_uniform_eta2_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_eta2_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/aarch64_opt/src/rej_uniform_eta4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_eta4_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -22,7 +22,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 200

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -22,7 +22,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 400

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -16,6 +16,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 800

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -16,7 +16,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 800

--- a/dev/fips202/aarch64/x1_v84a.h
+++ b/dev/fips202/aarch64/x1_v84a.h
@@ -22,7 +22,8 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x1_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) ||
+      !mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/aarch64/x2_v84a.h
+++ b/dev/fips202/aarch64/x2_v84a.h
@@ -23,7 +23,8 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) ||
+      !mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/aarch64/x4_v8a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_scalar.h
@@ -18,6 +18,11 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
+
   mld_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(
       state, mld_keccakf1600_round_constants);
   return MLD_NATIVE_FUNC_SUCCESS;

--- a/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
@@ -22,7 +22,8 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) ||
+      !mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/integration/aws-lc/post_import.patch
+++ b/integration/aws-lc/post_import.patch
@@ -10,7 +10,7 @@
 diff --git a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h b/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
 --- a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
 +++ b/crypto/fipsmodule/ml_dsa/mldsa_native_config.h
-@@ -42,7 +42,7 @@
+@@ -42,10 +42,15 @@
  static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  {
  #if defined(MLD_SYS_X86_64)
@@ -19,6 +19,14 @@ diff --git a/crypto/fipsmodule/ml_dsa/mldsa_native_config.h b/crypto/fipsmodule/
    {
      return CRYPTO_is_AVX2_capable();
    }
++#elif defined(MLD_SYS_AARCH64)
++  if (cap == MLD_SYS_CAP_AARCH64_NEON)
++  {
++    return CRYPTO_is_NEON_capable();
++  }
+ #endif
+   return 0;
+ }
 diff --git a/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h b/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h
 --- a/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h
 +++ b/crypto/fipsmodule/ml_dsa/mldsa_x86_64_meta.h

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -22,7 +22,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 200

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -22,7 +22,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 400

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -16,6 +16,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 800

--- a/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -16,7 +16,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 800

--- a/mldsa/src/fips202/native/aarch64/x1_v84a.h
+++ b/mldsa/src/fips202/native/aarch64/x1_v84a.h
@@ -22,7 +22,8 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x1_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) ||
+      !mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/fips202/native/aarch64/x2_v84a.h
+++ b/mldsa/src/fips202/native/aarch64/x2_v84a.h
@@ -23,7 +23,8 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) ||
+      !mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/fips202/native/aarch64/x4_v8a_scalar.h
+++ b/mldsa/src/fips202/native/aarch64/x4_v8a_scalar.h
@@ -18,6 +18,11 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
+
   mld_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(
       state, mld_keccakf1600_round_constants);
   return MLD_NATIVE_FUNC_SUCCESS;

--- a/mldsa/src/fips202/native/aarch64/x4_v8a_v84a_scalar.h
+++ b/mldsa/src/fips202/native/aarch64/x4_v8a_v84a_scalar.h
@@ -22,7 +22,8 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) ||
+      !mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }

--- a/mldsa/src/native/aarch64/meta.h
+++ b/mldsa/src/native/aarch64/meta.h
@@ -38,6 +38,10 @@
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_ntt_aarch64_asm(data, mld_aarch64_ntt_zetas_layer123456,
                       mld_aarch64_ntt_zetas_layer78);
   return MLD_NATIVE_FUNC_SUCCESS;
@@ -46,6 +50,10 @@ static MLD_INLINE int mld_ntt_native(int32_t data[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_intt_native(int32_t data[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_intt_aarch64_asm(data, mld_aarch64_intt_zetas_layer78,
                        mld_aarch64_intt_zetas_layer123456);
   return MLD_NATIVE_FUNC_SUCCESS;
@@ -56,8 +64,8 @@ static MLD_INLINE int mld_rej_uniform_native(int32_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLDSA_N ||
-      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen % 24 != 0)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -76,7 +84,8 @@ static MLD_INLINE int mld_rej_uniform_eta2_native(int32_t *r, unsigned len,
 {
   uint64_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
-  if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen != MLD_AARCH64_REJ_UNIFORM_ETA2_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -104,7 +113,8 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 {
   uint64_t outlen;
   /* AArch64 implementation assumes specific buffer lengths */
-  if (len != MLDSA_N || buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) || len != MLDSA_N ||
+      buflen != MLD_AARCH64_REJ_UNIFORM_ETA4_BUFLEN)
   {
     return MLD_NATIVE_FUNC_FALLBACK;
   }
@@ -131,6 +141,10 @@ static MLD_INLINE int mld_rej_uniform_eta4_native(int32_t *r, unsigned len,
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_decompose_32_aarch64_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -141,6 +155,10 @@ static MLD_INLINE int mld_poly_decompose_32_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_decompose_88_aarch64_asm(a1, a0);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -151,6 +169,10 @@ static MLD_INLINE int mld_poly_decompose_88_native(int32_t *a1, int32_t *a0)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_caddq_aarch64_asm(a);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -161,6 +183,10 @@ static MLD_INLINE int mld_poly_caddq_native(int32_t a[MLDSA_N])
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_use_hint_32_aarch64_asm(a, h);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -171,6 +197,10 @@ static MLD_INLINE int mld_poly_use_hint_32_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_use_hint_88_aarch64_asm(a, h);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -181,6 +211,10 @@ static MLD_INLINE int mld_poly_use_hint_88_native(int32_t *a, const int32_t *h)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   return mld_poly_chknorm_aarch64_asm(a, B);
 }
 
@@ -189,6 +223,10 @@ static MLD_INLINE int mld_poly_chknorm_native(const int32_t *a, int32_t B)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyz_unpack_17_aarch64_asm(r, buf, mld_polyz_unpack_17_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -200,6 +238,10 @@ static MLD_INLINE int mld_polyz_unpack_17_native(int32_t *r, const uint8_t *buf)
 MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_polyz_unpack_19_native(int32_t *r, const uint8_t *buf)
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyz_unpack_19_aarch64_asm(r, buf, mld_polyz_unpack_19_indices);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -213,6 +255,10 @@ MLD_MUST_CHECK_RETURN_VALUE
 static MLD_INLINE int mld_poly_pointwise_montgomery_native(
     int32_t a[MLDSA_N], const int32_t b[MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_poly_pointwise_montgomery_aarch64_asm(a, b);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -225,6 +271,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l4_native(
     int32_t w[MLDSA_N], const int32_t u[4][MLDSA_N],
     const int32_t v[4][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -236,6 +286,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l5_native(
     int32_t w[MLDSA_N], const int32_t u[5][MLDSA_N],
     const int32_t v[5][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }
@@ -247,6 +301,10 @@ static MLD_INLINE int mld_polyvecl_pointwise_acc_montgomery_l7_native(
     int32_t w[MLDSA_N], const int32_t u[7][MLDSA_N],
     const int32_t v[7][MLDSA_N])
 {
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    return MLD_NATIVE_FUNC_FALLBACK;
+  }
   mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(w, u, v);
   return MLD_NATIVE_FUNC_SUCCESS;
 }

--- a/mldsa/src/native/aarch64/src/intt_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/intt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/ntt_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/ntt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/pointwise_montgomery_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/pointwise_montgomery_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/poly_caddq_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_caddq_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/poly_chknorm_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_chknorm_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/poly_decompose_32_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_decompose_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/poly_decompose_88_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_decompose_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/poly_use_hint_32_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_use_hint_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/poly_use_hint_88_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/poly_use_hint_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/polyz_unpack_17_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_17_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/polyz_unpack_19_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/polyz_unpack_19_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/rej_uniform_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/rej_uniform_eta2_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_eta2_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/native/aarch64/src/rej_uniform_eta4_aarch64_asm.S
+++ b/mldsa/src/native/aarch64/src/rej_uniform_eta4_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/mldsa/src/sys.h
+++ b/mldsa/src/sys.h
@@ -266,6 +266,7 @@ typedef enum
   /* x86_64 */
   MLD_SYS_CAP_X86_64_AVX2,
   /* AArch64 */
+  MLD_SYS_CAP_AARCH64_NEON,
   MLD_SYS_CAP_AARCH64_SHA3,
   /* Armv8.1-M */
   MLD_SYS_CAP_ARMV81M_MVE

--- a/proofs/hol_light/aarch64/mldsa/intt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/intt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -22,7 +22,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 200

--- a/proofs/hol_light/aarch64/mldsa/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -22,7 +22,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 400

--- a/proofs/hol_light/aarch64/mldsa/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -16,6 +16,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 800

--- a/proofs/hol_light/aarch64/mldsa/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -16,7 +16,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 800

--- a/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/ntt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/ntt_aarch64_asm.S
@@ -34,6 +34,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/pointwise_montgomery_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/pointwise_montgomery_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/poly_caddq_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_caddq_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/poly_chknorm_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_chknorm_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/poly_decompose_32_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_decompose_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/poly_decompose_88_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_decompose_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/poly_use_hint_32_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_use_hint_32_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/poly_use_hint_88_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/poly_use_hint_88_aarch64_asm.S
@@ -9,6 +9,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/polyz_unpack_17_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/polyz_unpack_17_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/polyz_unpack_19_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/polyz_unpack_19_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/rej_uniform_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/rej_uniform_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/rej_uniform_eta2_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/rej_uniform_eta2_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/proofs/hol_light/aarch64/mldsa/rej_uniform_eta4_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mldsa/rej_uniform_eta4_aarch64_asm.S
@@ -11,6 +11,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 1024

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2342,6 +2342,7 @@ def check_macro_typos_in_file(filename, macro_check):
 def get_syscaps():
     return [
         "MLD_SYS_CAP_X86_64_AVX2",
+        "MLD_SYS_CAP_AARCH64_NEON",
         "MLD_SYS_CAP_AARCH64_SHA3",
         "MLD_SYS_CAP_ARMV81M_MVE",
     ]
@@ -4254,6 +4255,14 @@ ABI_CAPS = {
         "cflags": ["-mavx2", "-mbmi2"],
         "aux_files": [],
     },
+    "NEON": {
+        "asm_subdir": "aarch64",
+        "guard": None,
+        "syscap": "MLD_SYS_CAP_AARCH64_NEON",
+        "description": "AArch64 NEON",
+        "cflags": [],
+        "aux_files": [],
+    },
     "SHA3": {
         "asm_subdir": "aarch64",
         "guard": "__ARM_FEATURE_SHA3",
@@ -4295,7 +4304,7 @@ ARCH_CALLINGS = {
         "gpr_int_type": "uint64_t",
         "fn_qualifier": "",
         "init_func": "init_aarch64_register_state",
-        "stub_func": "asm_call_stub_aarch64",
+        "stub_func": "call_stub_aarch64",
         "check_func": "check_aarch64_aapcs_compliance",
         # YAML register xN maps to gpr[N].
         "reg_to_field": lambda reg: f"gpr[{int(reg[1:])}]",
@@ -4312,7 +4321,7 @@ ARCH_CALLINGS = {
         # mldsa/src/native/x86_64/src/arith_native_x86_64.h.
         "fn_qualifier": "MLD_SYSV_ABI",
         "init_func": "init_x86_64_register_state",
-        "stub_func": "asm_call_stub_x86_64_sysv",
+        "stub_func": "call_stub_x86_64_sysv",
         "check_func": "check_x86_64_sysv_compliance",
         "reg_to_field": lambda reg: reg,
     },
@@ -4324,7 +4333,7 @@ ARCH_CALLINGS = {
         "gpr_int_type": "uint32_t",
         "fn_qualifier": "",
         "init_func": "init_armv81m_register_state",
-        "stub_func": "asm_call_stub_armv81m",
+        "stub_func": "call_stub_armv81m",
         "check_func": "check_armv81m_aapcs32_compliance",
         # AAPCS32 GPRs r0-r12 map directly to gpr[0..12].
         "reg_to_field": lambda reg: f"gpr[{int(reg[1:])}]",
@@ -4790,7 +4799,8 @@ def gen_abicheck():
                 f"ABICHECK_REQ_{cap}_OBJS := "
                 f"$(call MAKE_OBJS,$(ABICHECK_DIR),$(ABICHECK_REQ_{cap}_FILES))"
             )
-            yield f"$(ABICHECK_REQ_{cap}_OBJS): CFLAGS += {cflags}"
+            if cflags:
+                yield f"$(ABICHECK_REQ_{cap}_OBJS): CFLAGS += {cflags}"
         yield ""
 
     for asm_subdir, caps in caps_by_subdir.items():

--- a/test/abicheck/aarch64/abicheck_aarch64.c
+++ b/test/abicheck/aarch64/abicheck_aarch64.c
@@ -45,13 +45,17 @@ int check_aarch64_aapcs_compliance(struct aarch64_register_state *before,
     }
   }
 
-  /* Check callee-saved NEON registers (d8-d15, lower 64 bits only) */
-  for (i = 8; i <= 15; i++)
+  /* The call stub leaves vector output untouched when NEON is unavailable. */
+  if (mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
   {
-    if (before->neon[i][0] != after->neon[i][0])
+    /* Check callee-saved NEON registers (d8-d15, lower 64 bits only). */
+    for (i = 8; i <= 15; i++)
     {
-      MLD_ABI_VIOLATION(quiet, "d%d modified\n", i);
-      violations++;
+      if (before->neon[i][0] != after->neon[i][0])
+      {
+        MLD_ABI_VIOLATION(quiet, "d%d modified\n", i);
+        violations++;
+      }
     }
   }
 

--- a/test/abicheck/aarch64/abicheck_aarch64.h
+++ b/test/abicheck/aarch64/abicheck_aarch64.h
@@ -27,7 +27,15 @@ void init_aarch64_register_state(struct aarch64_register_state *state);
 
 extern void asm_call_stub_aarch64(struct aarch64_register_state *input,
                                   struct aarch64_register_state *output,
-                                  void (*function_ptr)(void));
+                                  void (*function_ptr)(void), int use_neon);
+
+static MLD_INLINE void call_stub_aarch64(struct aarch64_register_state *input,
+                                         struct aarch64_register_state *output,
+                                         void (*function_ptr)(void))
+{
+  int use_neon = mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON) != 0;
+  asm_call_stub_aarch64(input, output, function_ptr, use_neon);
+}
 
 #endif /* MLD_SYS_AARCH64 */
 

--- a/test/abicheck/aarch64/abicheck_aarch64.mk
+++ b/test/abicheck/aarch64/abicheck_aarch64.mk
@@ -14,7 +14,33 @@
 
 # Default each cap's file list to empty so the unconditional appends
 # below are safe even when a cap has no kernels on this arch.
+ABICHECK_REQ_NEON_FILES :=
 ABICHECK_REQ_SHA3_FILES :=
+
+# NEON: AArch64 NEON
+ABICHECK_REQ_NEON_FILES := \
+  mldsa/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S \
+  mldsa/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S \
+  mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S \
+  mldsa/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/intt_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/ntt_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/pointwise_montgomery_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/poly_caddq_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/poly_chknorm_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/poly_decompose_32_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/poly_decompose_88_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/poly_use_hint_32_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/poly_use_hint_88_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/polyz_unpack_17_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/polyz_unpack_19_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/rej_uniform_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/rej_uniform_eta2_aarch64_asm.S \
+  mldsa/src/native/aarch64/src/rej_uniform_eta4_aarch64_asm.S
+ABICHECK_REQ_NEON_OBJS := $(call MAKE_OBJS,$(ABICHECK_DIR),$(ABICHECK_REQ_NEON_FILES))
 
 # SHA3: Armv8.4-A SHA3 (eor3, rax1, xar, bcax)
 ABICHECK_REQ_SHA3_FILES := \

--- a/test/abicheck/aarch64/callstub_aarch64.S
+++ b/test/abicheck/aarch64/callstub_aarch64.S
@@ -15,19 +15,21 @@
  *
  * C Signature: void asm_call_stub_aarch64(struct aarch64_register_state *input,
  *                                         struct aarch64_register_state *output,
- *                                         void (*function_ptr)(void))
+ *                                         void (*function_ptr)(void),
+ *                                         int use_neon)
  *
- * Stack Usage: 192 bytes total (16-byte aligned)
+ * Stack Usage: 208 bytes total (16-byte aligned)
  *   - 112 bytes for saving callee-saved GPRs (x18-x30: 7 pairs * 16 bytes)
  *   - 64 bytes for saving callee-saved NEON registers (d8-d15: 8 regs * 8 bytes)
- *   - 16 bytes for local variables (output state ptr, function ptr)
+ *   - 32 bytes for local variables (output state ptr, function ptr,
+ *     use_neon flag, padding)
  */
 
 #define STACK_SIZE_GPRS   112
 #define STACK_SIZE_VREGS  64
-#define STACK_SIZE_LOCALS 16
+#define STACK_SIZE_LOCALS 32
 
-#define STACK_SIZE 192
+#define STACK_SIZE 208
 #define STACK_BASE_GPRS 0
 #define STACK_BASE_VREGS  STACK_SIZE_GPRS
 #define STACK_BASE_LOCALS (STACK_SIZE_GPRS + STACK_SIZE_VREGS)
@@ -62,28 +64,6 @@
         .cfi_restore \hi
 .endm
 
-/* Callee-saved GPRs x18-x30; xzr pads the x18 slot for 16-byte stp/ldp
- * alignment (see save_pair_padlo). */
-.macro save_gprs
-        save_pair_padlo x18, STACK_BASE_GPRS, 0
-        save_pair x19, x20, STACK_BASE_GPRS, 1
-        save_pair x21, x22, STACK_BASE_GPRS, 2
-        save_pair x23, x24, STACK_BASE_GPRS, 3
-        save_pair x25, x26, STACK_BASE_GPRS, 4
-        save_pair x27, x28, STACK_BASE_GPRS, 5
-        save_pair x29, x30, STACK_BASE_GPRS, 6
-.endm
-
-.macro restore_gprs
-        restore_pair_padlo x18, STACK_BASE_GPRS, 0
-        restore_pair x19, x20, STACK_BASE_GPRS, 1
-        restore_pair x21, x22, STACK_BASE_GPRS, 2
-        restore_pair x23, x24, STACK_BASE_GPRS, 3
-        restore_pair x25, x26, STACK_BASE_GPRS, 4
-        restore_pair x27, x28, STACK_BASE_GPRS, 5
-        restore_pair x29, x30, STACK_BASE_GPRS, 6
-.endm
-
 /* Callee-saved NEON registers d8-d15. */
 .macro save_vregs
         save_pair  d8,  d9, STACK_BASE_VREGS, 0
@@ -99,46 +79,76 @@
         restore_pair d14, d15, STACK_BASE_VREGS, 3
 .endm
 
-.text
-.balign 4
-#ifdef __APPLE__
-.global _asm_call_stub_aarch64
-_asm_call_stub_aarch64:
-#else
-.global asm_call_stub_aarch64
-asm_call_stub_aarch64:
-#endif
-        .cfi_startproc
-        sub sp, sp, #(STACK_SIZE)
-        .cfi_def_cfa_offset STACK_SIZE
+/* Save the caller's callee-saved vector registers and seed q0-q31 from the
+ * input state. Skip every vector instruction when \use_neon is zero. */
+.macro save_and_load_vregs use_neon, scratch
+        cbz \use_neon, 1f
 
-        save_gprs
         save_vregs
 
-        /* Spill output ptr (x1) and fn ptr (x2); the next block loads
-         * x0-x29 from input state and clobbers them. */
-        stp x1, x2, [sp, #(STACK_BASE_LOCALS)]
+        add \scratch, x0,  #256
+        ldp q0,  q1,  [\scratch, #(16*0)]
+        ldp q2,  q3,  [\scratch, #(16*2)]
+        ldp q4,  q5,  [\scratch, #(16*4)]
+        ldp q6,  q7,  [\scratch, #(16*6)]
+        ldp q8,  q9,  [\scratch, #(16*8)]
+        ldp q10, q11, [\scratch, #(16*10)]
+        ldp q12, q13, [\scratch, #(16*12)]
+        ldp q14, q15, [\scratch, #(16*14)]
+        ldp q16, q17, [\scratch, #(16*16)]
+        ldp q18, q19, [\scratch, #(16*18)]
+        ldp q20, q21, [\scratch, #(16*20)]
+        ldp q22, q23, [\scratch, #(16*22)]
+        ldp q24, q25, [\scratch, #(16*24)]
+        ldp q26, q27, [\scratch, #(16*26)]
+        ldp q28, q29, [\scratch, #(16*28)]
+        ldp q30, q31, [\scratch, #(16*30)]
 
-        /* Load NEON registers from input state */
-        add x30, x0,  #256
-        ldp q0,  q1,  [x30, #(16*0)]
-        ldp q2,  q3,  [x30, #(16*2)]
-        ldp q4,  q5,  [x30, #(16*4)]
-        ldp q6,  q7,  [x30, #(16*6)]
-        ldp q8,  q9,  [x30, #(16*8)]
-        ldp q10, q11, [x30, #(16*10)]
-        ldp q12, q13, [x30, #(16*12)]
-        ldp q14, q15, [x30, #(16*14)]
-        ldp q16, q17, [x30, #(16*16)]
-        ldp q18, q19, [x30, #(16*18)]
-        ldp q20, q21, [x30, #(16*20)]
-        ldp q22, q23, [x30, #(16*22)]
-        ldp q24, q25, [x30, #(16*24)]
-        ldp q26, q27, [x30, #(16*26)]
-        ldp q28, q29, [x30, #(16*28)]
-        ldp q30, q31, [x30, #(16*30)]
-        /* Load GPRs from input state */
-        sub x30, x30, #256
+1:
+.endm
+
+/* Capture q0-q31 in the output state and restore the caller's callee-saved
+ * vector registers. Skip every vector instruction when \use_neon is zero. */
+.macro store_and_restore_vregs use_neon, scratch
+        ldr \use_neon, [sp, #(STACK_BASE_LOCALS + 16)]
+        cbz \use_neon, 1f
+
+        ldr \scratch, [sp, #(STACK_BASE_LOCALS + 0)]
+        add \scratch, \scratch, #256
+        stp q0,  q1,  [\scratch, #(16*0)]
+        stp q2,  q3,  [\scratch, #(16*2)]
+        stp q4,  q5,  [\scratch, #(16*4)]
+        stp q6,  q7,  [\scratch, #(16*6)]
+        stp q8,  q9,  [\scratch, #(16*8)]
+        stp q10, q11, [\scratch, #(16*10)]
+        stp q12, q13, [\scratch, #(16*12)]
+        stp q14, q15, [\scratch, #(16*14)]
+        stp q16, q17, [\scratch, #(16*16)]
+        stp q18, q19, [\scratch, #(16*18)]
+        stp q20, q21, [\scratch, #(16*20)]
+        stp q22, q23, [\scratch, #(16*22)]
+        stp q24, q25, [\scratch, #(16*24)]
+        stp q26, q27, [\scratch, #(16*26)]
+        stp q28, q29, [\scratch, #(16*28)]
+        stp q30, q31, [\scratch, #(16*30)]
+
+        restore_vregs
+
+1:
+.endm
+
+/* Save the caller's callee-saved GPRs and seed x0-x29 from the input state
+ * initially passed in x0. xzr pads the x18 slot for 16-byte alignment. */
+.macro save_and_load_gprs
+        save_pair_padlo x18, STACK_BASE_GPRS, 0
+        save_pair x19, x20, STACK_BASE_GPRS, 1
+        save_pair x21, x22, STACK_BASE_GPRS, 2
+        save_pair x23, x24, STACK_BASE_GPRS, 3
+        save_pair x25, x26, STACK_BASE_GPRS, 4
+        save_pair x27, x28, STACK_BASE_GPRS, 5
+        save_pair x29, x30, STACK_BASE_GPRS, 6
+
+        mov x30, x0
         ldp x0,  x1,  [x30, #(8*0)]
         ldp x2,  x3,  [x30, #(8*2)]
         ldp x4,  x5,  [x30, #(8*4)]
@@ -165,15 +175,13 @@ asm_call_stub_aarch64:
         ldp x24, x25, [x30, #(8*24)]
         ldp x26, x27, [x30, #(8*26)]
         ldp x28, x29, [x30, #(8*28)]
+.endm
 
-        /* Reload target function pointer (overwriting x30/LR is fine - blr will set it) */
-        ldr x30, [sp, #(STACK_BASE_LOCALS + 8)]
-        /* Call target */
-        blr x30
-        /* Load output state address (overwrite x30/LR again) */
+/* Capture x0-x29 in the output state and restore the caller's callee-saved
+ * GPRs. */
+.macro store_and_restore_gprs
         ldr x30, [sp, #(STACK_BASE_LOCALS + 0)]
 
-        /* Store final GPR state to output state */
         stp x0,  x1,  [x30, #(8*0)]
         stp x2,  x3,  [x30, #(8*2)]
         stp x4,  x5,  [x30, #(8*4)]
@@ -190,27 +198,40 @@ asm_call_stub_aarch64:
         stp x26, x27, [x30, #(8*26)]
         stp x28, x29, [x30, #(8*28)]
 
-        /* Store final NEON state to output state */
-        add x30,  x30,  #256
-        stp q0,  q1,  [x30, #(16*0)]
-        stp q2,  q3,  [x30, #(16*2)]
-        stp q4,  q5,  [x30, #(16*4)]
-        stp q6,  q7,  [x30, #(16*6)]
-        stp q8,  q9,  [x30, #(16*8)]
-        stp q10, q11, [x30, #(16*10)]
-        stp q12, q13, [x30, #(16*12)]
-        stp q14, q15, [x30, #(16*14)]
-        stp q16, q17, [x30, #(16*16)]
-        stp q18, q19, [x30, #(16*18)]
-        stp q20, q21, [x30, #(16*20)]
-        stp q22, q23, [x30, #(16*22)]
-        stp q24, q25, [x30, #(16*24)]
-        stp q26, q27, [x30, #(16*26)]
-        stp q28, q29, [x30, #(16*28)]
-        stp q30, q31, [x30, #(16*30)]
+        restore_pair_padlo x18, STACK_BASE_GPRS, 0
+        restore_pair x19, x20, STACK_BASE_GPRS, 1
+        restore_pair x21, x22, STACK_BASE_GPRS, 2
+        restore_pair x23, x24, STACK_BASE_GPRS, 3
+        restore_pair x25, x26, STACK_BASE_GPRS, 4
+        restore_pair x27, x28, STACK_BASE_GPRS, 5
+        restore_pair x29, x30, STACK_BASE_GPRS, 6
+.endm
 
-        restore_vregs
-        restore_gprs
+.text
+.balign 4
+#ifdef __APPLE__
+.global _asm_call_stub_aarch64
+_asm_call_stub_aarch64:
+#else
+.global asm_call_stub_aarch64
+asm_call_stub_aarch64:
+#endif
+        .cfi_startproc
+        sub sp, sp, #(STACK_SIZE)
+        .cfi_def_cfa_offset STACK_SIZE
+
+        /* Spill output ptr (x1), fn ptr (x2), and use_neon (w3). */
+        stp x1, x2, [sp, #(STACK_BASE_LOCALS)]
+        str w3, [sp, #(STACK_BASE_LOCALS + 16)]
+
+        save_and_load_vregs w3, x3
+        save_and_load_gprs
+
+        ldr x30, [sp, #(STACK_BASE_LOCALS + 8)]
+        blr x30
+
+        store_and_restore_gprs
+        store_and_restore_vregs w3, x3
         add sp, sp, #(STACK_SIZE)
         .cfi_def_cfa_offset 0
         ret

--- a/test/abicheck/aarch64/checks/check_intt_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_intt_aarch64_asm.c
@@ -34,6 +34,13 @@ int check_intt_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x2[640]; /* Twiddle factors for layers 1-6 (160 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check intt_aarch64_asm: host lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,8 +56,8 @@ int check_intt_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_intt_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_intt_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x1_scalar_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x1_scalar_aarch64_asm.c
@@ -44,9 +44,8 @@ int check_keccak_f1600_x1_scalar_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
-        &input_state, &output_state,
-        (void (*)(void))mld_keccak_f1600_x1_scalar_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_keccak_f1600_x1_scalar_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x1_v84a_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x1_v84a_aarch64_asm.c
@@ -31,6 +31,14 @@ int check_keccak_f1600_x1_v84a_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x0[200]; /* Keccak state (25 x uint64_t) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x1_v84a_aarch64_asm: host lacks AArch64 "
+            "NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     fprintf(stderr,
@@ -52,8 +60,8 @@ int check_keccak_f1600_x1_v84a_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_keccak_f1600_x1_v84a_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_keccak_f1600_x1_v84a_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x2_v84a_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x2_v84a_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_keccak_f1600_x2_v84a_aarch64_asm(void)
       buf_x0[400]; /* Two sequential Keccak states (state0[25], state1[25]) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x2_v84a_aarch64_asm: host lacks AArch64 "
+            "NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     fprintf(stderr,
@@ -53,8 +61,8 @@ int check_keccak_f1600_x2_v84a_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_keccak_f1600_x2_v84a_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_keccak_f1600_x2_v84a_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(void)
                                     state1[25], state2[25], state3[25]) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm: host "
+            "lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -45,7 +53,7 @@ int check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mld_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm(void)
                                     state1[25], state2[25], state3[25]) */
   MLD_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm: "
+            "host lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_SHA3))
   {
     fprintf(stderr,
@@ -53,7 +61,7 @@ int check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mld_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_ntt_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_ntt_aarch64_asm.c
@@ -34,6 +34,13 @@ int check_ntt_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x2[1536]; /* Twiddle factors for layers 7-8 (384 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check ntt_aarch64_asm: host lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,8 +56,8 @@ int check_ntt_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_ntt_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_ntt_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_caddq_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_caddq_aarch64_asm.c
@@ -29,6 +29,14 @@ int check_poly_caddq_aarch64_asm(void)
   int violations;
   MLD_ALIGN uint8_t buf_x0[1024]; /* Input/output polynomial (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_caddq_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -40,8 +48,8 @@ int check_poly_caddq_aarch64_asm(void)
     input_state.gpr[0] = (uint64_t)buf_x0;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_poly_caddq_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_poly_caddq_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_chknorm_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_chknorm_aarch64_asm.c
@@ -29,6 +29,14 @@ int check_poly_chknorm_aarch64_asm(void)
   int violations;
   MLD_ALIGN uint8_t buf_x0[1024]; /* Input polynomial (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_chknorm_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -41,8 +49,8 @@ int check_poly_chknorm_aarch64_asm(void)
     input_state.gpr[1] = 131072;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_poly_chknorm_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_poly_chknorm_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_decompose_32_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_decompose_32_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_poly_decompose_32_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x1[1024]; /* Input polynomial / output low-part (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_decompose_32_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -45,8 +53,8 @@ int check_poly_decompose_32_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_poly_decompose_32_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_poly_decompose_32_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_decompose_88_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_decompose_88_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_poly_decompose_88_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x1[1024]; /* Input polynomial / output low-part (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_decompose_88_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -45,8 +53,8 @@ int check_poly_decompose_88_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_poly_decompose_88_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_poly_decompose_88_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_pointwise_montgomery_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_pointwise_montgomery_aarch64_asm.c
@@ -31,6 +31,14 @@ int check_poly_pointwise_montgomery_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x0[1024]; /* Input/output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_x1[1024]; /* Input polynomial (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_pointwise_montgomery_aarch64_asm: host lacks "
+            "AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -44,7 +52,7 @@ int check_poly_pointwise_montgomery_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mld_poly_pointwise_montgomery_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_poly_use_hint_32_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_use_hint_32_aarch64_asm.c
@@ -30,6 +30,14 @@ int check_poly_use_hint_32_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x0[1024]; /* Input/output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_x1[1024]; /* Hint polynomial (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_use_hint_32_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -43,8 +51,8 @@ int check_poly_use_hint_32_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_poly_use_hint_32_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_poly_use_hint_32_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_use_hint_88_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_use_hint_88_aarch64_asm.c
@@ -30,6 +30,14 @@ int check_poly_use_hint_88_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x0[1024]; /* Input/output polynomial (256 x int32_t) */
   MLD_ALIGN uint8_t buf_x1[1024]; /* Hint polynomial (256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_use_hint_88_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -43,8 +51,8 @@ int check_poly_use_hint_88_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_poly_use_hint_88_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_poly_use_hint_88_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm.c
@@ -34,6 +34,14 @@ int check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x2[4096]; /* Input polynomial vector b (4 x 256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyvecl_pointwise_acc_montgomery_l4_aarch64_asm: host "
+            "lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,7 +57,7 @@ int check_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mld_polyvecl_pointwise_acc_montgomery_l4_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm.c
@@ -34,6 +34,14 @@ int check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x2[5120]; /* Input polynomial vector b (5 x 256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyvecl_pointwise_acc_montgomery_l5_aarch64_asm: host "
+            "lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,7 +57,7 @@ int check_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mld_polyvecl_pointwise_acc_montgomery_l5_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm.c
@@ -34,6 +34,14 @@ int check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(void)
   MLD_ALIGN uint8_t
       buf_x2[7168]; /* Input polynomial vector b (7 x 256 x int32_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyvecl_pointwise_acc_montgomery_l7_aarch64_asm: host "
+            "lacks AArch64 NEON, skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,7 +57,7 @@ int check_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mld_polyvecl_pointwise_acc_montgomery_l7_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_polyz_unpack_17_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyz_unpack_17_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_polyz_unpack_17_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x1[576];  /* Packed input bytes */
   MLD_ALIGN uint8_t buf_x2[64];   /* Permutation index table (64 x uint8_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyz_unpack_17_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -47,8 +55,8 @@ int check_polyz_unpack_17_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_polyz_unpack_17_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_polyz_unpack_17_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_polyz_unpack_19_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyz_unpack_19_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_polyz_unpack_19_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x1[640];  /* Packed input bytes */
   MLD_ALIGN uint8_t buf_x2[64];   /* Permutation index table (64 x uint8_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyz_unpack_19_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -47,8 +55,8 @@ int check_polyz_unpack_19_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_polyz_unpack_19_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_polyz_unpack_19_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_rej_uniform_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_rej_uniform_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x1[840];  /* Input buffer */
   MLD_ALIGN uint8_t buf_x3[256];  /* Lookup table (256 x uint8_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check rej_uniform_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -48,8 +56,8 @@ int check_rej_uniform_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_rej_uniform_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_rej_uniform_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_rej_uniform_eta2_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_eta2_aarch64_asm.c
@@ -33,6 +33,14 @@ int check_rej_uniform_eta2_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x1[136];  /* Input buffer */
   MLD_ALIGN uint8_t buf_x3[4096]; /* Lookup table (4096 x uint8_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check rej_uniform_eta2_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,8 +57,8 @@ int check_rej_uniform_eta2_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_rej_uniform_eta2_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_rej_uniform_eta2_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_rej_uniform_eta4_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_eta4_aarch64_asm.c
@@ -33,6 +33,14 @@ int check_rej_uniform_eta4_aarch64_asm(void)
   MLD_ALIGN uint8_t buf_x1[272];  /* Input buffer */
   MLD_ALIGN uint8_t buf_x3[4096]; /* Lookup table (4096 x uint8_t) */
 
+  if (!mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    fprintf(stderr,
+            "ABI check rej_uniform_eta4_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLD_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLD_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,8 +57,8 @@ int check_rej_uniform_eta4_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mld_rej_uniform_eta4_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mld_rej_uniform_eta4_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/armv81m/abicheck_armv81m.h
+++ b/test/abicheck/armv81m/abicheck_armv81m.h
@@ -37,6 +37,13 @@ extern void asm_call_stub_armv81m(struct armv81m_register_state *input,
                                   struct armv81m_register_state *output,
                                   void (*function_ptr)(void));
 
+static MLD_INLINE void call_stub_armv81m(struct armv81m_register_state *input,
+                                         struct armv81m_register_state *output,
+                                         void (*function_ptr)(void))
+{
+  asm_call_stub_armv81m(input, output, function_ptr);
+}
+
 #endif /* MLD_SYS_ARMV81M_MVE */
 
 #endif /* !MLD_TEST_ABICHECK_ABICHECK_ARMV81M_H */

--- a/test/abicheck/armv81m/checks/check_keccak_f1600_x4_mve_asm.c
+++ b/test/abicheck/armv81m/checks/check_keccak_f1600_x4_mve_asm.c
@@ -57,8 +57,8 @@ int check_keccak_f1600_x4_mve_asm(void)
     input_state.gpr[2] = (uint32_t)buf_r2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_armv81m(&input_state, &output_state,
-                          (void (*)(void))mld_keccak_f1600_x4_mve_asm);
+    call_stub_armv81m(&input_state, &output_state,
+                      (void (*)(void))mld_keccak_f1600_x4_mve_asm);
 
     /* Check ABI compliance */
     violations = check_armv81m_aapcs32_compliance(&input_state, &output_state,

--- a/test/abicheck/selftest.c
+++ b/test/abicheck/selftest.c
@@ -109,7 +109,7 @@ extern void selftest_aarch64_corrupt_d13(void);
 extern void selftest_aarch64_corrupt_d14(void);
 extern void selftest_aarch64_corrupt_d15(void);
 
-static const selftest_entry_t aarch64_entries[] = {
+static const selftest_entry_t aarch64_gpr_entries[] = {
     {"noop", selftest_aarch64_noop, 0},
 #if !defined(__APPLE__)
     {"corrupt_x18", selftest_aarch64_corrupt_x18, 1},
@@ -125,6 +125,10 @@ static const selftest_entry_t aarch64_entries[] = {
     {"corrupt_x27", selftest_aarch64_corrupt_x27, 1},
     {"corrupt_x28", selftest_aarch64_corrupt_x28, 1},
     {"corrupt_x29", selftest_aarch64_corrupt_x29, 1},
+    {NULL, NULL, 0},
+};
+
+static const selftest_entry_t aarch64_neon_entries[] = {
     {"corrupt_d8", selftest_aarch64_corrupt_d8, 1},
     {"corrupt_d9", selftest_aarch64_corrupt_d9, 1},
     {"corrupt_d10", selftest_aarch64_corrupt_d10, 1},
@@ -209,18 +213,28 @@ int abicheck_selftest(void)
 
 #if defined(MLD_SYS_AARCH64)
   SELFTEST_RUN_ARCH("aarch64", struct aarch64_register_state,
-                    init_aarch64_register_state, asm_call_stub_aarch64,
-                    check_aarch64_aapcs_compliance, aarch64_entries,
+                    init_aarch64_register_state, call_stub_aarch64,
+                    check_aarch64_aapcs_compliance, aarch64_gpr_entries,
                     (void (*)(void)));
+
+  /* The NEON corrupters execute vector instructions, so running them on a
+   * host without NEON would fault instead of testing the ABI checker. */
+  if (mld_sys_check_capability(MLD_SYS_CAP_AARCH64_NEON))
+  {
+    SELFTEST_RUN_ARCH("aarch64", struct aarch64_register_state,
+                      init_aarch64_register_state, call_stub_aarch64,
+                      check_aarch64_aapcs_compliance, aarch64_neon_entries,
+                      (void (*)(void)));
+  }
 #elif defined(MLD_SYS_X86_64) && defined(MLD_SYSV_ABI_SUPPORTED)
   SELFTEST_RUN_ARCH(
       "x86_64", struct x86_64_register_state, init_x86_64_register_state,
-      asm_call_stub_x86_64_sysv, check_x86_64_sysv_compliance, x86_64_entries,
+      call_stub_x86_64_sysv, check_x86_64_sysv_compliance, x86_64_entries,
       (MLD_SYSV_ABI
        void (*)(void)));
 #elif defined(MLD_SYS_ARMV81M_MVE)
   SELFTEST_RUN_ARCH("armv81m", struct armv81m_register_state,
-                    init_armv81m_register_state, asm_call_stub_armv81m,
+                    init_armv81m_register_state, call_stub_armv81m,
                     check_armv81m_aapcs32_compliance, armv81m_entries,
                     (void (*)(void)));
 #else  /* !MLD_SYS_AARCH64 && !(MLD_SYS_X86_64 && MLD_SYSV_ABI_SUPPORTED) && \

--- a/test/abicheck/x86_64/abicheck_x86_64.h
+++ b/test/abicheck/x86_64/abicheck_x86_64.h
@@ -42,6 +42,14 @@ void asm_call_stub_x86_64_sysv(
                                MLD_SYSV_ABI
     void (*function_ptr)(void));
 
+static MLD_INLINE void call_stub_x86_64_sysv(
+    struct x86_64_register_state *input, struct x86_64_register_state *output,
+                               MLD_SYSV_ABI
+    void (*function_ptr)(void))
+{
+  asm_call_stub_x86_64_sysv(input, output, function_ptr);
+}
+
 #endif /* MLD_SYS_X86_64 && MLD_SYSV_ABI_SUPPORTED */
 
 #endif /* !MLD_TEST_ABICHECK_ABICHECK_X86_64_H */

--- a/test/abicheck/x86_64/checks/check_invntt_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_invntt_avx2_asm.c
@@ -51,7 +51,7 @@ int check_invntt_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_invntt_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_keccak_f1600_x4_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_keccak_f1600_x4_avx2_asm.c
@@ -61,7 +61,7 @@ int check_keccak_f1600_x4_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_keccak_f1600_x4_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_ntt_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_ntt_avx2_asm.c
@@ -51,7 +51,7 @@ int check_ntt_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_ntt_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_nttunpack_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_nttunpack_avx2_asm.c
@@ -49,7 +49,7 @@ int check_nttunpack_avx2_asm(void)
     input_state.rdi = (uint64_t)buf_rdi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_nttunpack_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_pointwise_acc_l4_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_acc_l4_avx2_asm.c
@@ -62,7 +62,7 @@ int check_pointwise_acc_l4_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_pointwise_acc_l4_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_pointwise_acc_l5_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_acc_l5_avx2_asm.c
@@ -62,7 +62,7 @@ int check_pointwise_acc_l5_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_pointwise_acc_l5_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_pointwise_acc_l7_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_acc_l7_avx2_asm.c
@@ -62,7 +62,7 @@ int check_pointwise_acc_l7_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_pointwise_acc_l7_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_pointwise_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_pointwise_avx2_asm.c
@@ -55,7 +55,7 @@ int check_pointwise_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_pointwise_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_poly_caddq_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_caddq_avx2_asm.c
@@ -49,7 +49,7 @@ int check_poly_caddq_avx2_asm(void)
     input_state.rdi = (uint64_t)buf_rdi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_poly_caddq_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_poly_chknorm_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_chknorm_avx2_asm.c
@@ -50,7 +50,7 @@ int check_poly_chknorm_avx2_asm(void)
     input_state.rsi = 131072;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_poly_chknorm_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_poly_decompose_32_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_decompose_32_avx2_asm.c
@@ -55,7 +55,7 @@ int check_poly_decompose_32_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_poly_decompose_32_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_poly_decompose_88_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_decompose_88_avx2_asm.c
@@ -55,7 +55,7 @@ int check_poly_decompose_88_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_poly_decompose_88_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_poly_use_hint_32_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_use_hint_32_avx2_asm.c
@@ -52,7 +52,7 @@ int check_poly_use_hint_32_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_poly_use_hint_32_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_poly_use_hint_88_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_poly_use_hint_88_avx2_asm.c
@@ -52,7 +52,7 @@ int check_poly_use_hint_88_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_poly_use_hint_88_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_polyz_unpack_17_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_polyz_unpack_17_avx2_asm.c
@@ -52,7 +52,7 @@ int check_polyz_unpack_17_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_polyz_unpack_17_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_polyz_unpack_19_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_polyz_unpack_19_avx2_asm.c
@@ -52,7 +52,7 @@ int check_polyz_unpack_19_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_polyz_unpack_19_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_rej_uniform_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_rej_uniform_avx2_asm.c
@@ -57,7 +57,7 @@ int check_rej_uniform_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_rej_uniform_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_rej_uniform_eta2_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_rej_uniform_eta2_avx2_asm.c
@@ -59,7 +59,7 @@ int check_rej_uniform_eta2_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_rej_uniform_eta2_avx2_asm);

--- a/test/abicheck/x86_64/checks/check_rej_uniform_eta4_avx2_asm.c
+++ b/test/abicheck/x86_64/checks/check_rej_uniform_eta4_avx2_asm.c
@@ -59,7 +59,7 @@ int check_rej_uniform_eta4_avx2_asm(void)
     input_state.rsi = (uint64_t)buf_rsi;
 
     /* Call function through ABI test stub */
-    asm_call_stub_x86_64_sysv(
+    call_stub_x86_64_sysv(
         &input_state, &output_state,
         (MLD_SYSV_ABI
          void (*)(void))mld_rej_uniform_eta4_avx2_asm);

--- a/test/configs/configs.yml
+++ b/test/configs/configs.yml
@@ -270,6 +270,19 @@ configs:
 
           static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
           {
+            if (cap == MLD_SYS_CAP_AARCH64_NEON)
+            {
+              uint64_t id_aa64pfr0_el1;
+
+              /* Read ID_AA64PFR0_EL1 system register */
+              __asm__ volatile("mrs %0, id_aa64pfr0_el1" : "=r"(id_aa64pfr0_el1));
+
+              /* AdvSIMD field: 0b1111 = not implemented */
+              uint64_t advsimd_field = (id_aa64pfr0_el1 >> 20) & 0xF;
+
+              return (advsimd_field != 0xF) ? 1 : 0;
+            }
+
             if (cap == MLD_SYS_CAP_AARCH64_SHA3)
             {
               uint64_t id_aa64pfr1_el1;

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -471,6 +471,19 @@
 
 static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 {
+  if (cap == MLD_SYS_CAP_AARCH64_NEON)
+  {
+    uint64_t id_aa64pfr0_el1;
+
+    /* Read ID_AA64PFR0_EL1 system register */
+    __asm__ volatile("mrs %0, id_aa64pfr0_el1" : "=r"(id_aa64pfr0_el1));
+
+    /* AdvSIMD field: 0b1111 = not implemented */
+    uint64_t advsimd_field = (id_aa64pfr0_el1 >> 20) & 0xF;
+
+    return (advsimd_field != 0xF) ? 1 : 0;
+  }
+
   if (cap == MLD_SYS_CAP_AARCH64_SHA3)
   {
     uint64_t id_aa64pfr1_el1;


### PR DESCRIPTION
Previously, the native backend and ABI checker assumed that NEON was
present on every AArch64 system.

Add MLD_SYS_CAP_AARCH64_NEON and gate every NEON-dependent native and
FIPS202 entry point on it. This allows integrators to provide runtime
capability detection and fall back to C.

Mark NEON requirements in the assembly ABI metadata and teach generated
ABI checks to skip unsupported kernels.

Route ABI checks through C call-stub wrappers. On AArch64, pass the
runtime capability into the assembly stub so it only saves, seeds,
captures, and restores vector registers when NEON is available. Keep the
GPR self-test unconditional and run vector corrupters only when NEON is
supported.

Extend the custom ID-register test configuration to detect AdvSIMD
through ID_AA64PFR0_EL1.

**NOTE:** This does currently _not_ yet address #1304 