### PR TITLE
Fix build and coverage under MLD_CONFIG_NO_RANDOMIZED_API

### DIFF
--- a/.github/actions/config-variations/action.yml
+++ b/.github/actions/config-variations/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'GitHub token'
     required: true
   tests:
-    description: 'List of tests to run (space-separated IDs) or "all" for all tests. Available IDs: pct-enabled, pct-enabled-broken, signing-bound-exhausted, reduce-ram, reduce-ram-pct, custom-alloc-heap, custom-zeroize, native-cap-ON, native-cap-OFF, native-cap-ID_AA64PFR1_EL1, native-cap-CPUID_AVX2, no-asm, serial-fips202, custom-randombytes, custom-memcpy, custom-memset, custom-stdlib, nblocks-1, nblocks-4, nblocks-6, keygen-only, sign-only, verify-only, keygen-sign, keygen-verify, sign-verify'
+    description: 'List of tests to run (space-separated IDs) or "all" for all tests. Available IDs: pct-enabled, pct-enabled-broken, signing-bound-exhausted, reduce-ram, reduce-ram-pct, custom-alloc-heap, custom-zeroize, native-cap-ON, native-cap-OFF, native-cap-ID_AA64PFR1_EL1, native-cap-CPUID_AVX2, no-asm, serial-fips202, custom-randombytes, custom-memcpy, custom-memset, custom-stdlib, nblocks-1, nblocks-4, nblocks-6, keygen-only, sign-only, verify-only, keygen-sign, keygen-verify, sign-verify, no-randomized'
     required: false
     default: 'all'
   opt:
@@ -421,6 +421,23 @@ runs:
         gh_token: ${{ inputs.gh_token }}
         compile_mode: native
         cflags: "${{ inputs.extra_cflags }} -DMLD_CONFIG_NO_KEYPAIR_API -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        func: true
+        kat: true
+        acvp: true
+        stack: true
+        rng_fail: true
+        opt: ${{ inputs.opt }}
+        examples: true
+    - name: "No randomized API (deterministic only)"
+      if: ${{ inputs.tests == 'all' || contains(inputs.tests, 'no-randomized') }}
+      uses: ./.github/actions/multi-functest
+      with:
+        gh_token: ${{ inputs.gh_token }}
+        compile_mode: native
+        # Defined empty rather than bare so it does not clash with configs
+        # that define it themselves.
+        cflags: "${{ inputs.extra_cflags }} -DMLD_CONFIG_NO_RANDOMIZED_API= -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         ldflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
         func: true
         kat: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,9 +510,9 @@ jobs:
          - name: nblocks
            ids: nblocks-1 nblocks-4 nblocks-6
          - name: reduced-api
-           ids: keygen-only sign-only verify-only keygen-sign keygen-verify sign-verify
+           ids: keygen-only sign-only verify-only keygen-sign keygen-verify sign-verify no-randomized
          - name: reduced-api-reduce-ram
-           ids: keygen-only sign-only verify-only keygen-sign keygen-verify sign-verify
+           ids: keygen-only sign-only verify-only keygen-sign keygen-verify sign-verify no-randomized
            extra_cflags: -DMLD_CONFIG_REDUCE_RAM
     runs-on: ${{ matrix.target.runner }}
     steps:

