### PR TITLE
Zephyr: apply -O3 across test firmware

### DIFF
--- a/test/zephyr/README.md
+++ b/test/zephyr/README.md
@@ -52,9 +52,13 @@ The Zephyr application lives in `app/`:
 - `app/Kconfig` force-selects the FPU/MVE features for Corstone-300, whose
   Zephyr SoC does not otherwise advertise MVE.
 
-`platform.mk` forwards the test binary's full `CFLAGS` to the CMake build, so
-the firmware is compiled with the project's own warning/optimization/standard
-policy and feature defines rather than a divergent Zephyr default.
+`platform.mk` forwards the test binary's full `CFLAGS` to the CMake build. The
+application selects Zephyr's speed policy and supplements its `-O2` with the
+project's normal `-O3` through `CONFIG_COMPILER_OPT`. CMake reapplies that
+configured option to application sources because Zephyr's target options would
+otherwise follow them. This gives ML-DSA, the test harness, support sources,
+and Zephyr itself an effective final `-O3`. The resolved ordering can be
+inspected in the per-binary Zephyr build directory's `compile_commands.json`.
 
 `exec_wrapper.py` runs a built ELF under QEMU (`-nographic`, semihosting on),
 forwarding the guest's exit code; it is wired in as `EXEC_WRAPPER`.

--- a/test/zephyr/app/CMakeLists.txt
+++ b/test/zephyr/app/CMakeLists.txt
@@ -41,7 +41,8 @@ if(ZEPHYR_NUCLEO_N657X0_Q)
     VECT_TAB_BASE_ADDRESS=0x10000000
     VECT_TAB_OFFSET=0x0
   )
-  target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/shim_nucleo_n657x0_q.c)
+  set(_zephyr_shim ${CMAKE_CURRENT_SOURCE_DIR}/shim_nucleo_n657x0_q.c)
+  target_sources(app PRIVATE ${_zephyr_shim})
   target_compile_definitions(app PRIVATE
     printf=__wrap_printf
     fprintf=__wrap_fprintf
@@ -59,7 +60,8 @@ if(ZEPHYR_NUCLEO_N657X0_Q)
     -Wl,--wrap=exit
   )
 else()
-  target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/shim.c)
+  set(_zephyr_shim ${CMAKE_CURRENT_SOURCE_DIR}/shim.c)
+  target_sources(app PRIVATE ${_zephyr_shim})
 endif()
 
 # The test binary's CFLAGS, forwarded from the build (test/zephyr/platform.mk
@@ -81,6 +83,12 @@ set_source_files_properties(${R}/test/hal/hal.c
 
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/shim_nucleo_n657x0_q.c
   PROPERTIES COMPILE_OPTIONS "-Wno-error")
+
+# CONFIG_COMPILER_OPT reaches Zephyr's own targets after its optimization
+# choice. The application target has the opposite ordering, so reapply the
+# same configured option as a source property to make it effective there too.
+set_property(SOURCE ${R}/mldsa/mldsa_native.c ${_test_srcs} ${_zephyr_shim}
+  APPEND PROPERTY COMPILE_OPTIONS ${CONFIG_COMPILER_OPT})
 
 # Optional native FIPS202 backend (e.g. Armv8.1-M MVE on Cortex-M55). The
 # monolithic mldsa_native.c already includes the backend C sources; its

--- a/test/zephyr/app/prj.conf
+++ b/test/zephyr/app/prj.conf
@@ -6,3 +6,9 @@
 # the main thread a generous stack.
 CONFIG_MAIN_STACK_SIZE=131072
 CONFIG_BOOT_BANNER=n
+
+# Match the project's speed-first compiler policy throughout the test image.
+# Zephyr's speed choice is -O2, so use its documented custom option for the
+# project's normal -O3 level.
+CONFIG_SPEED_OPTIMIZATIONS=y
+CONFIG_COMPILER_OPT="-O3"


### PR DESCRIPTION
Closes #1332.

## Summary

- Select Zephyr's speed optimization policy, avoiding size-specialized libc paths.
- Use `CONFIG_COMPILER_OPT="-O3"` for Zephyr sources.
- Reapply that option to application sources after Zephyr's target options.
- Preserve `OPT=0`/`OPT=1` backend-selection semantics.

Resolved compile commands end with `-O3` for ML-DSA, the benchmark harness, HAL, shim, minimal libc, and kernel.

## Correctness

QEMU `mps3-an547` passed ML-DSA-44/65/87 with both `OPT=0` and `OPT=1`.

Portable ML-DSA-44/65/87 also passed on:

- `mps2-an385`
- `mps2-an386`
- `mps2-an500`
- `mps2-an521`

The repository lint and autogeneration suite passed.

## N657 ML-DSA-87 results

Baseline: `12b52449a`  
Candidate: `b229f176a`

| Configuration | Operation | Baseline median | Candidate median | Change |
|---|---|---:|---:|---:|
| OPT=0 | Keypair | 7,066,966 | 6,885,051 | -2.57% |
| OPT=0 | Sign | 18,174,380 | 17,557,960 | -3.39% |
| OPT=0 | Verify | 7,059,234 | 6,864,424 | -2.76% |
| OPT=1 | Keypair | 6,885,847 | 6,487,948 | -5.78% |
| OPT=1 | Sign | 18,457,701 | 17,557,960 | -4.88% |
| OPT=1 | Verify | 7,186,031 | 6,864,424 | -4.48% |

Each row used ten samples. The printed percentile lines retain all ten sorted observations.

Command:

nix --extra-experimental-features 'nix-command flakes' develop .#zephyr --command \
  make run_bench_87 EXTRA_MAKEFILE=test/zephyr/platform.mk \
  ZEPHYR_TARGET=nucleo-n657x0-q CYCLES=NO OPT=<0|1> -j1

## Size and stack

N657 `OPT=1` image:

- Text: 46,264 → 68,216 bytes (+21,952 bytes)
- BSS: 93,604 → 93,607 bytes
- Conservative benchmark call-path stack bound: 35,432 bytes
- Configured stack: 65,536 bytes
- ITCM/DTCM capacity: 256 KiB each

The speedup therefore costs substantial code size, but the image remains comfortably within the target layout.