### PR TITLE
Raise FIPS 204 signing-attempt bound to 821

### DIFF
--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -172,6 +172,46 @@ source code and documentation.
   - [test/configs/test_sign_hook_config.h](test/configs/test_sign_hook_config.h)
   - [test/src/test_sign_hook.c](test/src/test_sign_hook.c)
 
+### `FIPS204_UPDATES`
+
+* FIPS 204 Potential Updates (Errata)
+* Author(s):
+  - National Institute of Standards and Technology
+* URL: https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
+* Referenced from:
+  - [examples/basic_deterministic/mldsa_native/mldsa_native_config.h](examples/basic_deterministic/mldsa_native/mldsa_native_config.h)
+  - [examples/basic_lowram/mldsa_native/mldsa_native_config.h](examples/basic_lowram/mldsa_native/mldsa_native_config.h)
+  - [examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h](examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h)
+  - [examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h](examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h)
+  - [examples/custom_backend/mldsa_native/mldsa_native_config.h](examples/custom_backend/mldsa_native/mldsa_native_config.h)
+  - [examples/monolithic_build/mldsa_native/mldsa_native_config.h](examples/monolithic_build/mldsa_native/mldsa_native_config.h)
+  - [examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h](examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h)
+  - [examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h](examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h)
+  - [examples/monolithic_build_native/mldsa_native/mldsa_native_config.h](examples/monolithic_build_native/mldsa_native/mldsa_native_config.h)
+  - [examples/multilevel_build/mldsa_native/mldsa_native_config.h](examples/multilevel_build/mldsa_native/mldsa_native_config.h)
+  - [examples/multilevel_build_native/mldsa_native/mldsa_native_config.h](examples/multilevel_build_native/mldsa_native/mldsa_native_config.h)
+  - [examples/restartable_sign/mldsa_native/mldsa_native_config.h](examples/restartable_sign/mldsa_native/mldsa_native_config.h)
+  - [mldsa/mldsa_native_config.h](mldsa/mldsa_native_config.h)
+  - [mldsa/src/sign.c](mldsa/src/sign.c)
+  - [proofs/cbmc/mldsa_native_config_cbmc.h](proofs/cbmc/mldsa_native_config_cbmc.h)
+  - [test/configs/break_pct_config.h](test/configs/break_pct_config.h)
+  - [test/configs/custom_heap_alloc_config.h](test/configs/custom_heap_alloc_config.h)
+  - [test/configs/custom_memcpy_config.h](test/configs/custom_memcpy_config.h)
+  - [test/configs/custom_memset_config.h](test/configs/custom_memset_config.h)
+  - [test/configs/custom_native_capability_config_0.h](test/configs/custom_native_capability_config_0.h)
+  - [test/configs/custom_native_capability_config_1.h](test/configs/custom_native_capability_config_1.h)
+  - [test/configs/custom_native_capability_config_CPUID_AVX2.h](test/configs/custom_native_capability_config_CPUID_AVX2.h)
+  - [test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h](test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h)
+  - [test/configs/custom_randombytes_config.h](test/configs/custom_randombytes_config.h)
+  - [test/configs/custom_stdlib_config.h](test/configs/custom_stdlib_config.h)
+  - [test/configs/custom_zeroize_config.h](test/configs/custom_zeroize_config.h)
+  - [test/configs/low_signing_bound_config.h](test/configs/low_signing_bound_config.h)
+  - [test/configs/no_asm_config.h](test/configs/no_asm_config.h)
+  - [test/configs/serial_fips202_config.h](test/configs/serial_fips202_config.h)
+  - [test/configs/test_alloc_config.h](test/configs/test_alloc_config.h)
+  - [test/configs/test_sign_hook_config.h](test/configs/test_sign_hook_config.h)
+  - [test/src/test_sign_hook.c](test/src/test_sign_hook.c)
+
 ### `HYBRID`
 
 * Hybrid scalar/vector implementations of Keccak and SPHINCS+ on AArch64

