### PR TITLE
Consolidate error codes for lower level functions

### DIFF
--- a/mldsa/src/packing.c
+++ b/mldsa/src/packing.c
@@ -156,7 +156,7 @@ int mld_sig_unpack_hints(mld_poly *h, const uint8_t sig[MLDSA_CRYPTO_BYTES],
 
   if (new_hint_count < old_hint_count || new_hint_count > MLDSA_OMEGA)
   {
-    return MLD_ERR_FAIL;
+    return MLD_ERR_INVALID_SIGNATURE;
   }
 
   mld_memset(h, 0, sizeof(mld_poly));
@@ -174,7 +174,7 @@ int mld_sig_unpack_hints(mld_poly *h, const uint8_t sig[MLDSA_CRYPTO_BYTES],
   {
     if (j > old_hint_count && packed_hints[j] <= packed_hints[j - 1])
     {
-      return MLD_ERR_FAIL;
+      return MLD_ERR_INVALID_SIGNATURE;
     }
     /* Safety: packed_hints[j] is uint8_t (<= 255) and MLDSA_N == 256. */
     h->coeffs[packed_hints[j]] = 1;
@@ -191,7 +191,7 @@ int mld_sig_unpack_hints(mld_poly *h, const uint8_t sig[MLDSA_CRYPTO_BYTES],
     {
       if (packed_hints[j] != 0)
       {
-        return MLD_ERR_FAIL;
+        return MLD_ERR_INVALID_SIGNATURE;
       }
     }
   }

--- a/mldsa/src/packing.h
+++ b/mldsa/src/packing.h
@@ -247,8 +247,8 @@ __contract__(
  *   - on i == MLDSA_K - 1, the trailing index slots are zero.
  *
  * Callers must invoke this for every i in [0, 1, .., MLDSA_K - 1]; if any
- * call returns MLD_ERR_FAIL the encoding is malformed and the signature must
- * be rejected.
+ * call returns MLD_ERR_INVALID_SIGNATURE the encoding is malformed and the
+ * signature must be rejected.
  *
  * @spec{Implements @[FIPS204, Algorithm 21, HintBitUnpack] (one row; part of
  * @[FIPS204, Algorithm 27, sigDecode]).}
@@ -257,8 +257,8 @@ __contract__(
  * @param[in]  sig Signature buffer.
  * @param      i   Row index, must be < MLDSA_K.
  *
- * @retval 0            Hints were decoded successfully.
- * @retval MLD_ERR_FAIL Hints are malformed.
+ * @retval 0                         Hints were decoded successfully.
+ * @retval MLD_ERR_INVALID_SIGNATURE Hints are malformed.
  */
 MLD_INTERNAL_API
 MLD_MUST_CHECK_RETURN_VALUE
@@ -269,7 +269,7 @@ __contract__(
   requires(memory_no_alias(h, sizeof(mld_poly)))
   requires(i < MLDSA_K)
   assigns(memory_slice(h, sizeof(mld_poly)))
-  ensures(return_value == 0 || return_value == MLD_ERR_FAIL)
+  ensures(return_value == 0 || return_value == MLD_ERR_INVALID_SIGNATURE)
   ensures(return_value == 0 ==> array_bound(h->coeffs, 0, MLDSA_N, 0, 2))
 );
 #endif /* !MLD_CONFIG_NO_VERIFY_API */

--- a/mldsa/src/sign.c
+++ b/mldsa/src/sign.c
@@ -1225,9 +1225,10 @@ int mld_sign_verify_internal(const uint8_t sig[MLDSA_CRYPTO_BYTES],
   mld_memcpy(c, sig, MLDSA_CTILDEBYTES);
   mld_polyvecl_unpack_z(z, sig + MLDSA_SIG_Z_OFFSET);
 
-  /* mld_polyvecl_chknorm signals failure through a single non-zero error code
-   * that's not yet aligned with MLD_ERR_XXX. A norm-check failure here means
-   * the signature is invalid, so map it to MLD_ERR_INVALID_SIGNATURE. */
+  /* mld_polyvecl_chknorm signals failure as a constant-time mask, rather than
+   * aligned with MLD_ERR_XXX, since this is also used for secret key
+   * validation. A norm-check failure here means the signature is invalid, so
+   * map it to MLD_ERR_INVALID_SIGNATURE. */
   if (mld_polyvecl_chknorm(z, MLDSA_GAMMA1 - MLDSA_BETA))
   {
     ret = MLD_ERR_INVALID_SIGNATURE;
@@ -1286,9 +1287,9 @@ int mld_sign_verify_internal(const uint8_t sig[MLDSA_CRYPTO_BYTES],
 
     /* tmp = h_i (decoded and validated from signature). A non-zero return
      * means the hint encoding is malformed, i.e. the signature is invalid. */
-    if (mld_sig_unpack_hints(tmp, sig, i) != 0)
+    ret = mld_sig_unpack_hints(tmp, sig, i);
+    if (ret != 0)
     {
-      ret = MLD_ERR_INVALID_SIGNATURE;
       goto cleanup;
     }
 


### PR DESCRIPTION
- Resolves: #1316

This PR moves error-code normalization from `mld_sign_verify_internal` into the function that detects the failure, so the caller no longer needs to re-label a generic return value.

`mld_sig_unpack_hints` now returns `MLD_ERR_INVALID_SIGNATURE` instead of `MLD_ERR_FAIL`. Since this function is verify-only, all three of its failure paths indicate malformed hint encoding, which means the signature must be rejected.

`mld_polyvecl_chknorm` keeps its existing `0 / 0xFFFFFFFF` contract. It is also used to validate the secret key in `mld_sign_pk_from_sk`, where `MLD_ERR_INVALID_SIGNATURE` would not be meaningful, and a generic code would still have to be mapped by each caller. Only the corresponding comment is refined.