### PR TITLE
Fix stale filename reference

### DIFF
--- a/mldsa/mldsa_native_asm.S
+++ b/mldsa/mldsa_native_asm.S
@@ -22,7 +22,7 @@
  * levels, you should include this file once with
  * MLD_CONFIG_MULTILEVEL_WITH_SHARED set.
  *
- * (You could also follow the same pattern as for mldsa_native_monobuild.c
+ * (You could also follow the same pattern as for mldsa_native.c
  *  and include it for every level, setting MLD_CONFIG_MULTILEVEL_NO_SHARED
  *  for all but one. For builds with MLD_CONFIG_MULTILEVEL_NO_SHARED, this
  *  file will then be ignored.)

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2202,7 +2202,7 @@ def gen_monolithic_asm_file():
         yield " * If you want an SCU build of mldsa-native with support for multiple security"
         yield " * levels, you should include this file once with MLD_CONFIG_MULTILEVEL_WITH_SHARED set."
         yield " *"
-        yield " * (You could also follow the same pattern as for mldsa_native_monobuild.c"
+        yield " * (You could also follow the same pattern as for mldsa_native.c"
         yield " *  and include it for every level, setting MLD_CONFIG_MULTILEVEL_NO_SHARED"
         yield " *  for all but one. For builds with MLD_CONFIG_MULTILEVEL_NO_SHARED, this"
         yield " *  file will then be ignored.)"


### PR DESCRIPTION
The monolithic assembly unit still pointed at mldsa_native_monobuild.c, which was renamed to mldsa/mldsa_native.c.

- Ports https://github.com/pq-code-package/mlkem-native/pull/1833