--- a/BIBLIOGRAPHY.yml
+++ b/BIBLIOGRAPHY.yml
@@ -22,6 +22,12 @@
   author: National Institute of Standards and Technology
   url: https://csrc.nist.gov/pubs/fips/204/final
 
+- id: FIPS204_UPDATES
+  short: FIPS 204 potential updates
+  name: "FIPS 204 Potential Updates (Errata)"
+  author: National Institute of Standards and Technology
+  url: https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
+
 - id: FIPS202
   short: FIPS 202
   name: "FIPS202 SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions"

--- a/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -663,9 +668,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -673,7 +678,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/basic_lowram/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_lowram/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -663,9 +668,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -673,7 +678,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -664,9 +669,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -674,7 +679,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/custom_backend/mldsa_native/mldsa_native_config.h
+++ b/examples/custom_backend/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -659,9 +664,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -669,7 +674,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/monolithic_build/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -663,9 +668,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -673,7 +678,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -669,9 +674,9 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -679,7 +684,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/multilevel_build/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -660,9 +665,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -670,7 +675,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/examples/restartable_sign/mldsa_native/mldsa_native_config.h
+++ b/examples/restartable_sign/mldsa_native/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -664,9 +669,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -674,7 +679,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -106,7 +106,7 @@
 #define MLD_ERR_RNG_FAIL (-3)
 /* The signing rejection-sampling loop exceeded
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS iterations without producing a valid
- * signature. With a FIPS 204 Appendix C compliant bound (>= 814) this
+ * signature. With a FIPS 204 Appendix C compliant bound (>= 821) this
  * has probability < 2^-256. */
 #define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED (-4)
 /* Signing was paused before completing, at the request of a caller-provided

--- a/mldsa/mldsa_native_config.h
+++ b/mldsa/mldsa_native_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 #ifndef MLD_CONFIG_H
@@ -647,9 +652,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -657,7 +662,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/mldsa/src/common.h
+++ b/mldsa/src/common.h
@@ -269,7 +269,7 @@
 #define MLD_ERR_RNG_FAIL (-3)
 /* The signing rejection-sampling loop exceeded
  * MLD_CONFIG_MAX_SIGNING_ATTEMPTS iterations without producing a valid
- * signature. With a FIPS 204 Appendix C compliant bound (>= 814) this
+ * signature. With a FIPS 204 Appendix C compliant bound (>= 821) this
  * has probability < 2^-256. */
 #define MLD_ERR_SIGN_ATTEMPTS_EXHAUSTED (-4)
 /* Signing was paused before completing, at the request of a caller-provided

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -17,6 +17,11 @@
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
  *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
+ *
  * - [Round3_Spec]
  *   CRYSTALS-Dilithium Algorithm Specifications and Supporting Documentation
  *   (Version 3.1)
@@ -620,8 +625,8 @@ __contract__(
 #if defined(MLD_CONFIG_MAX_SIGNING_ATTEMPTS)
 
 #if !defined(MLD_ALLOW_NONCOMPLIANT_SIGNING_BOUND) && \
-    MLD_CONFIG_MAX_SIGNING_ATTEMPTS < 814
-#error Bad configuration: MLD_CONFIG_MAX_SIGNING_ATTEMPTS must be >= 814 for FIPS 204 compliance @[FIPS204, Appendix C]
+    MLD_CONFIG_MAX_SIGNING_ATTEMPTS < 821
+#error Bad configuration: MLD_CONFIG_MAX_SIGNING_ATTEMPTS must be >= 821 for FIPS 204 compliance @[FIPS204, Appendix C] @[FIPS204_UPDATES]
 #endif
 
 #if MLD_CONFIG_MAX_SIGNING_ATTEMPTS < 1

--- a/proofs/cbmc/mldsa_native_config_cbmc.h
+++ b/proofs/cbmc/mldsa_native_config_cbmc.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -667,9 +672,9 @@ static MLD_INLINE int mld_break_pct(void)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -677,7 +682,7 @@ static MLD_INLINE int mld_break_pct(void)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -680,9 +685,9 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -690,7 +695,7 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -670,9 +675,9 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -680,7 +685,7 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -669,9 +674,9 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -679,7 +684,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -669,9 +674,9 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -679,7 +684,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -668,9 +673,9 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -678,7 +683,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -700,9 +705,9 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -710,7 +715,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -700,9 +705,9 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -710,7 +715,7 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -678,9 +683,9 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -688,7 +693,7 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -663,9 +668,9 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -673,7 +678,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/low_signing_bound_config.h
+++ b/test/configs/low_signing_bound_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -663,9 +668,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -664,9 +669,9 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -674,7 +679,7 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -662,9 +667,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -672,7 +677,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -670,9 +675,9 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -680,7 +685,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/configs/test_sign_hook_config.h
+++ b/test/configs/test_sign_hook_config.h
@@ -16,6 +16,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 /*
@@ -666,9 +671,9 @@
  * This is useful in timing-sensitive environments that
  * require a deterministic worst-case bound on signing time.
  *
- * For FIPS 204 compliance, this value MUST be at least 814,
- * cf. @[FIPS204, Appendix C], which is chosen so that the
- * signing failure rate is < 2^{-256}.
+ * For FIPS 204 compliance, this value MUST be at least 821,
+ * cf. @[FIPS204, Appendix C] and @[FIPS204_UPDATES], which is
+ * chosen so that the signing failure rate is < 2^{-256}.
  *
  * Default: Largest possible value before internal counters
  * would overflow. This is larger than the FIPS204 bound.
@@ -676,7 +681,7 @@
  * In particular, in the default configuration, the signing
  * failure rate is < 2^{-256}.
  */