--- a/examples/basic/main.c
+++ b/examples/basic/main.c
@@ -48,8 +48,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(mldsa_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(mldsa_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -67,11 +75,24 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/basic/main.c
+++ b/examples/basic/main.c
@@ -75,7 +75,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -87,11 +88,12 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 TEST_VECTOR_MSG_LEN, pre, pre_len,
                                  test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");

--- a/examples/basic_lowram/main.c
+++ b/examples/basic_lowram/main.c
@@ -48,8 +48,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(mldsa_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(mldsa_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -67,11 +75,24 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/basic_lowram/main.c
+++ b/examples/basic_lowram/main.c
@@ -75,7 +75,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -87,11 +88,12 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 TEST_VECTOR_MSG_LEN, pre, pre_len,
                                  test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -48,8 +48,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(mldsa_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(mldsa_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -67,11 +75,24 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -75,7 +75,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -87,11 +88,12 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 TEST_VECTOR_MSG_LEN, pre, pre_len,
                                  test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");

--- a/examples/bring_your_own_fips202_static/main.c
+++ b/examples/bring_your_own_fips202_static/main.c
@@ -84,7 +84,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -96,11 +97,12 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 TEST_VECTOR_MSG_LEN, pre, pre_len,
                                  test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");

--- a/examples/bring_your_own_fips202_static/main.c
+++ b/examples/bring_your_own_fips202_static/main.c
@@ -57,8 +57,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(mldsa_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(mldsa_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -76,11 +84,24 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -75,7 +75,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -88,12 +89,13 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = CUSTOM_TINY_SHA3_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(CUSTOM_TINY_SHA3_signature_internal(
             sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN, pre,
-            sizeof(pre), test_vector_rnd, test_vector_sk, 0) == 0);
+            pre_len, test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -48,8 +48,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(CUSTOM_TINY_SHA3_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(CUSTOM_TINY_SHA3_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -67,12 +75,25 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(CUSTOM_TINY_SHA3_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                                    TEST_VECTOR_MSG_LEN,
                                    (const uint8_t *)TEST_VECTOR_CTX,
                                    TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(CUSTOM_TINY_SHA3_signature_internal(
+            sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN, pre,
+            sizeof(pre), test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -51,8 +51,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(mldsa_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(mldsa_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -70,11 +78,24 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -78,7 +78,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -90,11 +91,12 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 TEST_VECTOR_MSG_LEN, pre, pre_len,
                                  test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");

--- a/examples/monolithic_build_multilevel/main.c
+++ b/examples/monolithic_build_multilevel/main.c
@@ -32,8 +32,16 @@ static int example_mldsa44_keygen(void)
   uint8_t pk[MLDSA44_PUBLICKEYBYTES];
   uint8_t sk[MLDSA44_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa44_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa44_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -45,8 +53,16 @@ static int example_mldsa65_keygen(void)
   uint8_t pk[MLDSA65_PUBLICKEYBYTES];
   uint8_t sk[MLDSA65_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa65_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa65_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -58,8 +74,16 @@ static int example_mldsa87_keygen(void)
   uint8_t pk[MLDSA87_PUBLICKEYBYTES];
   uint8_t sk[MLDSA87_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa87_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa87_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -89,11 +113,24 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
@@ -102,11 +139,24 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
@@ -115,11 +165,24 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/monolithic_build_multilevel/main.c
+++ b/examples/monolithic_build_multilevel/main.c
@@ -113,7 +113,8 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -125,11 +126,12 @@ static int example_mldsa44_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa44_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
@@ -139,7 +141,8 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -151,11 +154,12 @@ static int example_mldsa65_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa65_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
@@ -165,7 +169,8 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -177,11 +182,12 @@ static int example_mldsa87_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa87_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");

--- a/examples/monolithic_build_multilevel_native/main.c
+++ b/examples/monolithic_build_multilevel_native/main.c
@@ -34,8 +34,16 @@ static int example_mldsa44_keygen(void)
   uint8_t pk[MLDSA44_PUBLICKEYBYTES];
   uint8_t sk[MLDSA44_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa44_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa44_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -47,8 +55,16 @@ static int example_mldsa65_keygen(void)
   uint8_t pk[MLDSA65_PUBLICKEYBYTES];
   uint8_t sk[MLDSA65_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa65_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa65_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -60,8 +76,16 @@ static int example_mldsa87_keygen(void)
   uint8_t pk[MLDSA87_PUBLICKEYBYTES];
   uint8_t sk[MLDSA87_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa87_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa87_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -91,11 +115,24 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
@@ -104,11 +141,24 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
@@ -117,11 +167,24 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/monolithic_build_multilevel_native/main.c
+++ b/examples/monolithic_build_multilevel_native/main.c
@@ -115,7 +115,8 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -127,11 +128,12 @@ static int example_mldsa44_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa44_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
@@ -141,7 +143,8 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -153,11 +156,12 @@ static int example_mldsa65_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa65_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
@@ -167,7 +171,8 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -179,11 +184,12 @@ static int example_mldsa87_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa87_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");

--- a/examples/monolithic_build_native/main.c
+++ b/examples/monolithic_build_native/main.c
@@ -51,8 +51,16 @@ static int example_keygen(void)
   uint8_t pk[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
 
-  printf("Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Generating keypair (randomized)... ");
   CHECK(mldsa_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Generating keypair (deterministic)... ");
+  CHECK(mldsa_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk, MLDSA_PK_BYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk, MLDSA_SK_BYTES) == 0);
   printf("DONE\n");
@@ -70,11 +78,24 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("Signing message (randomized)... ");
   CHECK(mldsa_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                         TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                         TEST_VECTOR_CTX_LEN, test_vector_sk) == 0);
+  CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/monolithic_build_native/main.c
+++ b/examples/monolithic_build_native/main.c
@@ -78,7 +78,8 @@ static int example_keygen(void)
 static int example_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("Signing message (randomized)... ");
@@ -90,11 +91,12 @@ static int example_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                 TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                 TEST_VECTOR_MSG_LEN, pre, pre_len,
                                  test_vector_rnd, test_vector_sk, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig, sizeof(test_vector_sig)) == 0);
   printf("DONE\n");

--- a/examples/multilevel_build/main.c
+++ b/examples/multilevel_build/main.c
@@ -32,8 +32,16 @@ static int example_mldsa44_keygen(void)
   uint8_t pk[MLDSA44_PUBLICKEYBYTES];
   uint8_t sk[MLDSA44_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa44_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa44_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -45,8 +53,16 @@ static int example_mldsa65_keygen(void)
   uint8_t pk[MLDSA65_PUBLICKEYBYTES];
   uint8_t sk[MLDSA65_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa65_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa65_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -58,8 +74,16 @@ static int example_mldsa87_keygen(void)
   uint8_t pk[MLDSA87_PUBLICKEYBYTES];
   uint8_t sk[MLDSA87_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa87_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa87_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -89,11 +113,24 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
@@ -102,11 +139,24 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
@@ -115,11 +165,24 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/multilevel_build/main.c
+++ b/examples/multilevel_build/main.c
@@ -113,7 +113,8 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -125,11 +126,12 @@ static int example_mldsa44_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa44_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
@@ -139,7 +141,8 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -151,11 +154,12 @@ static int example_mldsa65_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa65_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
@@ -165,7 +169,8 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -177,11 +182,12 @@ static int example_mldsa87_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa87_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");

--- a/examples/multilevel_build_native/main.c
+++ b/examples/multilevel_build_native/main.c
@@ -32,8 +32,16 @@ static int example_mldsa44_keygen(void)
   uint8_t pk[MLDSA44_PUBLICKEYBYTES];
   uint8_t sk[MLDSA44_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa44_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa44_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_44, MLDSA44_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_44, MLDSA44_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -45,8 +53,16 @@ static int example_mldsa65_keygen(void)
   uint8_t pk[MLDSA65_PUBLICKEYBYTES];
   uint8_t sk[MLDSA65_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa65_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa65_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_65, MLDSA65_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_65, MLDSA65_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -58,8 +74,16 @@ static int example_mldsa87_keygen(void)
   uint8_t pk[MLDSA87_PUBLICKEYBYTES];
   uint8_t sk[MLDSA87_SECRETKEYBYTES];
 
-  printf("  Generating keypair... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Generating keypair (randomized)... ");
   CHECK(mldsa87_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Generating keypair (deterministic)... ");
+  CHECK(mldsa87_keypair_internal(pk, sk, test_vector_rnd) == 0);
   CHECK(memcmp(pk, test_vector_pk_87, MLDSA87_PUBLICKEYBYTES) == 0);
   CHECK(memcmp(sk, test_vector_sk_87, MLDSA87_SECRETKEYBYTES) == 0);
   printf("DONE\n");
@@ -89,11 +113,24 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa44_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_44) == 0);
+  CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
   return 0;
@@ -102,11 +139,24 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa65_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_65) == 0);
+  CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
   return 0;
@@ -115,11 +165,24 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  printf("  Signing message... ");
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
+  printf("  Signing message (randomized)... ");
   CHECK(mldsa87_signature(sig, (const uint8_t *)TEST_VECTOR_MSG,
                           TEST_VECTOR_MSG_LEN, (const uint8_t *)TEST_VECTOR_CTX,
                           TEST_VECTOR_CTX_LEN, test_vector_sk_87) == 0);
+  CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
+  printf("DONE\n");
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
+
+  printf("  Signing message (deterministic)... ");
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
+                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");
   return 0;

--- a/examples/multilevel_build_native/main.c
+++ b/examples/multilevel_build_native/main.c
@@ -113,7 +113,8 @@ static int example_mldsa87_keygen(void)
 static int example_mldsa44_sign(void)
 {
   uint8_t sig[MLDSA44_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -125,11 +126,12 @@ static int example_mldsa44_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa44_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa44_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_44, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_44, sizeof(test_vector_sig_44)) == 0);
   printf("DONE\n");
@@ -139,7 +141,8 @@ static int example_mldsa44_sign(void)
 static int example_mldsa65_sign(void)
 {
   uint8_t sig[MLDSA65_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -151,11 +154,12 @@ static int example_mldsa65_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa65_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa65_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_65, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_65, sizeof(test_vector_sig_65)) == 0);
   printf("DONE\n");
@@ -165,7 +169,8 @@ static int example_mldsa65_sign(void)
 static int example_mldsa87_sign(void)
 {
   uint8_t sig[MLDSA87_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
 #if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   printf("  Signing message (randomized)... ");
@@ -177,11 +182,12 @@ static int example_mldsa87_sign(void)
 #endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
   printf("  Signing message (deterministic)... ");
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mldsa87_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK(mldsa87_signature_internal(sig, (const uint8_t *)TEST_VECTOR_MSG,
-                                   TEST_VECTOR_MSG_LEN, pre, sizeof(pre),
+                                   TEST_VECTOR_MSG_LEN, pre, pre_len,
                                    test_vector_rnd, test_vector_sk_87, 0) == 0);
   CHECK(memcmp(sig, test_vector_sig_87, sizeof(test_vector_sig_87)) == 0);
   printf("DONE\n");

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -165,6 +165,24 @@
 #define MLD_API_QUALIFIER
 #endif
 
+/* Hash algorithm constants for domain separation */
+#define MLD_PREHASH_NONE 0
+#define MLD_PREHASH_SHA2_224 1
+#define MLD_PREHASH_SHA2_256 2
+#define MLD_PREHASH_SHA2_384 3
+#define MLD_PREHASH_SHA2_512 4
+#define MLD_PREHASH_SHA2_512_224 5
+#define MLD_PREHASH_SHA2_512_256 6
+#define MLD_PREHASH_SHA3_224 7
+#define MLD_PREHASH_SHA3_256 8
+#define MLD_PREHASH_SHA3_384 9
+#define MLD_PREHASH_SHA3_512 10
+#define MLD_PREHASH_SHAKE_128 11
+#define MLD_PREHASH_SHAKE_256 12
+
+/* Maximum formatted domain separation message length */
+#define MLD_DOMAIN_SEPARATION_MAX_BYTES (2 + 255 + 11 + 64)
+
 /****************************** Function API **********************************/
 
 #if !defined(MLD_CONFIG_CONSTANTS_ONLY)
@@ -544,21 +562,6 @@ int MLD_API_NAMESPACE(verify_extmu)(
 #endif /* !MLD_CONFIG_CORE_API_ONLY */
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 
-/* Hash algorithm constants for domain separation */
-#define MLD_PREHASH_NONE 0
-#define MLD_PREHASH_SHA2_224 1
-#define MLD_PREHASH_SHA2_256 2
-#define MLD_PREHASH_SHA2_384 3
-#define MLD_PREHASH_SHA2_512 4
-#define MLD_PREHASH_SHA2_512_224 5
-#define MLD_PREHASH_SHA2_512_256 6
-#define MLD_PREHASH_SHA3_224 7
-#define MLD_PREHASH_SHA3_256 8
-#define MLD_PREHASH_SHA3_384 9
-#define MLD_PREHASH_SHA3_512 10
-#define MLD_PREHASH_SHAKE_128 11
-#define MLD_PREHASH_SHAKE_256 12
-
 #if !defined(MLD_CONFIG_CORE_API_ONLY)
 #if !defined(MLD_CONFIG_NO_SIGN_API)
 /**
@@ -775,9 +778,6 @@ int MLD_API_NAMESPACE(verify_pre_hash_shake256)(
 );
 #endif /* !MLD_CONFIG_NO_VERIFY_API */
 #endif /* !MLD_CONFIG_CORE_API_ONLY */
-
-/* Maximum formatted domain separation message length */
-#define MLD_DOMAIN_SEPARATION_MAX_BYTES (2 + 255 + 11 + 64)
 
 #if !defined(MLD_CONFIG_CORE_API_ONLY)
 /**

--- a/test/src/test_alloc.c
+++ b/test/src/test_alloc.c
@@ -339,6 +339,7 @@ void custom_free(test_ctx_t *ctx, void *p, size_t sz, const char *file,
 /* Keygen tests */
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 static int test_keygen_alloc_failure(test_ctx_t *ctx)
 {
   uint8_t pk[MLDSA_PK_BYTES];
@@ -348,6 +349,7 @@ static int test_keygen_alloc_failure(test_ctx_t *ctx)
                      MLD_TOTAL_ALLOC_KEYPAIR, &ctx->global_high_mark_keypair);
   return 0;
 }
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
 static int test_pk_from_sk_alloc_failure(test_ctx_t *ctx)
 {
@@ -363,6 +365,7 @@ static int test_pk_from_sk_alloc_failure(test_ctx_t *ctx)
 /* Sign tests — use test_vector_sk directly */
 
 #if !defined(MLD_CONFIG_NO_SIGN_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 static int test_sign_alloc_failure(test_ctx_t *ctx)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
@@ -384,6 +387,7 @@ static int test_signature_extmu_alloc_failure(test_ctx_t *ctx)
                      MLD_TOTAL_ALLOC_SIGN, &ctx->global_high_mark_sign);
   return 0;
 }
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
 static int test_signature_pre_hash_shake256_alloc_failure(test_ctx_t *ctx)
 {
@@ -476,16 +480,20 @@ int main(void)
 
   /* Keygen tests */
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   r |= test_keygen_alloc_failure(&ctx);
-  r |= test_pk_from_sk_alloc_failure(&ctx);
 #endif
+  r |= test_pk_from_sk_alloc_failure(&ctx);
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API */
 
   /* Sign tests */
 #if !defined(MLD_CONFIG_NO_SIGN_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   r |= test_sign_alloc_failure(&ctx);
   r |= test_signature_extmu_alloc_failure(&ctx);
-  r |= test_signature_pre_hash_shake256_alloc_failure(&ctx);
 #endif
+  r |= test_signature_pre_hash_shake256_alloc_failure(&ctx);
+#endif /* !MLD_CONFIG_NO_SIGN_API */
 
   /* Verify tests */
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
@@ -499,20 +507,27 @@ int main(void)
     return 1;
   }
 
-  /* Check per-operation high watermarks match the declared limits */
+  /* Check per-operation high watermarks match the declared limits.
+   *
+   * The keypair and sign limits are attained by the randomized wrappers,
+   * which allocate a seed resp. rnd buffer on top of the internal entry
+   * points, so they are only tight when those wrappers are present. */
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   CHECK_ALLOC_MATCH(ctx.global_high_mark_keypair, MLD_TOTAL_ALLOC_KEYPAIR);
+#endif
   CHECK_ALLOC_MATCH(ctx.global_high_mark_pk_from_sk,
                     MLD_TOTAL_ALLOC_PK_FROM_SK);
-#endif
-#if !defined(MLD_CONFIG_NO_SIGN_API)
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API */
+#if !defined(MLD_CONFIG_NO_SIGN_API) && !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   CHECK_ALLOC_MATCH(ctx.global_high_mark_sign, MLD_TOTAL_ALLOC_SIGN);
 #endif
 #if !defined(MLD_CONFIG_NO_VERIFY_API)
   CHECK_ALLOC_MATCH(ctx.global_high_mark_verify, MLD_TOTAL_ALLOC_VERIFY);
 #endif
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) && !defined(MLD_CONFIG_NO_SIGN_API) && \
-    !defined(MLD_CONFIG_NO_VERIFY_API)
+    !defined(MLD_CONFIG_NO_VERIFY_API) &&                                      \
+    !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   CHECK_ALLOC_MATCH(ctx.global_high_mark, MLD_TOTAL_ALLOC);
 #endif
 

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -49,7 +49,8 @@
 
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) && !defined(MLD_CONFIG_NO_SIGN_API) && \
-    !defined(MLD_CONFIG_NO_VERIFY_API)
+    !defined(MLD_CONFIG_NO_VERIFY_API) &&                                      \
+    !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 static int test_sign_core(uint8_t pk[MLDSA_PK_BYTES],
                           uint8_t sk[MLDSA_SK_BYTES],
                           uint8_t sig[MLDSA_SIG_BYTES], uint8_t m[MLEN],
@@ -195,7 +196,7 @@ static int test_sign_empty_message(void)
   return 0;
 }
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \
-          !MLD_CONFIG_NO_VERIFY_API */
+          !MLD_CONFIG_NO_VERIFY_API && !MLD_CONFIG_NO_RANDOMIZED_API */
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
 static int test_pk_from_sk(void)
@@ -204,10 +205,14 @@ static int test_pk_from_sk(void)
   uint8_t pk_derived[MLDSA_PK_BYTES];
   uint8_t sk[MLDSA_SK_BYTES];
   uint8_t sk_corrupted[MLDSA_SK_BYTES];
+  uint8_t seed[MLDSA_SEEDBYTES];
   int rc;
 
-  /* Generate a keypair */
-  CHECK(mld_sign_keypair(pk, sk) == 0);
+  /* Generate a keypair. Drive the internal entry point so that this test
+   * also runs when the randomized API is disabled. */
+  CHECK(randombytes(seed, MLDSA_SEEDBYTES) == 0);
+  MLD_CT_TESTING_SECRET(seed, MLDSA_SEEDBYTES);
+  CHECK(mld_sign_keypair_internal(pk, sk, seed) == 0);
 
   /* Derive public key from secret key */
   CHECK(mld_sign_pk_from_sk(pk_derived, sk) == 0);
@@ -259,7 +264,8 @@ static int test_pk_from_sk(void)
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API */
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) && !defined(MLD_CONFIG_NO_SIGN_API) && \
-    !defined(MLD_CONFIG_NO_VERIFY_API)
+    !defined(MLD_CONFIG_NO_VERIFY_API) &&                                      \
+    !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 static int test_wrong_pk(void)
 {
   uint8_t pk[MLDSA_PK_BYTES];
@@ -372,7 +378,7 @@ static int test_wrong_ctx(void)
   return 0;
 }
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \
-          !MLD_CONFIG_NO_VERIFY_API */
+          !MLD_CONFIG_NO_VERIFY_API && !MLD_CONFIG_NO_RANDOMIZED_API */
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
 static int test_sign_expected_keypair(void)
@@ -381,8 +387,9 @@ static int test_sign_expected_keypair(void)
   uint8_t sk[MLDSA_SK_BYTES];
   uint8_t test_vector_sk_copy[MLDSA_SK_BYTES];
 
-  randombytes_reset();
-  CHECK(mld_sign_keypair(pk, sk) == 0);
+  /* test_vector_rnd is the seed the deterministic test RNG hands out, so the
+   * internal entry point must reproduce the same keypair. */
+  CHECK(mld_sign_keypair_internal(pk, sk, test_vector_rnd) == 0);
 
   /* Declassify sk's for comparison. This is for testing purposes only.
    * Don't declassify the test_vector_sk itself because we need it to stay
@@ -402,15 +409,14 @@ static int test_sign_expected_keypair(void)
 static int test_sign_expected_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
+  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
 
-  /* WARNING: Test-only
-   * Normally, you would seed a PRNG _once_ with trustworthy entropy
-   * and not reseed it afterwards. Here, we reseed to make tests
-   * independent and reproducible. */
-  randombytes_reset();
-  CHECK_SIGN_RC(mld_sign_signature(
-      sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN,
-      (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN, test_vector_sk));
+  pre[0] = 0;
+  pre[1] = TEST_VECTOR_CTX_LEN;
+  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  CHECK_SIGN_RC(mld_sign_signature_internal(
+      sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN, pre,
+      sizeof(pre), test_vector_rnd, test_vector_sk, 0));
   CHECK(memcmp(sig, test_vector_sig, MLDSA_SIG_BYTES) == 0);
 
   return 0;
@@ -480,7 +486,8 @@ int main(void)
   {
     r = 0;
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API) && !defined(MLD_CONFIG_NO_SIGN_API) && \
-    !defined(MLD_CONFIG_NO_VERIFY_API)
+    !defined(MLD_CONFIG_NO_VERIFY_API) &&                                      \
+    !defined(MLD_CONFIG_NO_RANDOMIZED_API)
     r |= test_sign();
     r |= test_sign_unaligned();
     r |= test_wrong_pk();
@@ -490,7 +497,7 @@ int main(void)
     r |= test_sign_pre_hash();
     r |= test_sign_empty_message();
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API && !MLD_CONFIG_NO_SIGN_API && \
-          !MLD_CONFIG_NO_VERIFY_API */
+          !MLD_CONFIG_NO_VERIFY_API && !MLD_CONFIG_NO_RANDOMIZED_API */
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
     r |= test_pk_from_sk();
 #endif

--- a/test/src/test_mldsa.c
+++ b/test/src/test_mldsa.c
@@ -409,14 +409,16 @@ static int test_sign_expected_keypair(void)
 static int test_sign_expected_sign(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
-  uint8_t pre[TEST_VECTOR_CTX_LEN + 2]; /* (0, ctxlen, ctx) */
+  uint8_t pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
 
-  pre[0] = 0;
-  pre[1] = TEST_VECTOR_CTX_LEN;
-  memcpy(pre + 2, TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN);
+  pre_len = mld_prepare_domain_separation_prefix(
+      pre, NULL, 0, (const uint8_t *)TEST_VECTOR_CTX, TEST_VECTOR_CTX_LEN,
+      MLD_PREHASH_NONE);
+  CHECK(pre_len != 0);
   CHECK_SIGN_RC(mld_sign_signature_internal(
-      sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN, pre,
-      sizeof(pre), test_vector_rnd, test_vector_sk, 0));
+      sig, (const uint8_t *)TEST_VECTOR_MSG, TEST_VECTOR_MSG_LEN, pre, pre_len,
+      test_vector_rnd, test_vector_sk, 0));
   CHECK(memcmp(sig, test_vector_sig, MLDSA_SIG_BYTES) == 0);
 
   return 0;

--- a/test/src/test_namespace.h
+++ b/test/src/test_namespace.h
@@ -11,6 +11,8 @@
 #define MLDSA_NAMESPACE(sym) \
   MLD_TEST_CONCAT(MLD_TEST_CONCAT(MLD_CONFIG_NAMESPACE_PREFIX, _), sym)
 
+#define mld_prepare_domain_separation_prefix \
+  MLDSA_NAMESPACE(prepare_domain_separation_prefix)
 #define mld_sign_keypair MLDSA_NAMESPACE(keypair)
 #define mld_sign_keypair_internal MLDSA_NAMESPACE(keypair_internal)
 #define mld_sign_pk_from_sk MLDSA_NAMESPACE(pk_from_sk)

--- a/test/src/test_rng_fail.c
+++ b/test/src/test_rng_fail.c
@@ -114,6 +114,7 @@ int randombytes(uint8_t *buf, size_t len)
   } while (0)
 
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 static int test_keygen_rng_failure(void)
 {
   uint8_t pk[MLDSA_PK_BYTES];
@@ -122,6 +123,7 @@ static int test_keygen_rng_failure(void)
   TEST_RNG_FAILURE("keypair", mld_sign_keypair(pk, sk));
   return 0;
 }
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
 static int test_pk_from_sk_rng_failure(void)
 {
@@ -133,6 +135,7 @@ static int test_pk_from_sk_rng_failure(void)
 #endif /* !MLD_CONFIG_NO_KEYPAIR_API */
 
 #if !defined(MLD_CONFIG_NO_SIGN_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
 static int test_sign_rng_failure(void)
 {
   uint8_t sig[MLDSA_SIG_BYTES];
@@ -153,6 +156,7 @@ static int test_signature_extmu_rng_failure(void)
                    mld_sign_signature_extmu(sig, mu, test_vector_sk));
   return 0;
 }
+#endif /* !MLD_CONFIG_NO_RANDOMIZED_API */
 
 static int test_signature_pre_hash_shake256_rng_failure(void)
 {
@@ -208,16 +212,20 @@ int main(void)
 
   /* Keygen tests */
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   r |= test_keygen_rng_failure();
-  r |= test_pk_from_sk_rng_failure();
 #endif
+  r |= test_pk_from_sk_rng_failure();
+#endif /* !MLD_CONFIG_NO_KEYPAIR_API */
 
   /* Sign tests */
 #if !defined(MLD_CONFIG_NO_SIGN_API)
+#if !defined(MLD_CONFIG_NO_RANDOMIZED_API)
   r |= test_sign_rng_failure();
   r |= test_signature_extmu_rng_failure();
-  r |= test_signature_pre_hash_shake256_rng_failure();
 #endif
+  r |= test_signature_pre_hash_shake256_rng_failure();
+#endif /* !MLD_CONFIG_NO_SIGN_API */
 
   /* Verify tests */
 #if !defined(MLD_CONFIG_NO_VERIFY_API)

--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -10,15 +10,23 @@
 
 #include "test_namespace.h"
 
+/*
+ * We measure the internal deterministic entry points rather than the
+ * randomized wrappers: they are available in every configuration, so the
+ * same measurements are taken under reduced-API builds such as
+ * MLD_CONFIG_NO_RANDOMIZED_API. The randomized wrappers merely add a seed
+ * buffer and a randombytes() call on top.
+ */
 static void test_keygen_only(void)
 {
 #if !defined(MLD_CONFIG_NO_KEYPAIR_API)
   unsigned char pk[MLDSA_PK_BYTES];
   unsigned char sk[MLDSA_SK_BYTES];
+  unsigned char seed[MLDSA_SEEDBYTES] = {0};
 
-  /* Only call keypair - this is what we're measuring */
-  /* Uses the notrandombytes implementation for deterministic randomness */
-  int ret = mld_sign_keypair(pk, sk);
+  /* Only call keypair_internal - this is what we're measuring */
+  /* seed is zero-initialized; its value is irrelevant for stack measurement */
+  int ret = mld_sign_keypair_internal(pk, sk, seed);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_KEYPAIR_API */
   printf("keygen test skipped (API disabled)\n");
@@ -30,13 +38,21 @@ static void test_sign_only(void)
 #if !defined(MLD_CONFIG_NO_SIGN_API)
   unsigned char sk[MLDSA_SK_BYTES] = {0};
   unsigned char sig[MLDSA_SIG_BYTES];
+  unsigned char rnd[MLDSA_RNDBYTES] = {0};
   const unsigned char msg[] = "test message for stack measurement";
   const unsigned char ctx[] = "test context";
+  unsigned char pre[2 + sizeof(ctx) - 1];
+  int ret;
 
-  /* Only call signature - this is what we're measuring */
+  /* Prepare pre = (0, ctxlen, ctx) */
+  pre[0] = 0;
+  pre[1] = sizeof(ctx) - 1;
+  memcpy(pre + 2, ctx, sizeof(ctx) - 1);
+
+  /* Only call signature_internal - this is what we're measuring */
   /* sk is zero-initialized (invalid key, but OK for stack measurement) */
-  int ret =
-      mld_sign_signature(sig, msg, sizeof(msg) - 1, ctx, sizeof(ctx) - 1, sk);
+  ret = mld_sign_signature_internal(sig, msg, sizeof(msg) - 1, pre, sizeof(pre),
+                                    rnd, sk, 0);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_SIGN_API */
   printf("sign test skipped (API disabled)\n");

--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -41,17 +41,16 @@ static void test_sign_only(void)
   unsigned char rnd[MLDSA_RNDBYTES] = {0};
   const unsigned char msg[] = "test message for stack measurement";
   const unsigned char ctx[] = "test context";
-  unsigned char pre[2 + sizeof(ctx) - 1];
+  unsigned char pre[MLD_DOMAIN_SEPARATION_MAX_BYTES];
+  size_t pre_len;
   int ret;
 
-  /* Prepare pre = (0, ctxlen, ctx) */
-  pre[0] = 0;
-  pre[1] = sizeof(ctx) - 1;
-  memcpy(pre + 2, ctx, sizeof(ctx) - 1);
+  pre_len = mld_prepare_domain_separation_prefix(
+      pre, NULL, 0, ctx, sizeof(ctx) - 1, MLD_PREHASH_NONE);
 
   /* Only call signature_internal - this is what we're measuring */
   /* sk is zero-initialized (invalid key, but OK for stack measurement) */
-  ret = mld_sign_signature_internal(sig, msg, sizeof(msg) - 1, pre, sizeof(pre),
+  ret = mld_sign_signature_internal(sig, msg, sizeof(msg) - 1, pre, pre_len,
                                     rnd, sk, 0);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 #else        /* !MLD_CONFIG_NO_SIGN_API */


### PR DESCRIPTION
The func, stack, alloc and rng_fail tests and every example called keypair(), signature() or signature_extmu(), which are absent when MLD_CONFIG_NO_RANDOMIZED_API is set, so none of them linked.

Guard the tests that specifically exercise the randomized wrappers, and drive the remaining ones through keypair_internal() and signature_internal(), which exist in every configuration. The examples now exercise the deterministic entry points alongside the randomized ones.

Skip the keypair and sign allocation-bound checks when the randomized wrappers are absent: MLD_TOTAL_ALLOC_KEYPAIR and MLD_TOTAL_ALLOC_SIGN account for the seed resp. rnd buffer those allocate, so the bounds are no longer tight without them.

Add a no-randomized config variation and run it as part of the reduced-API CI matrix.

- Ports pq-code-package/mlkem-native#1816.
- Resolves https://github.com/pq-code-package/mldsa-native/issues/1314
- Resolves https://github.com/pq-code-package/mldsa-native/issues/1317
- Depends on #1354 