### PR TITLE
Port: CBMC: Use gcc and minimal libc headers for all proofs

### DIFF
--- a/mldsa/src/common.h
+++ b/mldsa/src/common.h
@@ -7,6 +7,7 @@
 #define MLD_COMMON_H
 
 #ifndef __ASSEMBLER__
+#include <stddef.h>
 #include <stdint.h>
 #endif
 

--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -143,11 +143,25 @@ default: report
 #
 MAKEFILE_PATHS = $(foreach makefile,$(MAKEFILE_LIST),$(abspath $(makefile)))
 PROOF_ROOT = $(dir $(filter %/Makefile.common,$(MAKEFILE_PATHS)))
-
 CBMC_ROOT = $(shell dirname $(PROOF_ROOT))
 PROOF_SOURCE = $(CBMC_ROOT)/sources
-PROOF_INCLUDE = $(CBMC_ROOT)/include
 PROOF_STUB = $(CBMC_ROOT)/stubs
+
+# Determine flags and include files for Data Model
+# which must be
+#     "LP64"  - 64-bit systems where "long and pointer are 64-bit"
+#
+# if CBMC_DM is not set, default to LP64
+ifndef CBMC_DM
+  CBMC_DM = LP64
+endif
+ifeq ($(strip $(CBMC_DM)),LP64)
+  GOTO_CC_DM_FLAG = --64
+  CBMC_DM_FLAG = --LP64
+  PROOF_INCLUDE = $(CBMC_ROOT)/cbmc/include/LP64
+else
+  $(error CBMC_DM=$(CBMC_DM) but must be LP64)
+endif
 
 # Flag to pass to goto-cc to make all static symbols globally visible. Leave it
 # unset or set it to --export-file-local-symbols to enable this behavior. Else,
@@ -335,7 +349,7 @@ NONDET_STATIC ?=
 # in order to get consistent header files on all platforms,
 # rather than using $(CC) (which might be preferred for compilation
 # on some platforms such as macOS/Darwin)
-COMPILE_FLAGS ?= -Wall -Werror --native-compiler gcc
+COMPILE_FLAGS ?= -Wall -Werror --native-compiler gcc -nostdinc -I$(PROOF_INCLUDE) $(GOTO_CC_DM_FLAG)
 LINK_FLAGS ?= -Wall -Werror
 EXPORT_FILE_LOCAL_SYMBOLS ?= --export-file-local-symbols
 
@@ -592,6 +606,7 @@ endif
 CBMCFLAGS += $(CBMC_FLAG_FLUSH)
 CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
 CBMCFLAGS += --slice-formula
+CBMCFLAGS += $(CBMC_DM_FLAG)
 
 ################################################################
 # Set C compiler defines
@@ -1099,6 +1114,7 @@ result:
 	$(MAKE) -B _result
 	@ echo Running 'litani build'
 	$(LITANI) run-build
+	@ echo Proofs run with MLD_CONFIG_PARAMETER_SET=$(MLD_CONFIG_PARAMETER_SET) and CBMC_DM=$(CBMC_DM)
 	tail -4 $(LOGDIR)/result.txt
 	-grep FAILURE $(LOGDIR)/result.txt
 
@@ -1110,7 +1126,7 @@ smt:
 	$(MAKE) -B _smt
 	@ echo Running 'litani build'
 	$(LITANI) run-build
-	@ echo Generated SMT file for prover $(PROVER_NAME) in $(HARNESS_GOTO).smt2
+	@ echo Generated SMT file for prover $(PROVER_NAME) in $(HARNESS_GOTO).smt2 with MLD_CONFIG_PARAMETER_SET=$(MLD_CONFIG_PARAMETER_SET) and CBMC_DM=$(CBMC_DM)
 
 _smtz: $(HARNESS_GOTO).smtz
 smtz:
@@ -1181,6 +1197,7 @@ report:
 	$(MAKE) -B _report
 	@ echo Running 'litani build'
 	$(LITANI) run-build
+	@ echo Proofs run with MLD_CONFIG_PARAMETER_SET=$(MLD_CONFIG_PARAMETER_SET) and CBMC_DM=$(CBMC_DM)
 
 _report_no_coverage:
 	$(MAKE) COVERAGE="" VIEWER_COVERAGE_FLAG="" _report

