### PR TITLE
Port: Doc: Fix a few minor mistakes

### DIFF
--- a/examples/bring_your_own_fips202_static/README.md
+++ b/examples/bring_your_own_fips202_static/README.md
@@ -4,7 +4,8 @@
 
 This directory contains a minimal example for using mldsa-native with a custom FIPS-202 implementation
 that uses a single global state. This is common for hardware accelerators that can only hold one
-Keccak state at a time.
+Keccak state at a time. We use tiny_sha3[^tiny_sha3], wrapped to operate on a single global state, as
+an example.
 
 ## Use Case
 

--- a/examples/monolithic_build_multilevel/README.md
+++ b/examples/monolithic_build_multilevel/README.md
@@ -35,8 +35,6 @@ The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.
 
 The wrapper [mldsa_native_all.c](mldsa_native_all.c) includes `mldsa_native.c` three times:
 ```c
-#define MLD_CONFIG_FILE "multilevel_config.h"
-
 /* Include level-independent code with first level */
 #define MLD_CONFIG_MULTILEVEL_WITH_SHARED
 #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS

--- a/examples/monolithic_build_multilevel_native/README.md
+++ b/examples/monolithic_build_multilevel_native/README.md
@@ -34,8 +34,6 @@ The configuration file [mldsa_native_config.h](mldsa_native/mldsa_native_config.
 
 The wrapper [mldsa_native_all.c](mldsa_native_all.c) includes `mldsa_native.c` three times:
 ```c
-#define MLD_CONFIG_FILE "multilevel_config.h"
-
 /* Include level-independent code with first level */
 #define MLD_CONFIG_MULTILEVEL_WITH_SHARED 1
 #define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS

--- a/mldsa/mldsa_native.h
+++ b/mldsa/mldsa_native.h
@@ -35,6 +35,10 @@
  * in the configuration file and include this header multiple times, setting
  * MLD_CONFIG_PARAMETER_SET accordingly for each, and #undef'ing the MLD_H
  * guard to allow multiple inclusions.
+ *
+ * In this case, the configuration file must also set
+ * MLD_CONFIG_MULTILEVEL_BUILD. Without it, the parameter set is not appended
+ * to the namespace prefix and all inclusions declare the same symbol names.
  */
 
 /******************************* Key sizes ************************************/


### PR DESCRIPTION
- Note in mldsa_native.h that multi-level builds must also set MLD_CONFIG_MULTILEVEL_BUILD, without which all inclusions declare the same symbol names.
- Drop the MLD_CONFIG_FILE line quoted in the multi-level monobuild READMEs; neither wrapper contains it and multilevel_config.h does not exist.
- Cite the tiny_sha3 footnote in the static FIPS-202 example README, which defined it without using it.

Ports https://github.com/pq-code-package/mlkem-native/pull/1865. The other fixes there do not apply to mldsa-native.