### PR TITLE
Express alignment portably with alignas (C23) / _Alignas (C11/C17)

### DIFF
--- a/examples/context_parameter/example_context.h
+++ b/examples/context_parameter/example_context.h
@@ -18,7 +18,11 @@
 /* This mirrors MLD_ALIGN from mldsa/src/sys.h, including the fallback to no
  * alignment at all: on a toolchain that cannot express the constraint, the
  * library's own buffers are equally unaligned, so we are no worse off. */
-#if defined(__GNUC__)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define EXAMPLE_ALIGN alignas(EXAMPLE_ALLOC_ALIGN)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define EXAMPLE_ALIGN _Alignas(EXAMPLE_ALLOC_ALIGN)
+#elif defined(__GNUC__)
 #define EXAMPLE_ALIGN __attribute__((aligned(EXAMPLE_ALLOC_ALIGN)))
 #elif defined(_MSC_VER)
 #define EXAMPLE_ALIGN __declspec(align(EXAMPLE_ALLOC_ALIGN))

--- a/integration/pavona/fips202_glue_align.patch
+++ b/integration/pavona/fips202_glue_align.patch
@@ -1,0 +1,24 @@
+# Copyright (c) The mldsa-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# MLD_ALIGN is an alignment specifier, which C forbids on a typedef. Drop it
+# from Pavona's SHAKE context types: they are empty placeholders for the KMAC
+# hardware backend, ignored by every function that takes one, so there is no
+# object whose alignment it could constrain.
+diff --git a/sw/device/lib/crypto/impl/mldsa/mldsa-native/fips202_glue.h b/sw/device/lib/crypto/impl/mldsa/mldsa-native/fips202_glue.h
+index ff39a163dc..fda2d84473 100644
+--- a/sw/device/lib/crypto/impl/mldsa/mldsa-native/fips202_glue.h
++++ b/sw/device/lib/crypto/impl/mldsa/mldsa-native/fips202_glue.h
+@@ -16,10 +16,10 @@
+ #define SHAKE256_RATE 136
+ 
+ typedef struct {
+-} MLD_ALIGN mld_shake128ctx;
++} mld_shake128ctx;
+ 
+ typedef struct {
+-} MLD_ALIGN mld_shake256ctx;
++} mld_shake256ctx;
+ 
+ static MLD_INLINE void mld_shake128_absorb_once(mld_shake128ctx *state,
+                                                 const uint8_t *input,

--- a/mldsa/src/poly.h
+++ b/mldsa/src/poly.h
@@ -33,8 +33,8 @@
  */
 typedef struct
 {
-  int32_t coeffs[MLDSA_N]; /**< Polynomial coefficients. */
-} MLD_ALIGN mld_poly;
+  MLD_ALIGN int32_t coeffs[MLDSA_N]; /**< Polynomial coefficients. */
+} mld_poly;
 
 #define mld_poly_reduce MLD_NAMESPACE(poly_reduce)
 /**

--- a/mldsa/src/sys.h
+++ b/mldsa/src/sys.h
@@ -208,7 +208,13 @@
 #define MLD_DEFAULT_ALIGN 32
 #define MLD_ALIGN_UP(N) \
   ((((N) + (MLD_DEFAULT_ALIGN - 1)) / MLD_DEFAULT_ALIGN) * MLD_DEFAULT_ALIGN)
-#if defined(__GNUC__)
+/* C23: alignas; C11/C17: _Alignas; otherwise compiler extensions.
+ * Must precede the declaration; cannot be used on a typedef. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define MLD_ALIGN alignas(MLD_DEFAULT_ALIGN)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define MLD_ALIGN _Alignas(MLD_DEFAULT_ALIGN)
+#elif defined(__GNUC__)
 #define MLD_ALIGN __attribute__((aligned(MLD_DEFAULT_ALIGN)))
 #elif defined(_MSC_VER)
 #define MLD_ALIGN __declspec(align(MLD_DEFAULT_ALIGN))

--- a/test/abicheck/aarch64/abicheck_aarch64.h
+++ b/test/abicheck/aarch64/abicheck_aarch64.h
@@ -12,9 +12,9 @@
 #if defined(MLD_SYS_AARCH64)
 
 /* MLD_ALIGN-aligned so the stub's 128-bit ldp/stp q on neon[] are aligned. */
-struct MLD_ALIGN aarch64_register_state
+struct aarch64_register_state
 {
-  uint64_t gpr[32];     /* x0-x30 */
+  MLD_ALIGN uint64_t gpr[32]; /* x0-x30 */
   uint64_t neon[32][2]; /* q0-q31 (full 128-bit NEON registers as two 64-bit
                            values) */
 };

--- a/test/abicheck/armv81m/abicheck_armv81m.h
+++ b/test/abicheck/armv81m/abicheck_armv81m.h
@@ -21,9 +21,10 @@
  * gpr is sized to 16 entries so mve[] (which follows) is 16-byte aligned;
  * slots 13..15 are unused. The struct is MLD_ALIGN-aligned so the stub's
  * 128-bit vldrw.u32 / vstrw.32 are aligned. */
-struct MLD_ALIGN armv81m_register_state
+struct armv81m_register_state
 {
-  uint32_t gpr[16];   /* r0-r12 in slots 0..12; slots 13..15 are padding */
+  /* r0-r12 in slots 0..12; slots 13..15 are padding */
+  MLD_ALIGN uint32_t gpr[16];
   uint32_t mve[8][4]; /* q0-q7 (full 128-bit MVE registers as four 32-bit
                          lanes each) */
 };


### PR DESCRIPTION
MLD_ALIGN had no portable definition: `__attribute__((aligned))` for GCC/Clang, `__declspec(align)` for MSVC, and on anything else it expanded to nothing at all. A toolchain outside those two families therefore silently dropped the 32-byte alignment.

C11 added _Alignas and C23 renamed it to alignas, so any compiler claiming either standard can express the constraint without an extension. Prefer those when `__STDC_VERSION__` advertises them and keep the extensions as the fallback for C90 and C99.

An alignment specifier belongs to the declaration specifiers, so unlike an attribute it cannot be attached to a typedef or a struct tag.

 - Resolve #1378