--- a/proofs/cbmc/include/LP64/README.md
+++ b/proofs/cbmc/include/LP64/README.md
@@ -1,0 +1,80 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# C Header files for CBMC proof, LP64 data model
+
+These header files declare typedef's and constants to give
+CBMC the correct data-model for the "LP64" data model,
+which is that used on "64-bit UNIX-like" systems, including
+Linux and macOS using both AArch64 and x86_64 processors.
+
+"LP64" stands for "Long and Pointer are 64-bit", so
+the predefined types in this model are as follows:
+
+## Predefined integer types ##
+
+|type|comment|MIN|MAX|
+|----|-------|---|---|
+|signed char|8 bits, signed, 2's complement|-128|127|
+|unsigned char|8 bits, unsigned|0|255|
+|short|16 bits, signed, 2's complement|-32_768|32_767|
+|unsigned short|16 bits, unsigned|0|65535|
+|int|32 bits, signed, 2's complement|-2_147_483_648|2_147_483_647|
+|unsigned int|32 bits, unsigned|0|4_294_967_295|
+|long|64 bits, signed, 2'complement|-2**63|2**63-1|
+|unsigned long|64 bits, unsigned|0|2**64-1|
+
+## Derived fixed-width types ##
+
+These headers therefore declare fixed-width integer types
+as follow (in stdint.h)
+
+|type|base type|
+|----|---------|
+|int8_t|signed char|
+|uint8_t|unsigned char|
+|int16_t|short|
+|uint16_t|unsigned short|
+|int32_t|int|
+|uint32_t|unsigned int|
+|int64_t|long|
+|uint64_t|unsigned long|
+
+"Pointers" are 64-bit unsigned in LP64, and size_t is 64-bit
+so, in stddef.h, we declare
+
+`typedef unsigned long size_t;`
+
+## Macros
+
+The macro `SIZE_MAX` is required to declare preconditions that limit
+buffer sizes, so
+
+```
+/* size_t is 64-bit unsigned (see stddef.h), so SIZE_MAX is 2**64-1 */
+#define SIZE_MAX (18446744073709551615UL)
+```
+
+## Functions
+
+These header files only declare functions that are required by mldsa-native and no more.
+
+`stdlib.h` declares
+
+```
+void *malloc(size_t size);
+
+void free(void *ptr);
+```
+
+while `string.h` declares
+
+```
+void *memset(void *dest, int ch, size_t count);
+
+void *memcpy(void *dest, const void *src, size_t count);
+```
+
+These declarations reflect those specified in ISO C standard
+(aka C90, C99 and beyond), and offer CBMC a consistent view
+of these functions regardless of the platform on which
+analysis is being run.

--- a/proofs/cbmc/include/LP64/stddef.h
+++ b/proofs/cbmc/include/LP64/stddef.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+#ifndef _STDDEF_H
+#define _STDDEF_H 1
+
+/* "LP64" stands for "Long and Pointer are 64-bit", so
+ *  size_t is "unsigned long" which has the same size as a "pointer"
+ */
+typedef unsigned long size_t;
+
+#define NULL (0)
+
+#endif /* !_STDDEF_H */

--- a/proofs/cbmc/include/LP64/stdint.h
+++ b/proofs/cbmc/include/LP64/stdint.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+#ifndef _STDINT_H
+#define _STDINT_H 1
+
+typedef unsigned char uint8_t;
+typedef signed char int8_t;
+
+typedef unsigned short uint16_t;
+typedef short int16_t;
+
+/* "LP64" stands for "Long and Pointer are 64-bit", so
+ *   int32_t is "int"
+ *  uint32_t is "unsigned int"
+ *   int64_t is "long"
+ *  uint64_t is "unsigned long"
+ * and
+ *  SIZE_MAX is 2**64-1
+ */
+typedef unsigned int uint32_t;
+typedef int int32_t;
+
+typedef unsigned long uint64_t;
+typedef long int64_t;
+
+/* size_t is 64-bit unsigned (see stddef.h), so SIZE_MAX is 2**64-1 */
+#define SIZE_MAX (18446744073709551615UL)
+
+#define UINT16_MAX (65535U)
+#define INT16_MAX (32767)
+#define INT16_MIN (-32767 - 1)
+
+#define INT32_MAX (2147483647)
+#define INT32_MIN (-2147483647 - 1)
+#define UINT32_MAX (4294967295U)
+
+#define INT64_MAX (9223372036854775807L)
+
+#endif /* !_STDINT_H */

