### PR TITLE
Config: Move API-affecting options out of build-only section

### DIFF
--- a/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_deterministic/mldsa_native/mldsa_native_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -629,27 +706,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -712,48 +768,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -825,20 +839,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/basic_lowram/mldsa_native/mldsa_native_config.h
+++ b/examples/basic_lowram/mldsa_native/mldsa_native_config.h
@@ -199,6 +199,86 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+#if !defined(MLD_CONFIG_REDUCE_RAM)
+#define MLD_CONFIG_REDUCE_RAM
+#endif
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -628,27 +708,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -711,48 +770,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -824,23 +841,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-#if !defined(MLD_CONFIG_REDUCE_RAM)
-#define MLD_CONFIG_REDUCE_RAM
-#endif
-
 
 /*************************  Config internals  ********************************/
 

--- a/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202/mldsa_native/mldsa_native_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -629,27 +706,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -712,48 +768,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -825,20 +839,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
+++ b/examples/bring_your_own_fips202_static/mldsa_native/mldsa_native_config.h
@@ -201,6 +201,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -630,27 +707,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -713,48 +769,6 @@
  * Only enable this when you have to.
  */
 #define MLD_CONFIG_SERIAL_FIPS202_ONLY
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -826,20 +840,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/custom_backend/mldsa_native/mldsa_native_config.h
+++ b/examples/custom_backend/mldsa_native/mldsa_native_config.h
@@ -202,6 +202,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -625,27 +702,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -708,48 +764,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -821,20 +835,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build/mldsa_native/mldsa_native_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -628,27 +705,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -711,48 +767,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -824,20 +838,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel/mldsa_native/mldsa_native_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -629,27 +706,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -712,48 +768,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -825,20 +839,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mldsa_native/mldsa_native_config.h
@@ -204,6 +204,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -635,27 +712,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -718,48 +774,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -831,20 +845,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/monolithic_build_native/mldsa_native/mldsa_native_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -628,27 +705,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -711,48 +767,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -824,20 +838,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/multilevel_build/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build/mldsa_native/mldsa_native_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -628,27 +705,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -711,48 +767,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -824,20 +838,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
+++ b/examples/multilevel_build_native/mldsa_native/mldsa_native_config.h
@@ -201,6 +201,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -626,27 +703,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -709,48 +765,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -822,20 +836,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/restartable_sign/mldsa_native/mldsa_native_config.h
+++ b/examples/restartable_sign/mldsa_native/mldsa_native_config.h
@@ -201,6 +201,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -630,27 +707,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -715,48 +771,6 @@
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 /**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
-
-/**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
  *
  * Three optional, independent hooks into the ML-DSA signing rejection-sampling
@@ -818,20 +832,6 @@ int mld_sign_hook_attempt(uint16_t attempt);
 void mld_sign_hook_finish(uint16_t attempt);
 #endif /* !__ASSEMBLER__ */
 
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/mldsa/mldsa_native_config.h
+++ b/mldsa/mldsa_native_config.h
@@ -184,6 +184,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -613,27 +690,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -696,48 +752,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -809,20 +823,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/proofs/cbmc/mldsa_native_config_cbmc.h
+++ b/proofs/cbmc/mldsa_native_config_cbmc.h
@@ -202,6 +202,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+#define MLD_CONFIG_KEYGEN_PCT
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -637,27 +714,6 @@ __contract__(
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-#define MLD_CONFIG_KEYGEN_PCT
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -720,48 +776,6 @@ __contract__(
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -833,20 +847,6 @@ __contract__(
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+#define MLD_CONFIG_KEYGEN_PCT
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -629,27 +706,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-#define MLD_CONFIG_KEYGEN_PCT
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -716,48 +772,6 @@ static MLD_INLINE int mld_break_pct(void)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -829,20 +843,6 @@ static MLD_INLINE int mld_break_pct(void)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -646,27 +723,6 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -729,48 +785,6 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -842,20 +856,6 @@ static inline void *mld_posix_memalign(size_t align, size_t sz)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -636,27 +713,6 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -719,48 +775,6 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -832,20 +846,6 @@ static MLD_INLINE void *mld_memcpy(void *dest, const void *src, size_t n)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -635,27 +712,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -718,48 +774,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -831,20 +845,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -635,27 +712,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -718,48 +774,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -831,20 +845,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -634,27 +711,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -717,48 +773,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -830,20 +844,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -666,27 +743,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -749,48 +805,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -862,20 +876,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -666,27 +743,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -749,48 +805,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -862,20 +876,6 @@ static MLD_INLINE int mld_sys_check_capability(mld_sys_cap cap)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -628,27 +705,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -711,48 +767,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -824,20 +838,6 @@ static MLD_INLINE int mld_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -644,27 +721,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -727,48 +783,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -840,20 +854,6 @@ static MLD_INLINE void *mld_memset(void *s, int c, size_t n)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -629,27 +706,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -712,48 +768,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -825,20 +839,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/low_signing_bound_config.h
+++ b/test/configs/low_signing_bound_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -629,27 +706,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -714,48 +770,6 @@
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -827,20 +841,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -200,6 +200,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -630,27 +707,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -713,48 +769,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -826,20 +840,6 @@ static MLD_INLINE void mld_zeroize(void *ptr, size_t len)
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -199,6 +199,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -628,27 +705,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -711,48 +767,6 @@
  * Only enable this when you have to.
  */
 #define MLD_CONFIG_SERIAL_FIPS202_ONLY
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-/* #define MLD_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -824,20 +838,6 @@
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -202,6 +202,83 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+#define MLD_CONFIG_CONTEXT_PARAMETER
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+#define MLD_CONFIG_CONTEXT_PARAMETER_TYPE struct test_ctx_t *
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -636,27 +713,6 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -719,48 +775,6 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * Only enable this when you have to.
  */
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-#define MLD_CONFIG_CONTEXT_PARAMETER
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-#define MLD_CONFIG_CONTEXT_PARAMETER_TYPE struct test_ctx_t *
 
 /**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
@@ -832,20 +846,6 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
    }
    #endif
 */
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/test_sign_hook_config.h
+++ b/test/configs/test_sign_hook_config.h
@@ -203,6 +203,90 @@
  * the implementation.
  */
 /* #define MLD_CONFIG_CONSTANTS_ONLY */
+
+/**
+ * MLD_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a
+ * Pairwise Consistency Test (PCT) to be carried out on a freshly
+ * generated keypair before it can be exported.
+ *
+ * Set this option if such a check should be implemented.
+ * In this case, keypair_internal and
+ * keypair will return MLD_ERR_PCT_FAIL if the
+ * PCT failed.
+ *
+ * @note This feature will drastically lower the performance of
+ * key generation.
+ *
+ * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
+ * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
+ * requires signature() and verify().
+ */
+/* #define MLD_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a caller-supplied context parameter to the public API
+ * functions, which is then forwarded unchanged to the custom callbacks
+ * (allocation, and signing hooks below).
+ *
+ * When this option is set, every public API function gains a trailing
+ * parameter
+ *
+ *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
+ *
+ * as its last argument; its type is configured via
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
+ * value as opaque: it never dereferences it and only passes it on to the
+ * configurable hook macros. It is meant to carry per-caller state -- e.g. a
+ * pointer to a memory pool for the allocation hooks, or the resume state for
+ * the signing hooks -- into those hooks.
+ *
+ * When this option is unset (the default), no extra parameter is added and
+ * the hook macros never receive a context argument.
+ *
+ * The hooks that receive the context are the allocation hooks (see
+ * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
+ * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
+ * its own option below.
+ */
+#define MLD_CONFIG_CONTEXT_PARAMETER
+
+/**
+ * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type of the context parameter added by
+ * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
+ * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
+ * `struct my_ctx *`.
+ *
+ * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
+ * defined; defining one without the other is a compile-time error.
+ */
+#if !defined(__ASSEMBLER__)
+#include <stdint.h>
+/* The context type and the hook implementations live in
+ * test/src/test_sign_hook.c; here we only forward-declare them. */
+struct test_sign_hook_ctx; /* Forward declaration */
+#endif                     /* !__ASSEMBLER__ */
+#define MLD_CONFIG_CONTEXT_PARAMETER_TYPE struct test_sign_hook_ctx *
+
+
+/**
+ * MLD_CONFIG_REDUCE_RAM
+ *
+ * Set this to reduce RAM usage. This trades memory for performance.
+ *
+ * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
+ * mldsa_native.h.
+ *
+ * This option is useful for embedded systems with tight RAM constraints but
+ * relaxed performance requirements.
+ *
+ */
+/* #define MLD_CONFIG_REDUCE_RAM */
 /******************************************************************************
  *
  * Build-only configuration options
@@ -632,27 +716,6 @@
 /* #define MLD_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLD_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a
- * Pairwise Consistency Test (PCT) to be carried out on a freshly
- * generated keypair before it can be exported.
- *
- * Set this option if such a check should be implemented.
- * In this case, keypair_internal and
- * keypair will return MLD_ERR_PCT_FAIL if the
- * PCT failed.
- *
- * @note This feature will drastically lower the performance of
- * key generation.
- *
- * @note This option is incompatible with MLD_CONFIG_NO_SIGN_API
- * and MLD_CONFIG_NO_VERIFY_API as the current PCT implementation
- * requires signature() and verify().
- */
-/* #define MLD_CONFIG_KEYGEN_PCT */
-
-/**
  * MLD_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime
@@ -717,55 +780,6 @@
 /* #define MLD_CONFIG_SERIAL_FIPS202_ONLY */
 
 /**
- * MLD_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a caller-supplied context parameter to the public API
- * functions, which is then forwarded unchanged to the custom callbacks
- * (allocation, and signing hooks below).
- *
- * When this option is set, every public API function gains a trailing
- * parameter
- *
- *   MLD_CONFIG_CONTEXT_PARAMETER_TYPE context
- *
- * as its last argument; its type is configured via
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE (see below). mldsa-native treats this
- * value as opaque: it never dereferences it and only passes it on to the
- * configurable hook macros. It is meant to carry per-caller state -- e.g. a
- * pointer to a memory pool for the allocation hooks, or the resume state for
- * the signing hooks -- into those hooks.
- *
- * When this option is unset (the default), no extra parameter is added and
- * the hook macros never receive a context argument.
- *
- * The hooks that receive the context are the allocation hooks (see
- * MLD_CONFIG_CUSTOM_ALLOC_FREE) and the signing hooks (see
- * MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH); each is documented with
- * its own option below.
- */
-#define MLD_CONFIG_CONTEXT_PARAMETER
-
-/**
- * MLD_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type of the context parameter added by
- * MLD_CONFIG_CONTEXT_PARAMETER. It can be any C type usable as a function
- * parameter, e.g. `void *` or a pointer to a caller-defined struct such as
- * `struct my_ctx *`.
- *
- * This option must be defined if and only if MLD_CONFIG_CONTEXT_PARAMETER is
- * defined; defining one without the other is a compile-time error.
- */
-#if !defined(__ASSEMBLER__)
-#include <stdint.h>
-/* The context type and the hook implementations live in
- * test/src/test_sign_hook.c; here we only forward-declare them. */
-struct test_sign_hook_ctx; /* Forward declaration */
-#endif                     /* !__ASSEMBLER__ */
-#define MLD_CONFIG_CONTEXT_PARAMETER_TYPE struct test_sign_hook_ctx *
-
-
-/**
  * Signing hooks: MLD_CONFIG_SIGN_HOOK_RESUME / _ATTEMPT / _FINISH
  *
  * Three optional, independent hooks into the ML-DSA signing rejection-sampling
@@ -827,20 +841,6 @@ int mld_sign_hook_attempt(uint16_t attempt, struct test_sign_hook_ctx *context);
 void mld_sign_hook_finish(uint16_t attempt, struct test_sign_hook_ctx *context);
 #endif /* !__ASSEMBLER__ */
 
-
-/**
- * MLD_CONFIG_REDUCE_RAM
- *
- * Set this to reduce RAM usage. This trades memory for performance.
- *
- * For expected memory usage, see the MLD_TOTAL_ALLOC_* constants defined in
- * mldsa_native.h.
- *
- * This option is useful for embedded systems with tight RAM constraints but
- * relaxed performance requirements.
- *
- */
-/* #define MLD_CONFIG_REDUCE_RAM */
 
 /*************************  Config internals  ********************************/
 


### PR DESCRIPTION
mldsa_native.h evaluates MLD_CONFIG_KEYGEN_PCT,
MLD_CONFIG_CONTEXT_PARAMETER, MLD_CONFIG_CONTEXT_PARAMETER_TYPE and MLD_CONFIG_REDUCE_RAM, but they were documented behind the MLD_BUILD_INTERNAL guard. Consumers include mldsa_native.h without MLD_BUILD_INTERNAL, so setting any of them left the consumer with prototypes lacking the context parameter and with MLD_TOTAL_ALLOC_* values for a configuration other than the one the library was built with.

 - Fixes #1391