### PR TITLE
Wycheproof: Bump pinned test vectors to latest main

### DIFF
--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -20,8 +20,8 @@ from pathlib import Path
 exec_prefix = os.environ.get("EXEC_WRAPPER", "")
 exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
-# Pinned to a specific commit (2026-07-07).
-WYCHEPROOF_COMMIT = "fc24cd5b787d8e496bff31b0468af693a652b0f2"
+# Pinned to a specific commit (2026-08-18).
+WYCHEPROOF_COMMIT = "dac1dd4729fd1f8dd9e1e9f3dce51d783da6c166"
 WYCHEPROOF_BASE_URL = (
     "https://api.github.com/repos/C2SP/wycheproof/contents/testvectors_v1"
 )


### PR DESCRIPTION
The ML-DSA files have been changed, but all changes are only to metadata. No actual test vectors changed.

 - Resolves #1388