--- a/proofs/cbmc/include/LP64/stdlib.h
+++ b/proofs/cbmc/include/LP64/stdlib.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+#ifndef _STDLIB_H
+#define _STDLIB_H 1
+
+#include <stddef.h>
+
+void *malloc(size_t size);
+
+void free(void *ptr);
+
+#endif /* !_STDLIB_H */

--- a/proofs/cbmc/include/LP64/string.h
+++ b/proofs/cbmc/include/LP64/string.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) The mldsa-native project authors
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+#ifndef _STRING_H
+#define _STRING_H 1
+
+#include <stddef.h>
+
+void *memset(void *dest, int ch, size_t count);
+
+void *memcpy(void *dest, const void *src, size_t count);
+
+#endif /* !_STRING_H */

--- a/proofs/cbmc/run-cbmc-proofs.py
+++ b/proofs/cbmc/run-cbmc-proofs.py
@@ -447,6 +447,15 @@ async def main():  # pylint: disable=too-many-locals
         else []
     )
 
+    # Normalise CBMC_DM in the environment inherited by the make jobs that
+    # litani spawns later, defaulting to LP64 when unset or empty.
+    dm = os.environ.get("CBMC_DM", "")
+    if dm == "":
+        os.environ["CBMC_DM"] = "LP64"
+    elif dm != "LP64":
+        logging.critical("CBMC_DM set to %s, but must be LP64", dm)
+        sys.exit(1)
+
     if not args.no_standalone:
         cmd = [
             str(litani),
@@ -503,6 +512,14 @@ async def main():  # pylint: disable=too-many-locals
 
     enable_memory_profiling = should_enable_memory_profiling(litani_caps, args)
     report_target = "_report_no_coverage" if args.no_coverage else "_report"
+
+    print(
+        "Running proofs with parameter set =",
+        os.environ.get("MLD_CONFIG_PARAMETER_SET", ""),
+        "and DM =",
+        os.environ["CBMC_DM"],
+        "\n",
+    )
 
     for _ in range(task_pool_size()):
         task = asyncio.create_task(

--- a/scripts/tests
+++ b/scripts/tests
@@ -126,7 +126,7 @@ def config_logger(verbose):
         logger.setLevel(logging.INFO)
 
 
-def logger(test_type, scheme, cross_prefix, opt):
+def logger(test_type, scheme, dm, cross_prefix, opt):
     """Emit line indicating the processing of the given test"""
 
     test_desc = str(test_type)
@@ -145,10 +145,11 @@ def logger(test_type, scheme, cross_prefix, opt):
         sz = 18
 
     return logging.getLogger(
-        "{0:<{1}} {2:<11} {3:<17}".format(
+        "{0:<{1}} {2:<11} {4:<17} {3}".format(
             test_desc,
             sz,
             str(scheme),
+            dm or "",
             "({}{}):".format(compile_mode, opt_label),
         )
     )
@@ -474,7 +475,7 @@ class Tests:
             f"::group::compile {self.compile_mode()}{opt_label} {test_type.desc()}"
         )
 
-        log = logger(test_type, "Compile", self.args.cross_prefix, opt)
+        log = logger(test_type, "Compile", None, self.args.cross_prefix, opt)
 
         extra_make_args = []
         # Those options are not used in the examples
@@ -565,7 +566,7 @@ class Tests:
         else:
             scheme_str = str(scheme)
 
-        log = logger(test_type, scheme_str, self.args.cross_prefix, opt)
+        log = logger(test_type, scheme_str, None, self.args.cross_prefix, opt)
 
         args = ["make", test_type.make_run_target(scheme)]
         if test_type.is_example() is False:
@@ -986,15 +987,20 @@ class Tests:
                 print(p)
             exit(0)
 
-        def run_cbmc_single_step(mldsa_parameter_set, proofs):
-            envvars = {"MLD_CONFIG_PARAMETER_SET": mldsa_parameter_set}
+        def run_cbmc_single_step(mldsa_parameter_set, mldsa_dm, proofs):
+            envvars = {
+                "MLD_CONFIG_PARAMETER_SET": mldsa_parameter_set,
+                "CBMC_DM": mldsa_dm,
+            }
             if self.args.reduce_ram:
                 envvars["MLD_CONFIG_REDUCE_RAM"] = "1"
             scheme = SCHEME.from_mode(mldsa_parameter_set)
             num_proofs = len(proofs)
             for i, func in enumerate(proofs):
-                log = logger(f"CBMC ({i + 1}/{num_proofs})", scheme, None, None)
-                log.info(f"Starting CBMC proof for {func}")
+                log = logger(
+                    f"CBMC ({i + 1}/{num_proofs})", scheme, mldsa_dm, None, None
+                )
+                log.info(f"Starting CBMC proof for {func}, {scheme}, {mldsa_dm}")
                 start = time.time()
                 try:
                     p = subprocess.run(
@@ -1035,8 +1041,10 @@ class Tests:
                 else:
                     log.info(f"   SUCCESS (after {dur}s)")
 
-        def run_cbmc(mldsa_parameter_set):
-            log = logger("CBMC", SCHEME.from_mode(mldsa_parameter_set), None, None)
+        def run_cbmc(mldsa_parameter_set, mldsa_dm):
+            log = logger(
+                "CBMC", SCHEME.from_mode(mldsa_parameter_set), mldsa_dm, None, None
+            )
             all_proofs = list_proofs()
             proofs = all_proofs
             if self.args.start_with is not None:
@@ -1056,9 +1064,12 @@ class Tests:
                 proofs = sorted(set(proofs))
 
             if self.args.single_step:
-                run_cbmc_single_step(mldsa_parameter_set, proofs)
+                run_cbmc_single_step(mldsa_parameter_set, mldsa_dm, proofs)
                 return
-            envvars = {"MLD_CONFIG_PARAMETER_SET": mldsa_parameter_set}
+            envvars = {
+                "MLD_CONFIG_PARAMETER_SET": mldsa_parameter_set,
+                "CBMC_DM": mldsa_dm,
+            }
             if self.args.reduce_ram:
                 envvars["MLD_CONFIG_REDUCE_RAM"] = "1"
             cmd = (
@@ -1083,15 +1094,18 @@ class Tests:
             )
 
             if p.returncode != 0:
-                self.fail(f"CBMC proofs for parameter set={mldsa_parameter_set}")
+                self.fail(
+                    f"CBMC proofs for parameter set={mldsa_parameter_set}, dm={mldsa_dm}"
+                )
 
         mldsa_parameter_set = self.args.mldsa_parameter_set
+        dm = self.args.dm
         if mldsa_parameter_set == "ALL":
-            run_cbmc("44")
-            run_cbmc("65")
-            run_cbmc("87")
+            run_cbmc("44", dm)
+            run_cbmc("65", dm)
+            run_cbmc("87", dm)
         else:
-            run_cbmc(mldsa_parameter_set)
+            run_cbmc(mldsa_parameter_set, dm)
 
         self.check_fail()
 
@@ -1121,7 +1135,9 @@ class Tests:
         def run_hol_light_single_step(proofs, arch):
             num_proofs = len(proofs)
             for i, func in enumerate(proofs):
-                log = logger(f"HOL_LIGHT ({i + 1}/{num_proofs})", None, None, None)
+                log = logger(
+                    f"HOL_LIGHT ({i + 1}/{num_proofs})", None, None, None, None
+                )
                 log.info(f"Starting HOL-Light proof for {func}")
                 start = time.time()
                 proof_bin = f"mldsa/{func}.native"
@@ -1518,6 +1534,14 @@ def cli():
         choices=["44", "65", "87", "ALL"],
         type=str.upper,
         default="ALL",
+    )
+
+    cbmc_parser.add_argument(
+        "--dm",
+        help="Value of CBMC_DM, determining the data model for CBMC proofs. Default LP64",
+        choices=["LP64"],
+        type=str.upper,
+        default="LP64",
     )
 
     cbmc_parser.add_argument(


### PR DESCRIPTION
Pre-process with gcc -nostdinc and a minimal set of ISO C99 headers (stddef.h, stdint.h, stdlib.h, string.h) in proofs/cbmc/include/LP64, so proofs no longer depend on host headers. The data model is selected by CBMC_DM, which only accepts the default LP64 for now; Makefile.common, run-cbmc-proofs.py and "tests cbmc --dm" pass it through and report it alongside MLD_CONFIG_PARAMETER_SET.

- Ports https://github.com/pq-code-package/mlkem-native/pull/1879.

Unlike there, stdint.h also defines INT32_MIN and INT64_MAX.