### PR TITLE
liboqs: Declare derandomized keypair in integration META

### DIFF
--- a/integration/liboqs/ML-DSA-44_META.yml
+++ b/integration/liboqs/ML-DSA-44_META.yml
@@ -7,6 +7,8 @@ claimed-security: SUF-CMA
 length-public-key: 1312
 length-secret-key: 2560
 length-signature: 2420
+length-keypair-seed: 32
+derandomized_keypair: true
 length-mu: 64
 nistkat-sha256: 9a196e7fb32fbc93757dc2d8dc1924460eab66303c0c08aeb8b798fb8d8f8cf3
 testvectors-sha256: 5f0d135c0f7fd43f3fb9727265fcd6ec3651eb8c67c04ea5f3d8dfa1d99740d2
@@ -26,6 +28,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA44_C_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_C_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_C_signature_extmu_oqs
@@ -44,6 +47,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_X86_64_signature_extmu_oqs
@@ -71,6 +75,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA44_AARCH64_signature_extmu_oqs

--- a/integration/liboqs/ML-DSA-65_META.yml
+++ b/integration/liboqs/ML-DSA-65_META.yml
@@ -7,6 +7,8 @@ claimed-security: SUF-CMA
 length-public-key: 1952
 length-secret-key: 4032
 length-signature: 3309
+length-keypair-seed: 32
+derandomized_keypair: true
 length-mu: 64
 nistkat-sha256: 7cb96242eac9907a55b5c84c202f0ebd552419c50b2e986dc2e28f07ecebf072
 testvectors-sha256: 14bf84918ee90e7afbd580191d3eb890d4557e0900b1145e39a8399ef7dd3fba
@@ -26,6 +28,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA65_C_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_C_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_C_signature_extmu_oqs
@@ -44,6 +47,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_X86_64_signature_extmu_oqs
@@ -71,6 +75,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=65 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA65_AARCH64_signature_extmu_oqs

--- a/integration/liboqs/ML-DSA-87_META.yml
+++ b/integration/liboqs/ML-DSA-87_META.yml
@@ -7,6 +7,8 @@ claimed-security: SUF-CMA
 length-public-key: 2592
 length-secret-key: 4896
 length-signature: 4627
+length-keypair-seed: 32
+derandomized_keypair: true
 length-mu: 64
 nistkat-sha256: 4537905d2aabcf302fab2f242baed293459ecda7c230e6a67063b02c7e2840ed
 testvectors-sha256: 759a3ba35210c7e27ff90a7ce5e399295533b82ef125e6ec98af158e00268e44
@@ -26,6 +28,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_c.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA87_C_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_C_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_C_signature_extmu_oqs
@@ -44,6 +47,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_x86_64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_X86_64_signature_extmu_oqs
@@ -71,6 +75,7 @@ implementations:
   folder_name: .
   compile_opts: -DMLD_CONFIG_PARAMETER_SET=87 -DMLD_CONFIG_FILE="integration/liboqs/config_aarch64.h"
   signature_keypair: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair_oqs
+  signature_keypair_derand: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_keypair_derand_oqs
   signature_signature: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_oqs
   signature_verify: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_verify_oqs
   signature_signature_extmu: PQCP_MLDSA_NATIVE_MLDSA87_AARCH64_signature_extmu_oqs

--- a/integration/liboqs/sig_glue.c
+++ b/integration/liboqs/sig_glue.c
@@ -15,7 +15,8 @@
  *
  * The shims also normalize return codes to OQS_STATUS: mldsa-native returns a
  * wider error set than liboqs's OQS_SUCCESS / OQS_ERROR, so any nonzero result
- * is collapsed to OQS_ERROR. keypair is shimmed for this normalization alone.
+ * is collapsed to OQS_ERROR. keypair and keypair_derand are shimmed for this
+ * normalization alone.
  *
  * The shims are compiled once per build (parameter set and backend), so the
  * namespaced symbol names match the names liboqs links against.
@@ -41,6 +42,7 @@
   MLD_OQS_CONCAT(MLD_OQS_CONCAT(MLD_CONFIG_NAMESPACE_PREFIX, _), sym)
 
 #define mld_oqs_keypair MLD_OQS_NS(keypair_oqs)
+#define mld_oqs_keypair_derand MLD_OQS_NS(keypair_derand_oqs)
 #define mld_oqs_signature MLD_OQS_NS(signature_oqs)
 #define mld_oqs_verify MLD_OQS_NS(verify_oqs)
 #define mld_oqs_signature_extmu MLD_OQS_NS(signature_extmu_oqs)
@@ -56,6 +58,11 @@ static int mld_oqs_status(int ret)
 int mld_oqs_keypair(uint8_t *pk, uint8_t *sk)
 {
   return mld_oqs_status(MLD_OQS_NS(keypair)(pk, sk));
+}
+
+int mld_oqs_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *seed)
+{
+  return mld_oqs_status(MLD_OQS_NS(keypair_internal)(pk, sk, seed));
 }
 
 int mld_oqs_signature(uint8_t *sig, size_t *siglen, const uint8_t *m,
@@ -105,6 +112,7 @@ int mld_oqs_verify_extmu(const uint8_t *sig, size_t siglen, const uint8_t *mu,
 }
 
 #undef mld_oqs_keypair
+#undef mld_oqs_keypair_derand
 #undef mld_oqs_signature
 #undef mld_oqs_verify
 #undef mld_oqs_signature_extmu


### PR DESCRIPTION
Expose ML-DSA's seed-based keygen (@[FIPS204, Algorithm 6, ML-DSA.KeyGen_internal]) to the liboqs SIG derand API by declaring it in the per-level META files.

See open-quantum-safe/liboqs#2476.