### PR TITLE
Update to CBMC 6.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -15,12 +15,12 @@ buildEnv {
   paths =
     builtins.attrValues {
       cbmc = cbmc.overrideAttrs (_: {
-        version = "6.10.0";
+        version = "6.11.0";
         src = fetchFromGitHub {
           owner = "diffblue";
           repo = "cbmc";
-          hash = "sha256-GCagpb2TFhOEH+lzMth+PWiJxlEw0L+H1DYUEQoMF3g=";
-          tag = "cbmc-6.10.0";
+          hash = "sha256-GHpgcGBE/AAhTVxGVzTPMdZ8BkuXa7/OgMumZJ8ENRc";
+          tag = "cbmc-6.11.0";
         };
       });
       litani = callPackage ./litani.nix { }; # 1.29.0

--- a/proofs/cbmc/H/H_harness.c
+++ b/proofs/cbmc/H/H_harness.c
@@ -9,11 +9,6 @@ void mld_H(uint8_t *out, size_t outlen, const uint8_t *in1, size_t in1len,
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   uint8_t *out;
   size_t outlen;
   const uint8_t *in1;

--- a/proofs/cbmc/compute_pack_z/compute_pack_z_harness.c
+++ b/proofs/cbmc/compute_pack_z/compute_pack_z_harness.c
@@ -10,11 +10,6 @@ int mld_compute_pack_z(uint8_t sig[MLDSA_CRYPTO_BYTES], const mld_poly *cp,
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   uint8_t *sig;
   mld_poly *cp;
   mld_sk_s1hat *s1;

--- a/proofs/cbmc/prepare_domain_separation_prefix/prepare_domain_separation_prefix_harness.c
+++ b/proofs/cbmc/prepare_domain_separation_prefix/prepare_domain_separation_prefix_harness.c
@@ -5,11 +5,6 @@
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   uint8_t *prefix;
   const uint8_t *ph;
   size_t phlen;

--- a/proofs/cbmc/sample_s1_s2/sample_s1_s2_harness.c
+++ b/proofs/cbmc/sample_s1_s2/sample_s1_s2_harness.c
@@ -8,11 +8,6 @@ static void mld_sample_s1_s2(mld_polyvecl *s1, mld_polyveck *s2,
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   mld_polyvecl *s1;
   mld_polyveck *s2;
   uint8_t *seed;

--- a/proofs/cbmc/sample_s1_s2_serial/sample_s1_s2_harness.c
+++ b/proofs/cbmc/sample_s1_s2_serial/sample_s1_s2_harness.c
@@ -8,11 +8,6 @@ static void mld_sample_s1_s2(mld_polyvecl *s1, mld_polyveck *s2,
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   mld_polyvecl *s1;
   mld_polyveck *s2;
   uint8_t *seed;

--- a/proofs/cbmc/sign_attempt/sign_attempt_harness.c
+++ b/proofs/cbmc/sign_attempt/sign_attempt_harness.c
@@ -5,11 +5,6 @@
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   uint16_t attempt;
   int rc;
   /* `context` is consumed by the call macro (the CBMC config has no context

--- a/proofs/cbmc/sign_finish/sign_finish_harness.c
+++ b/proofs/cbmc/sign_finish/sign_finish_harness.c
@@ -7,11 +7,6 @@
  * parameter), exactly as at the call sites in sign.c. */
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   uint16_t attempt;
   mld_sign_finish(attempt, context);
 }

--- a/proofs/cbmc/sign_resume/sign_resume_harness.c
+++ b/proofs/cbmc/sign_resume/sign_resume_harness.c
@@ -5,11 +5,6 @@
 
 void harness(void)
 {
-  {
-    /* Dummy use of `free` to work around CBMC issue #8814. */
-    free(NULL);
-  }
-
   /* `context` is consumed by the call macro (the CBMC config has no context
    * parameter), exactly as at the call sites in sign.c. */
   uint16_t attempt = mld_sign_resume(context);


### PR DESCRIPTION
1. Update NIX config for CBMC 6.11 release/tag
2. Remove dummy calls to free() in CBMC harnesses, since these are no longer required.