-/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 814 */
+/* #define MLD_CONFIG_MAX_SIGNING_ATTEMPTS 821 */
 
 /**
  * MLD_CONFIG_SERIAL_FIPS202_ONLY

--- a/test/src/test_sign_hook.c
+++ b/test/src/test_sign_hook.c
@@ -10,6 +10,11 @@
  *   FIPS 204 Module-Lattice-Based Digital Signature Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/204/final
+ *
+ * - [FIPS204_UPDATES]
+ *   FIPS 204 Potential Updates (Errata)
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
  */
 
 #include <stddef.h>
@@ -56,11 +61,11 @@
  * to one key), which pins the mean to +-0.001; an independent BoringSSL
  * measurement agrees to within 0.15%.
  *
- * They exceed the expected repetitions of 4.25 / 5.10 / 3.85 tabulated in
- * @[FIPS204, Table 1], because that figure models only the first-stage
- * rejection (the ||z|| and ||r0|| low-bits checks) and omits the second-stage
- * @[FIPS204, Algorithm 7, line 28] checks (the ||ct0|| norm and the hint weight
- * <= omega). */
+ * They match the 4.36 / 5.14 / 3.91 that @[FIPS204_UPDATES] gives for
+ * @[FIPS204, Table 1]. They exceed the published 4.25 / 5.10 / 3.85, which
+ * model only the first-stage rejection (the ||z|| and ||r0|| low-bits checks)
+ * and omit the second-stage @[FIPS204, Algorithm 7, line 28] checks (the
+ * ||ct0|| norm and the hint weight <= omega). */
 #if MLD_CONFIG_PARAMETER_SET == 44
 #define MLD_SIGN_HOOK_EXPECTED_RATIO_X1000 4361
 #elif MLD_CONFIG_PARAMETER_SET == 65


### PR DESCRIPTION
NIST's list of potential updates to FIPS 204 revises the Repetitions row of Table 1 to 4.36 / 5.14 / 3.91, and with it the minimum allowable loop-iteration limit for ML-DSA.Sign_internal in Table 3 from 814 to
821. Require the larger value for MLD_CONFIG_MAX_SIGNING_ATTEMPTS.

The revised repetition figures agree with the empirical means asserted by the signing-attempt distribution test.

 - Resolves https://github.com/pq-code-package/mldsa-native/issues/1347