### PR TITLE
CI: Disable ABI checks on Zephyr targets

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -69,6 +69,9 @@ inputs:
   rng_fail:
     description: Determine whether to run rng fail tests or not
     default: "true"
+  abicheck:
+    description: Determine whether to run ABI compliance tests or not
+    default: "true"
   extra_args:
     description: Additional arguments to pass to the tests script
     default: ""
@@ -93,6 +96,7 @@ runs:
           echo ALLOC="${{ inputs.alloc == 'true' && 'alloc' || 'no-alloc' }}" >> $GITHUB_ENV
           echo SIGN_HOOK="${{ inputs.sign_hook == 'true' && 'sign-hook' || 'no-sign-hook' }}" >> $GITHUB_ENV
           echo RNGFAIL="${{ inputs.rng_fail == 'true' && 'rng-fail' || 'no-rng-fail' }}" >> $GITHUB_ENV
+          echo ABICHECK="${{ inputs.abicheck == 'true' && 'abicheck' || 'no-abicheck' }}" >> $GITHUB_ENV
       - name: Setup nix
         uses: ./.github/actions/setup-shell
         with:
@@ -129,7 +133,7 @@ runs:
           GH_TOKEN: ${{ inputs.gh_token }}
         run: |
           make clean
-          ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.WYCHEPROOF }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.SIGN_HOOK }} --${{ env.RNGFAIL }} -v ${{ inputs.extra_args }}
+          ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.WYCHEPROOF }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.SIGN_HOOK }} --${{ env.RNGFAIL }} --${{ env.ABICHECK }} -v ${{ inputs.extra_args }}
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -41,6 +41,7 @@ jobs:
           stack: false
           alloc: false
           rng_fail: false
+          abicheck: false
           check_namespace: false
           # Zephyr's CMake selects the target arch; disable the host-arch
           # auto-detection that would otherwise leak into the forwarded CFLAGS.


### PR DESCRIPTION
## Summary

- add a default-enabled `abicheck` input to the `functest` composite action;
- set `abicheck: false` for Zephyr functional-test jobs.

This follows the same action-input pattern used for the other optional test
suites. Existing `functest` callers retain ABI checking by default.

## Why

The current ABI checker is not built as a Zephyr application. Normal Zephyr
tests go through the Zephyr CMake build, but `abicheck` uses the generic Make
rules and derives its architecture from the CI host. On `ubuntu-latest`, that
produces an x86_64 executable which the Zephyr wrapper then passes to
`qemu-system-arm`.

On #1277, all preceding Cortex-M55 functional, KAT, ACVP, and sign-hook tests
passed before that host ABI executable reached QEMU and hard-locked at `PC=0`:

- historical failure: https://github.com/pq-code-package/mldsa-native/actions/runs/30073952185/job/89422620672
- fresh reproduction on unchanged head `655be044b8450b2713a5cf24ab8dd0bf53a8b847`: https://github.com/pq-code-package/mldsa-native/actions/runs/30107040830

Only M55 reached this path because it is the only Zephyr matrix target using
`opt=all`; ABI checking is enabled only for optimized builds.

This change makes the current Zephyr exclusion explicit without affecting the
standalone ABI-check command or other `functest` users. Supporting ABI checking
as a Zephyr application can be handled separately from the Armv8.1-M Keccak
backend work in #1277.

## Validation

- repository-pinned `actionlint`: passed
- `./scripts/tests all --help`: confirms `--abicheck` / `--no-abicheck`
- `git diff --check`: passed
- exact head: `059167a7dbf4d7bca518732a8070c7361177e7d5`
- exact-head Zephyr run: https://github.com/pq-code-package/mldsa-native/actions/runs/30282130963 (all five targets passed)
- Cortex-M55 job: https://github.com/pq-code-package/mldsa-native/actions/runs/30282130963/job/90030891843 (`abicheck: false` expanded to `--no-abicheck`; `extra_args` remained `--no-auto`; functional, KAT, ACVP, sign-hook, and smoke tests passed)
- exact-head PR CI: https://github.com/pq-code-package/mldsa-native/actions/runs/30282114266 (in progress with no failures at the time of this update)
